### PR TITLE
Rename java package

### DIFF
--- a/java/src/main/scala/prometheus4cats/javasimpleclient/JavaMetricsRegistry.scala
+++ b/java/src/main/scala/prometheus4cats/javasimpleclient/JavaMetricsRegistry.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package prometheus4cats.java
+package prometheus4cats.javasimpleclient
 
 import cats.data.NonEmptySeq
 import cats.effect.kernel._
@@ -32,8 +32,8 @@ import io.prometheus.client.{
   Gauge => PGauge,
   Histogram => PHistogram
 }
-import prometheus4cats.java.internal.Utils
-import prometheus4cats.java.models.MetricType
+import prometheus4cats.javasimpleclient.internal.Utils
+import prometheus4cats.javasimpleclient.models.MetricType
 import prometheus4cats.util.NameUtils
 import prometheus4cats._
 import org.typelevel.log4cats.Logger

--- a/java/src/main/scala/prometheus4cats/javasimpleclient/internal/Utils.scala
+++ b/java/src/main/scala/prometheus4cats/javasimpleclient/internal/Utils.scala
@@ -14,18 +14,18 @@
  * limitations under the License.
  */
 
-package prometheus4cats.java.internal
+package prometheus4cats.javasimpleclient.internal
 
 import cats.Show
 import cats.effect.kernel.Sync
 import cats.syntax.all._
-import prometheus4cats.java.models.Exceptions._
+import prometheus4cats.javasimpleclient.models.Exceptions._
 import io.prometheus.client.SimpleCollector
 import prometheus4cats.Label
-import prometheus4cats.java.models.Exceptions.PrometheusException
+import prometheus4cats.javasimpleclient.models.Exceptions.PrometheusException
 import org.typelevel.log4cats.Logger
 
-private[java] object Utils {
+private[javasimpleclient] object Utils {
   def modifyMetric[F[_]: Sync: Logger, A: Show, B](
       c: SimpleCollector[B],
       metricName: A,

--- a/java/src/main/scala/prometheus4cats/javasimpleclient/models/Exceptions.scala
+++ b/java/src/main/scala/prometheus4cats/javasimpleclient/models/Exceptions.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package prometheus4cats.java.models
+package prometheus4cats.javasimpleclient.models
 
 import cats.Show
 import cats.syntax.show._

--- a/java/src/main/scala/prometheus4cats/javasimpleclient/models/MetricType.scala
+++ b/java/src/main/scala/prometheus4cats/javasimpleclient/models/MetricType.scala
@@ -14,15 +14,11 @@
  * limitations under the License.
  */
 
-package prometheus4cats
+package prometheus4cats.javasimpleclient.models
 
-import io.prometheus.client.SimpleCollector
-import prometheus4cats.java.models.MetricType
-
-package object java {
-  private[java] type StateKey = (Option[Metric.Prefix], String) // TODO allow specific names maybe
-  private[java] type MetricID = (IndexedSeq[Label.Name], MetricType)
-  private[java] type StateValue = (MetricID, SimpleCollector[_])
-
-  private[java] type State = Map[StateKey, StateValue]
+sealed trait MetricType
+object MetricType {
+  case object Counter extends MetricType
+  case object Gauge extends MetricType
+  case object Histogram extends MetricType
 }

--- a/java/src/main/scala/prometheus4cats/javasimpleclient/package.scala
+++ b/java/src/main/scala/prometheus4cats/javasimpleclient/package.scala
@@ -14,11 +14,15 @@
  * limitations under the License.
  */
 
-package prometheus4cats.java.models
+package prometheus4cats
 
-sealed trait MetricType
-object MetricType {
-  case object Counter extends MetricType
-  case object Gauge extends MetricType
-  case object Histogram extends MetricType
+import io.prometheus.client.SimpleCollector
+import prometheus4cats.javasimpleclient.models.MetricType
+
+package object javasimpleclient {
+  private[javasimpleclient] type StateKey = (Option[Metric.Prefix], String) // TODO allow specific names maybe
+  private[javasimpleclient] type MetricID = (IndexedSeq[Label.Name], MetricType)
+  private[javasimpleclient] type StateValue = (MetricID, SimpleCollector[_])
+
+  private[javasimpleclient] type State = Map[StateKey, StateValue]
 }

--- a/java/src/test/scala/prometheus4cats/javasimpleclient/JavaMetricsRegistrySuite.scala
+++ b/java/src/test/scala/prometheus4cats/javasimpleclient/JavaMetricsRegistrySuite.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package prometheus4cats.java
+package prometheus4cats.javasimpleclient
 
 import cats.Show
 import cats.data.NonEmptySeq


### PR DESCRIPTION
The `prometheus4cats.java` package name can conflict with the `java` base package when `prometheus4cats._` is imported!