### PR TITLE
Add info metric type

### DIFF
--- a/core/src/main/scala-2/prometheus4cats/InfoNameFromStringLiteral.scala
+++ b/core/src/main/scala-2/prometheus4cats/InfoNameFromStringLiteral.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 Permutive
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package prometheus4cats
+
+import scala.reflect.macros.blackbox
+
+trait InfoNameFromStringLiteral {
+
+  def apply(t: String): Info.Name =
+    macro InfoNameMacros.fromStringLiteral
+
+  implicit def fromStringLiteral(t: String): Info.Name =
+    macro InfoNameMacros.fromStringLiteral
+
+}
+
+private[prometheus4cats] class InfoNameMacros(val c: blackbox.Context) extends MacroUtils {
+
+  def fromStringLiteral(t: c.Expr[String]): c.Expr[Info.Name] = {
+    val string: String = literal(t, or = "Info.Name.from({string})")
+
+    Info.Name
+      .from(string)
+      .fold(
+        abort,
+        _ => c.universe.reify(Info.Name.from(t.splice).toOption.get)
+      )
+  }
+
+}

--- a/core/src/main/scala-3/prometheus4cats/InfoNameFromStringLiteral.scala
+++ b/core/src/main/scala-3/prometheus4cats/InfoNameFromStringLiteral.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022 Permutive
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package prometheus4cats
+
+import scala.quoted.*
+
+trait InfoNameFromStringLiteral {
+
+  inline def apply(inline t: String): Info.Name = ${
+    InfoNameFromStringLiteral.nameLiteral('t)
+  }
+
+  implicit inline def fromStringLiteral(inline t: String): Info.Name = ${
+    InfoNameFromStringLiteral.nameLiteral('t)
+  }
+
+}
+
+object InfoNameFromStringLiteral extends MacroUtils {
+  def nameLiteral(s: Expr[String])(using q: Quotes): Expr[Info.Name] =
+    s.value match {
+      case Some(string) =>
+        Info.Name
+          .from(string)
+          .fold(
+            error,
+            _ =>
+              '{
+                Info.Name.from(${ Expr(string) }).toOption.get
+              }
+          )
+      case None =>
+        abort("Info.Name.from")
+        '{ ??? }
+    }
+}

--- a/core/src/main/scala/prometheus4cats/Info.scala
+++ b/core/src/main/scala/prometheus4cats/Info.scala
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2022 Permutive
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package prometheus4cats
+
+import cats.{Applicative, Contravariant, Eq, Hash, Order, Show, ~>}
+
+sealed abstract class Info[F[_], -A] extends Metric[A] { self =>
+
+  def info(labels: A): F[Unit]
+
+  override def contramap[B](f: B => A): Info[F, B] = new Info[F, B] {
+    override def info(labels: B): F[Unit] = self.info(f(labels))
+  }
+
+  final def mapK[G[_]](fk: F ~> G): Info[G, A] = new Info[G, A] {
+    override def info(labels: A): G[Unit] = fk(self.info(labels))
+  }
+}
+
+object Info {
+
+  /** Refined value class for a info name that has been parsed from a string
+    */
+  final class Name private (val value: String) extends AnyVal {
+    override def toString: String = s"""Info.Name("$value")"""
+  }
+
+  object Name extends InfoNameFromStringLiteral {
+
+    final private val regex = "^[a-zA-Z_:][a-zA-Z0-9_:]*_info$".r.pattern
+
+    /** Parse a [[Name]] from the given string
+      *
+      * @param string
+      *   value from which to parse a counter name
+      * @return
+      *   a parsed [[Name]] or failure message, represented by an [[scala.Either]]
+      */
+    def from(string: String): Either[String, Name] =
+      Either.cond(
+        regex.matcher(string).matches(),
+        new Name(string),
+        s"$string must match `$regex`"
+      )
+
+    /** Unsafely parse a [[Name]] from the given string
+      *
+      * @param string
+      *   value from which to parse a counter name
+      * @return
+      *   a parsed [[Name]]
+      * @throws java.lang.IllegalArgumentException
+      *   if `string` is not valid
+      */
+    def unsafeFrom(string: String): Name =
+      from(string).fold(msg => throw new IllegalArgumentException(msg), identity)
+
+    implicit val catsInstances: Hash[Name] with Order[Name] with Show[Name] = new Hash[Name]
+      with Order[Name]
+      with Show[Name] {
+      override def hash(x: Name): Int = Hash[String].hash(x.value)
+
+      override def compare(x: Name, y: Name): Int = Order[String].compare(x.value, y.value)
+
+      override def show(t: Name): String = t.value
+
+      override def eqv(x: Name, y: Name): Boolean = Eq[String].eqv(x.value, y.value)
+    }
+  }
+
+  implicit def catsInstances[F[_]]: Contravariant[Info[F, *]] = new Contravariant[Info[F, *]] {
+    override def contramap[A, B](fa: Info[F, A])(f: B => A): Info[F, B] = fa.contramap(f)
+  }
+
+  implicit class InfoMapSyntax[F[_]](info: Info[F, Map[Label.Name, String]]) {
+    def info(labels: (Label.Name, String)*): F[Unit] = info.info(labels.toMap)
+  }
+
+  def make[F[_], A](_info: A => F[Unit]): Info[F, A] = new Info[F, A] {
+    override def info(labels: A): F[Unit] = _info(labels)
+  }
+
+  def noop[F[_]: Applicative, A]: Info[F, A] = new Info[F, A] {
+    override def info(labels: A): F[Unit] = Applicative[F].unit
+  }
+}

--- a/core/src/main/scala/prometheus4cats/MetricFactory.scala
+++ b/core/src/main/scala/prometheus4cats/MetricFactory.scala
@@ -19,13 +19,7 @@ package prometheus4cats
 import cats.{Applicative, Functor, ~>}
 import prometheus4cats.Metric.CommonLabels
 import prometheus4cats.internal.histogram.BucketDsl
-import prometheus4cats.internal.{
-  HelpStep,
-  LabelledCallbackPartiallyApplied,
-  LabelledMetricPartiallyApplied,
-  MetricDsl,
-  TypeStep
-}
+import prometheus4cats.internal._
 
 sealed abstract class MetricFactory[F[_]](
     val metricRegistry: MetricRegistry[F],
@@ -169,6 +163,18 @@ sealed abstract class MetricFactory[F[_]](
         )
       )
     )
+
+  /** Starts creating an "info" metric.
+    *
+    * @example
+    *   {{{metrics.info("app_info").help("my counter help").build}}}
+    * @param name
+    *   [[Info.Name]] value
+    * @return
+    *   Info builder
+    */
+  def info(name: Info.Name): HelpStep[BuildStep[F, Info[F, Map[Label.Name, String]]]] =
+    new HelpStep(help => new BuildStep(metricRegistry.createAndRegisterInfo(prefix, name, help)))
 
   /** Creates a new instance of [[MetricFactory]] without a [[Metric.Prefix]] set
     */

--- a/core/src/test/scala/prometheus4cats/MetricsFactoryDslTest.scala
+++ b/core/src/test/scala/prometheus4cats/MetricsFactoryDslTest.scala
@@ -98,4 +98,9 @@ object MetricsFactoryDslTest {
   longHistogramBuilder.resource
   longHistogramBuilder.label[String]("label1").label[Int]("label2").label[BigInteger]("label3", _.toString).build
   longHistogramBuilder.unsafeLabels(Label.Name("label1"), Label.Name("label2")).build
+
+  val infoBuilder = factory.info("test_info").help("help")
+  infoBuilder.contramap[List[(Label.Name, String)]](_.toMap)
+  infoBuilder.build
+  infoBuilder.resource
 }

--- a/java/src/main/scala/prometheus4cats/javasimpleclient/models/MetricType.scala
+++ b/java/src/main/scala/prometheus4cats/javasimpleclient/models/MetricType.scala
@@ -21,4 +21,5 @@ object MetricType {
   case object Counter extends MetricType
   case object Gauge extends MetricType
   case object Histogram extends MetricType
+  case object Info extends MetricType
 }

--- a/java/src/test/scala/prometheus4cats/javasimpleclient/JavaMetricRegistrySuite.scala
+++ b/java/src/test/scala/prometheus4cats/javasimpleclient/JavaMetricRegistrySuite.scala
@@ -29,6 +29,7 @@ import prometheus4cats.util.NameUtils
 import org.scalacheck.effect.PropF._
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.noop.NoOpLogger
+import prometheus4cats.Metric.CommonLabels
 
 import scala.jdk.CollectionConverters._
 
@@ -123,6 +124,14 @@ class JavaMetricRegistrySuite
           }.toMap
         }
     }
+
+  override def getInfoValue(
+      state: CollectorRegistry,
+      prefix: Option[Metric.Prefix],
+      name: Info.Name,
+      help: Metric.Help,
+      labels: Map[Label.Name, String]
+  ): IO[Option[Double]] = IO(getMetricValue(state, prefix, name, CommonLabels.empty, labels))
 
   test("returns an existing metric when labels and name are the same") {
     forAllF {

--- a/testkit/src/main/scala/prometheus4cats/testkit/RegistrySuite.scala
+++ b/testkit/src/main/scala/prometheus4cats/testkit/RegistrySuite.scala
@@ -35,7 +35,7 @@ trait RegistrySuite[State] extends ScalaCheckEffectSuite {
     s <- Gen.alphaNumStr
   } yield s"$c1$c2$s"
 
-  private def niceStringArb[A](f: String => Either[String, A]): Arbitrary[A] = Arbitrary(
+  protected def niceStringArb[A](f: String => Either[String, A]): Arbitrary[A] = Arbitrary(
     niceStringGen.flatMap(s => Gen.oneOf(f(s).toOption))
   )
 


### PR DESCRIPTION
This is a very special type, it just takes a map of labels which are then represented like gauges with just a value of `1`. In the Java library it _is_ possible to create a labelled version of this, where the label names and values can be provided separately, but this seems entirely pointless to me, as does having a callback version.