### PR TITLE
Metrics as resources

### DIFF
--- a/core/src/main/scala/prometheus4cats/CallbackRegistry.scala
+++ b/core/src/main/scala/prometheus4cats/CallbackRegistry.scala
@@ -17,7 +17,9 @@
 package prometheus4cats
 
 import cats.data.NonEmptySeq
-import cats.{Applicative, ~>}
+import cats.effect.MonadCancel
+import cats.effect.kernel.Resource
+import cats.~>
 
 /** Trait for registering callbacks against different backends. May be implemented by anyone for use with
   * [[MetricFactory.WithCallbacks]]
@@ -45,7 +47,7 @@ trait CallbackRegistry[F[_]] {
       help: Metric.Help,
       commonLabels: Metric.CommonLabels,
       callback: F[Double]
-  ): F[Unit]
+  ): Resource[F, Unit]
 
   /** Register a counter value that records [[scala.Long]] values against a callback registry
     *
@@ -68,7 +70,7 @@ trait CallbackRegistry[F[_]] {
       help: Metric.Help,
       commonLabels: Metric.CommonLabels,
       callback: F[Long]
-  ): F[Unit]
+  ): Resource[F, Unit]
 
   /** Register a labelled counter value that records [[scala.Double]] values against a metrics registry
     *
@@ -97,7 +99,7 @@ trait CallbackRegistry[F[_]] {
       commonLabels: Metric.CommonLabels,
       labelNames: IndexedSeq[Label.Name],
       callback: F[(Double, A)]
-  )(f: A => IndexedSeq[String]): F[Unit]
+  )(f: A => IndexedSeq[String]): Resource[F, Unit]
 
   /** Register a labelled counter value that records [[scala.Long]] values against a metrics registry
     *
@@ -126,7 +128,7 @@ trait CallbackRegistry[F[_]] {
       commonLabels: Metric.CommonLabels,
       labelNames: IndexedSeq[Label.Name],
       callback: F[(Long, A)]
-  )(f: A => IndexedSeq[String]): F[Unit]
+  )(f: A => IndexedSeq[String]): Resource[F, Unit]
 
   /** Register a gauge value that records [[scala.Double]] values against a callback registry
     *
@@ -149,7 +151,7 @@ trait CallbackRegistry[F[_]] {
       help: Metric.Help,
       commonLabels: Metric.CommonLabels,
       callback: F[Double]
-  ): F[Unit]
+  ): Resource[F, Unit]
 
   /** Register a gauge value that records [[scala.Long]] values against a callback registry
     *
@@ -172,7 +174,7 @@ trait CallbackRegistry[F[_]] {
       help: Metric.Help,
       commonLabels: Metric.CommonLabels,
       callback: F[Long]
-  ): F[Unit]
+  ): Resource[F, Unit]
 
   /** Register a labelled gauge value that records [[scala.Double]] values against a metrics registry
     *
@@ -201,7 +203,7 @@ trait CallbackRegistry[F[_]] {
       commonLabels: Metric.CommonLabels,
       labelNames: IndexedSeq[Label.Name],
       callback: F[(Double, A)]
-  )(f: A => IndexedSeq[String]): F[Unit]
+  )(f: A => IndexedSeq[String]): Resource[F, Unit]
 
   /** Register a labelled gauge value that records [[scala.Long]] values against a metrics registry
     *
@@ -230,7 +232,7 @@ trait CallbackRegistry[F[_]] {
       commonLabels: Metric.CommonLabels,
       labelNames: IndexedSeq[Label.Name],
       callback: F[(Long, A)]
-  )(f: A => IndexedSeq[String]): F[Unit]
+  )(f: A => IndexedSeq[String]): Resource[F, Unit]
 
   /** Register a histogram value that records [[scala.Double]] values against a callback registry
     *
@@ -254,7 +256,7 @@ trait CallbackRegistry[F[_]] {
       commonLabels: Metric.CommonLabels,
       buckets: NonEmptySeq[Double],
       callback: F[Histogram.Value[Double]]
-  ): F[Unit]
+  ): Resource[F, Unit]
 
   /** Register a histogram value that records [[scala.Long]] values against a callback registry
     *
@@ -278,7 +280,7 @@ trait CallbackRegistry[F[_]] {
       commonLabels: Metric.CommonLabels,
       buckets: NonEmptySeq[Long],
       callback: F[Histogram.Value[Long]]
-  ): F[Unit]
+  ): Resource[F, Unit]
 
   /** Register a labelled histogram value that records [[scala.Double]] values against a metrics registry
     *
@@ -308,7 +310,7 @@ trait CallbackRegistry[F[_]] {
       labelNames: IndexedSeq[Label.Name],
       buckets: NonEmptySeq[Double],
       callback: F[(Histogram.Value[Double], A)]
-  )(f: A => IndexedSeq[String]): F[Unit]
+  )(f: A => IndexedSeq[String]): Resource[F, Unit]
 
   /** Register a labelled histogram value that records [[scala.Long]] values against a metrics registry
     *
@@ -338,7 +340,7 @@ trait CallbackRegistry[F[_]] {
       labelNames: IndexedSeq[Label.Name],
       buckets: NonEmptySeq[Long],
       callback: F[(Histogram.Value[Long], A)]
-  )(f: A => IndexedSeq[String]): F[Unit]
+  )(f: A => IndexedSeq[String]): Resource[F, Unit]
 
   /** Register a summary value that records [[scala.Double]] values against a metrics registry
     *
@@ -361,7 +363,7 @@ trait CallbackRegistry[F[_]] {
       help: Metric.Help,
       commonLabels: Metric.CommonLabels,
       callback: F[Summary.Value[Double]]
-  ): F[Unit]
+  ): Resource[F, Unit]
 
   /** Register a summary value that records [[scala.Long]] values against a metrics registry
     *
@@ -384,7 +386,7 @@ trait CallbackRegistry[F[_]] {
       help: Metric.Help,
       commonLabels: Metric.CommonLabels,
       callback: F[Summary.Value[Long]]
-  ): F[Unit]
+  ): Resource[F, Unit]
 
   /** Register a labelled summary value that records [[scala.Double]] values against a metrics registry
     *
@@ -413,7 +415,7 @@ trait CallbackRegistry[F[_]] {
       commonLabels: Metric.CommonLabels,
       labelNames: IndexedSeq[Label.Name],
       callback: F[(Summary.Value[Double], A)]
-  )(f: A => IndexedSeq[String]): F[Unit]
+  )(f: A => IndexedSeq[String]): Resource[F, Unit]
 
   /** Register a labelled summary value that records [[scala.Long]] values against a metrics registry
     *
@@ -442,29 +444,32 @@ trait CallbackRegistry[F[_]] {
       commonLabels: Metric.CommonLabels,
       labelNames: IndexedSeq[Label.Name],
       callback: F[(Summary.Value[Long], A)]
-  )(f: A => IndexedSeq[String]): F[Unit]
+  )(f: A => IndexedSeq[String]): Resource[F, Unit]
 
   protected[prometheus4cats] def registerMetricCollectionCallback(
       prefix: Option[Metric.Prefix],
       commonLabels: Metric.CommonLabels,
       callback: F[MetricCollection]
-  ): F[Unit]
+  ): Resource[F, Unit]
 
   /** Given a natural transformation from `F` to `G` and from `G` to `F`, transforms this [[CallbackRegistry]] from
     * effect `F` to effect `G`
     */
-  final def imapK[G[_]](fk: F ~> G, gk: G ~> F): CallbackRegistry[G] = CallbackRegistry.imapK(this, fk, gk)
+  final def imapK[G[_]](fk: F ~> G, gk: G ~> F)(implicit
+      F: MonadCancel[F, _],
+      G: MonadCancel[G, _]
+  ): CallbackRegistry[G] = CallbackRegistry.imapK(this, fk, gk)
 }
 
 object CallbackRegistry {
-  def noop[F[_]](implicit F: Applicative[F]): CallbackRegistry[F] = new CallbackRegistry[F] {
+  def noop[F[_]]: CallbackRegistry[F] = new CallbackRegistry[F] {
     override protected[prometheus4cats] def registerDoubleCounterCallback(
         prefix: Option[Metric.Prefix],
         name: Counter.Name,
         help: Metric.Help,
         commonLabels: Metric.CommonLabels,
         callback: F[Double]
-    ): F[Unit] = F.unit
+    ): Resource[F, Unit] = Resource.unit
 
     override protected[prometheus4cats] def registerLongCounterCallback(
         prefix: Option[Metric.Prefix],
@@ -472,7 +477,7 @@ object CallbackRegistry {
         help: Metric.Help,
         commonLabels: Metric.CommonLabels,
         callback: F[Long]
-    ): F[Unit] = F.unit
+    ): Resource[F, Unit] = Resource.unit
 
     override protected[prometheus4cats] def registerLabelledDoubleCounterCallback[A](
         prefix: Option[Metric.Prefix],
@@ -481,7 +486,7 @@ object CallbackRegistry {
         commonLabels: Metric.CommonLabels,
         labelNames: IndexedSeq[Label.Name],
         callback: F[(Double, A)]
-    )(f: A => IndexedSeq[String]): F[Unit] = F.unit
+    )(f: A => IndexedSeq[String]): Resource[F, Unit] = Resource.unit
 
     override protected[prometheus4cats] def registerLabelledLongCounterCallback[A](
         prefix: Option[Metric.Prefix],
@@ -490,7 +495,7 @@ object CallbackRegistry {
         commonLabels: Metric.CommonLabels,
         labelNames: IndexedSeq[Label.Name],
         callback: F[(Long, A)]
-    )(f: A => IndexedSeq[String]): F[Unit] = F.unit
+    )(f: A => IndexedSeq[String]): Resource[F, Unit] = Resource.unit
 
     override protected[prometheus4cats] def registerDoubleGaugeCallback(
         prefix: Option[Metric.Prefix],
@@ -498,7 +503,7 @@ object CallbackRegistry {
         help: Metric.Help,
         commonLabels: Metric.CommonLabels,
         callback: F[Double]
-    ): F[Unit] = F.unit
+    ): Resource[F, Unit] = Resource.unit
 
     override protected[prometheus4cats] def registerLongGaugeCallback(
         prefix: Option[Metric.Prefix],
@@ -506,7 +511,7 @@ object CallbackRegistry {
         help: Metric.Help,
         commonLabels: Metric.CommonLabels,
         callback: F[Long]
-    ): F[Unit] = F.unit
+    ): Resource[F, Unit] = Resource.unit
 
     override protected[prometheus4cats] def registerLabelledDoubleGaugeCallback[A](
         prefix: Option[Metric.Prefix],
@@ -515,7 +520,7 @@ object CallbackRegistry {
         commonLabels: Metric.CommonLabels,
         labelNames: IndexedSeq[Label.Name],
         callback: F[(Double, A)]
-    )(f: A => IndexedSeq[String]): F[Unit] = F.unit
+    )(f: A => IndexedSeq[String]): Resource[F, Unit] = Resource.unit
 
     override protected[prometheus4cats] def registerLabelledLongGaugeCallback[A](
         prefix: Option[Metric.Prefix],
@@ -524,7 +529,7 @@ object CallbackRegistry {
         commonLabels: Metric.CommonLabels,
         labelNames: IndexedSeq[Label.Name],
         callback: F[(Long, A)]
-    )(f: A => IndexedSeq[String]): F[Unit] = F.unit
+    )(f: A => IndexedSeq[String]): Resource[F, Unit] = Resource.unit
 
     override protected[prometheus4cats] def registerDoubleHistogramCallback(
         prefix: Option[Metric.Prefix],
@@ -533,7 +538,7 @@ object CallbackRegistry {
         commonLabels: Metric.CommonLabels,
         buckets: NonEmptySeq[Double],
         callback: F[Histogram.Value[Double]]
-    ): F[Unit] = F.unit
+    ): Resource[F, Unit] = Resource.unit
 
     override protected[prometheus4cats] def registerLongHistogramCallback(
         prefix: Option[Metric.Prefix],
@@ -542,7 +547,7 @@ object CallbackRegistry {
         commonLabels: Metric.CommonLabels,
         buckets: NonEmptySeq[Long],
         callback: F[Histogram.Value[Long]]
-    ): F[Unit] = F.unit
+    ): Resource[F, Unit] = Resource.unit
 
     override protected[prometheus4cats] def registerLabelledDoubleHistogramCallback[A](
         prefix: Option[Metric.Prefix],
@@ -552,7 +557,7 @@ object CallbackRegistry {
         labelNames: IndexedSeq[Label.Name],
         buckets: NonEmptySeq[Double],
         callback: F[(Histogram.Value[Double], A)]
-    )(f: A => IndexedSeq[String]): F[Unit] = F.unit
+    )(f: A => IndexedSeq[String]): Resource[F, Unit] = Resource.unit
 
     override protected[prometheus4cats] def registerLabelledLongHistogramCallback[A](
         prefix: Option[Metric.Prefix],
@@ -562,7 +567,7 @@ object CallbackRegistry {
         labelNames: IndexedSeq[Label.Name],
         buckets: NonEmptySeq[Long],
         callback: F[(Histogram.Value[Long], A)]
-    )(f: A => IndexedSeq[String]): F[Unit] = F.unit
+    )(f: A => IndexedSeq[String]): Resource[F, Unit] = Resource.unit
 
     override protected[prometheus4cats] def registerDoubleSummaryCallback(
         prefix: Option[Metric.Prefix],
@@ -570,7 +575,7 @@ object CallbackRegistry {
         help: Metric.Help,
         commonLabels: Metric.CommonLabels,
         callback: F[Summary.Value[Double]]
-    ): F[Unit] = F.unit
+    ): Resource[F, Unit] = Resource.unit
 
     override protected[prometheus4cats] def registerLongSummaryCallback(
         prefix: Option[Metric.Prefix],
@@ -578,7 +583,7 @@ object CallbackRegistry {
         help: Metric.Help,
         commonLabels: Metric.CommonLabels,
         callback: F[Summary.Value[Long]]
-    ): F[Unit] = F.unit
+    ): Resource[F, Unit] = Resource.unit
 
     override protected[prometheus4cats] def registerLabelledDoubleSummaryCallback[A](
         prefix: Option[Metric.Prefix],
@@ -587,7 +592,7 @@ object CallbackRegistry {
         commonLabels: Metric.CommonLabels,
         labelNames: IndexedSeq[Label.Name],
         callback: F[(Summary.Value[Double], A)]
-    )(f: A => IndexedSeq[String]): F[Unit] = F.unit
+    )(f: A => IndexedSeq[String]): Resource[F, Unit] = Resource.unit
 
     override protected[prometheus4cats] def registerLabelledLongSummaryCallback[A](
         prefix: Option[Metric.Prefix],
@@ -596,16 +601,20 @@ object CallbackRegistry {
         commonLabels: Metric.CommonLabels,
         labelNames: IndexedSeq[Label.Name],
         callback: F[(Summary.Value[Long], A)]
-    )(f: A => IndexedSeq[String]): F[Unit] = F.unit
+    )(f: A => IndexedSeq[String]): Resource[F, Unit] = Resource.unit
 
     override protected[prometheus4cats] def registerMetricCollectionCallback(
         prefix: Option[Metric.Prefix],
         commonLabels: Metric.CommonLabels,
         callback: F[MetricCollection]
-    ): F[Unit] = F.unit
+    ): Resource[F, Unit] = Resource.unit
   }
 
-  def imapK[F[_], G[_]](self: CallbackRegistry[F], fk: F ~> G, gk: G ~> F): CallbackRegistry[G] =
+  def imapK[F[_], G[_]](
+      self: CallbackRegistry[F],
+      fk: F ~> G,
+      gk: G ~> F
+  )(implicit F: MonadCancel[F, _], G: MonadCancel[G, _]): CallbackRegistry[G] =
     new CallbackRegistry[G] {
       override protected[prometheus4cats] def registerDoubleCounterCallback(
           prefix: Option[Metric.Prefix],
@@ -613,7 +622,7 @@ object CallbackRegistry {
           help: Metric.Help,
           commonLabels: Metric.CommonLabels,
           callback: G[Double]
-      ): G[Unit] = fk(self.registerDoubleCounterCallback(prefix, name, help, commonLabels, gk(callback)))
+      ): Resource[G, Unit] = self.registerDoubleCounterCallback(prefix, name, help, commonLabels, gk(callback)).mapK(fk)
 
       override protected[prometheus4cats] def registerLongCounterCallback(
           prefix: Option[Metric.Prefix],
@@ -621,7 +630,7 @@ object CallbackRegistry {
           help: Metric.Help,
           commonLabels: Metric.CommonLabels,
           callback: G[Long]
-      ): G[Unit] = fk(self.registerLongCounterCallback(prefix, name, help, commonLabels, gk(callback)))
+      ): Resource[G, Unit] = self.registerLongCounterCallback(prefix, name, help, commonLabels, gk(callback)).mapK(fk)
 
       override protected[prometheus4cats] def registerLabelledDoubleCounterCallback[A](
           prefix: Option[Metric.Prefix],
@@ -630,9 +639,9 @@ object CallbackRegistry {
           commonLabels: Metric.CommonLabels,
           labelNames: IndexedSeq[Label.Name],
           callback: G[(Double, A)]
-      )(f: A => IndexedSeq[String]): G[Unit] = fk(
-        self.registerLabelledDoubleCounterCallback(prefix, name, help, commonLabels, labelNames, gk(callback))(f)
-      )
+      )(f: A => IndexedSeq[String]): Resource[G, Unit] = self
+        .registerLabelledDoubleCounterCallback(prefix, name, help, commonLabels, labelNames, gk(callback))(f)
+        .mapK(fk)
 
       override protected[prometheus4cats] def registerLabelledLongCounterCallback[A](
           prefix: Option[Metric.Prefix],
@@ -641,9 +650,8 @@ object CallbackRegistry {
           commonLabels: Metric.CommonLabels,
           labelNames: IndexedSeq[Label.Name],
           callback: G[(Long, A)]
-      )(f: A => IndexedSeq[String]): G[Unit] = fk(
-        self.registerLabelledLongCounterCallback(prefix, name, help, commonLabels, labelNames, gk(callback))(f)
-      )
+      )(f: A => IndexedSeq[String]): Resource[G, Unit] =
+        self.registerLabelledLongCounterCallback(prefix, name, help, commonLabels, labelNames, gk(callback))(f).mapK(fk)
 
       override protected[prometheus4cats] def registerDoubleGaugeCallback(
           prefix: Option[Metric.Prefix],
@@ -651,7 +659,7 @@ object CallbackRegistry {
           help: Metric.Help,
           commonLabels: Metric.CommonLabels,
           callback: G[Double]
-      ): G[Unit] = fk(self.registerDoubleGaugeCallback(prefix, name, help, commonLabels, gk(callback)))
+      ): Resource[G, Unit] = self.registerDoubleGaugeCallback(prefix, name, help, commonLabels, gk(callback)).mapK(fk)
 
       override protected[prometheus4cats] def registerLongGaugeCallback(
           prefix: Option[Metric.Prefix],
@@ -659,7 +667,7 @@ object CallbackRegistry {
           help: Metric.Help,
           commonLabels: Metric.CommonLabels,
           callback: G[Long]
-      ): G[Unit] = fk(self.registerLongGaugeCallback(prefix, name, help, commonLabels, gk(callback)))
+      ): Resource[G, Unit] = self.registerLongGaugeCallback(prefix, name, help, commonLabels, gk(callback)).mapK(fk)
 
       override protected[prometheus4cats] def registerLabelledDoubleGaugeCallback[A](
           prefix: Option[Metric.Prefix],
@@ -668,9 +676,8 @@ object CallbackRegistry {
           commonLabels: Metric.CommonLabels,
           labelNames: IndexedSeq[Label.Name],
           callback: G[(Double, A)]
-      )(f: A => IndexedSeq[String]): G[Unit] = fk(
-        self.registerLabelledDoubleGaugeCallback(prefix, name, help, commonLabels, labelNames, gk(callback))(f)
-      )
+      )(f: A => IndexedSeq[String]): Resource[G, Unit] =
+        self.registerLabelledDoubleGaugeCallback(prefix, name, help, commonLabels, labelNames, gk(callback))(f).mapK(fk)
 
       override protected[prometheus4cats] def registerLabelledLongGaugeCallback[A](
           prefix: Option[Metric.Prefix],
@@ -679,9 +686,8 @@ object CallbackRegistry {
           commonLabels: Metric.CommonLabels,
           labelNames: IndexedSeq[Label.Name],
           callback: G[(Long, A)]
-      )(f: A => IndexedSeq[String]): G[Unit] = fk(
-        self.registerLabelledLongGaugeCallback(prefix, name, help, commonLabels, labelNames, gk(callback))(f)
-      )
+      )(f: A => IndexedSeq[String]): Resource[G, Unit] =
+        self.registerLabelledLongGaugeCallback(prefix, name, help, commonLabels, labelNames, gk(callback))(f).mapK(fk)
 
       override protected[prometheus4cats] def registerDoubleHistogramCallback(
           prefix: Option[Metric.Prefix],
@@ -690,7 +696,8 @@ object CallbackRegistry {
           commonLabels: Metric.CommonLabels,
           buckets: NonEmptySeq[Double],
           callback: G[Histogram.Value[Double]]
-      ): G[Unit] = fk(self.registerDoubleHistogramCallback(prefix, name, help, commonLabels, buckets, gk(callback)))
+      ): Resource[G, Unit] =
+        self.registerDoubleHistogramCallback(prefix, name, help, commonLabels, buckets, gk(callback)).mapK(fk)
 
       override protected[prometheus4cats] def registerLongHistogramCallback(
           prefix: Option[Metric.Prefix],
@@ -699,7 +706,8 @@ object CallbackRegistry {
           commonLabels: Metric.CommonLabels,
           buckets: NonEmptySeq[Long],
           callback: G[Histogram.Value[Long]]
-      ): G[Unit] = fk(self.registerLongHistogramCallback(prefix, name, help, commonLabels, buckets, gk(callback)))
+      ): Resource[G, Unit] =
+        self.registerLongHistogramCallback(prefix, name, help, commonLabels, buckets, gk(callback)).mapK(fk)
 
       override protected[prometheus4cats] def registerLabelledDoubleHistogramCallback[A](
           prefix: Option[Metric.Prefix],
@@ -709,17 +717,18 @@ object CallbackRegistry {
           labelNames: IndexedSeq[Label.Name],
           buckets: NonEmptySeq[Double],
           callback: G[(Histogram.Value[Double], A)]
-      )(f: A => IndexedSeq[String]): G[Unit] = fk(
-        self.registerLabelledDoubleHistogramCallback(
-          prefix,
-          name,
-          help,
-          commonLabels,
-          labelNames,
-          buckets,
-          gk(callback)
-        )(f)
-      )
+      )(f: A => IndexedSeq[String]): Resource[G, Unit] =
+        self
+          .registerLabelledDoubleHistogramCallback(
+            prefix,
+            name,
+            help,
+            commonLabels,
+            labelNames,
+            buckets,
+            gk(callback)
+          )(f)
+          .mapK(fk)
 
       override protected[prometheus4cats] def registerLabelledLongHistogramCallback[A](
           prefix: Option[Metric.Prefix],
@@ -729,17 +738,18 @@ object CallbackRegistry {
           labelNames: IndexedSeq[Label.Name],
           buckets: NonEmptySeq[Long],
           callback: G[(Histogram.Value[Long], A)]
-      )(f: A => IndexedSeq[String]): G[Unit] = fk(
-        self.registerLabelledLongHistogramCallback(
-          prefix,
-          name,
-          help,
-          commonLabels,
-          labelNames,
-          buckets,
-          gk(callback)
-        )(f)
-      )
+      )(f: A => IndexedSeq[String]): Resource[G, Unit] =
+        self
+          .registerLabelledLongHistogramCallback(
+            prefix,
+            name,
+            help,
+            commonLabels,
+            labelNames,
+            buckets,
+            gk(callback)
+          )(f)
+          .mapK(fk)
 
       override protected[prometheus4cats] def registerDoubleSummaryCallback(
           prefix: Option[Metric.Prefix],
@@ -747,15 +757,16 @@ object CallbackRegistry {
           help: Metric.Help,
           commonLabels: Metric.CommonLabels,
           callback: G[Summary.Value[Double]]
-      ): G[Unit] = fk(
-        self.registerDoubleSummaryCallback(
-          prefix,
-          name,
-          help,
-          commonLabels,
-          gk(callback)
-        )
-      )
+      ): Resource[G, Unit] =
+        self
+          .registerDoubleSummaryCallback(
+            prefix,
+            name,
+            help,
+            commonLabels,
+            gk(callback)
+          )
+          .mapK(fk)
 
       override protected[prometheus4cats] def registerLongSummaryCallback(
           prefix: Option[Metric.Prefix],
@@ -763,15 +774,16 @@ object CallbackRegistry {
           help: Metric.Help,
           commonLabels: Metric.CommonLabels,
           callback: G[Summary.Value[Long]]
-      ): G[Unit] = fk(
-        self.registerLongSummaryCallback(
-          prefix,
-          name,
-          help,
-          commonLabels,
-          gk(callback)
-        )
-      )
+      ): Resource[G, Unit] =
+        self
+          .registerLongSummaryCallback(
+            prefix,
+            name,
+            help,
+            commonLabels,
+            gk(callback)
+          )
+          .mapK(fk)
 
       override protected[prometheus4cats] def registerLabelledDoubleSummaryCallback[A](
           prefix: Option[Metric.Prefix],
@@ -780,16 +792,17 @@ object CallbackRegistry {
           commonLabels: Metric.CommonLabels,
           labelNames: IndexedSeq[Label.Name],
           callback: G[(Summary.Value[Double], A)]
-      )(f: A => IndexedSeq[String]): G[Unit] = fk(
-        self.registerLabelledDoubleSummaryCallback(
-          prefix,
-          name,
-          help,
-          commonLabels,
-          labelNames,
-          gk(callback)
-        )(f)
-      )
+      )(f: A => IndexedSeq[String]): Resource[G, Unit] =
+        self
+          .registerLabelledDoubleSummaryCallback(
+            prefix,
+            name,
+            help,
+            commonLabels,
+            labelNames,
+            gk(callback)
+          )(f)
+          .mapK(fk)
 
       override protected[prometheus4cats] def registerLabelledLongSummaryCallback[A](
           prefix: Option[Metric.Prefix],
@@ -798,21 +811,22 @@ object CallbackRegistry {
           commonLabels: Metric.CommonLabels,
           labelNames: IndexedSeq[Label.Name],
           callback: G[(Summary.Value[Long], A)]
-      )(f: A => IndexedSeq[String]): G[Unit] = fk(
-        self.registerLabelledLongSummaryCallback(
-          prefix,
-          name,
-          help,
-          commonLabels,
-          labelNames,
-          gk(callback)
-        )(f)
-      )
+      )(f: A => IndexedSeq[String]): Resource[G, Unit] =
+        self
+          .registerLabelledLongSummaryCallback(
+            prefix,
+            name,
+            help,
+            commonLabels,
+            labelNames,
+            gk(callback)
+          )(f)
+          .mapK(fk)
 
       override protected[prometheus4cats] def registerMetricCollectionCallback(
           prefix: Option[Metric.Prefix],
           commonLabels: Metric.CommonLabels,
           callback: G[MetricCollection]
-      ): G[Unit] = fk(self.registerMetricCollectionCallback(prefix, commonLabels, gk(callback)))
+      ): Resource[G, Unit] = self.registerMetricCollectionCallback(prefix, commonLabels, gk(callback)).mapK(fk)
     }
 }

--- a/core/src/main/scala/prometheus4cats/MetricCollection.scala
+++ b/core/src/main/scala/prometheus4cats/MetricCollection.scala
@@ -17,7 +17,7 @@
 package prometheus4cats
 
 import cats.data.NonEmptySeq
-import cats.kernel.Semigroup
+import cats.kernel.Monoid
 import cats.syntax.semigroup._
 
 final class MetricCollection private (
@@ -283,7 +283,8 @@ object MetricCollection {
     ) extends Summary
   }
 
-  implicit val catsInstances: Semigroup[MetricCollection] = new Semigroup[MetricCollection] {
+  implicit val catsInstances: Monoid[MetricCollection] = new Monoid[MetricCollection] {
+    override def empty: MetricCollection = MetricCollection.empty
     override def combine(x: MetricCollection, y: MetricCollection): MetricCollection = x ++ y
   }
 }

--- a/core/src/main/scala/prometheus4cats/MetricRegistry.scala
+++ b/core/src/main/scala/prometheus4cats/MetricRegistry.scala
@@ -17,8 +17,9 @@
 package prometheus4cats
 
 import cats.data.NonEmptySeq
-import cats.syntax.functor._
-import cats.{Applicative, Functor, ~>}
+import cats.effect.MonadCancel
+import cats.effect.kernel.Resource
+import cats.{Applicative, ~>}
 import prometheus4cats.Metric.CommonLabels
 import prometheus4cats.Summary.QuantileDefinition
 
@@ -47,7 +48,7 @@ trait MetricRegistry[F[_]] {
       name: Counter.Name,
       help: Metric.Help,
       commonLabels: Metric.CommonLabels
-  ): F[Counter[F, Double]]
+  ): Resource[F, Counter[F, Double]]
 
   /** Create and register a counter that records [[scala.Long]] values against a metrics registry
     *
@@ -67,7 +68,7 @@ trait MetricRegistry[F[_]] {
       name: Counter.Name,
       help: Metric.Help,
       commonLabels: Metric.CommonLabels
-  ): F[Counter[F, Long]]
+  ): Resource[F, Counter[F, Long]]
 
   /** Create and register a labelled counter that records [[scala.Double]] values against a metrics registry
     *
@@ -93,7 +94,7 @@ trait MetricRegistry[F[_]] {
       help: Metric.Help,
       commonLabels: Metric.CommonLabels,
       labelNames: IndexedSeq[Label.Name]
-  )(f: A => IndexedSeq[String]): F[Counter.Labelled[F, Double, A]]
+  )(f: A => IndexedSeq[String]): Resource[F, Counter.Labelled[F, Double, A]]
 
   /** Create and register a labelled counter that records [[scala.Long]] values against a metrics registry
     *
@@ -119,7 +120,7 @@ trait MetricRegistry[F[_]] {
       help: Metric.Help,
       commonLabels: Metric.CommonLabels,
       labelNames: IndexedSeq[Label.Name]
-  )(f: A => IndexedSeq[String]): F[Counter.Labelled[F, Long, A]]
+  )(f: A => IndexedSeq[String]): Resource[F, Counter.Labelled[F, Long, A]]
 
   /** Create and register a gauge that records [[scala.Double]] values against a metrics registry
     *
@@ -139,7 +140,7 @@ trait MetricRegistry[F[_]] {
       name: Gauge.Name,
       help: Metric.Help,
       commonLabels: Metric.CommonLabels
-  ): F[Gauge[F, Double]]
+  ): Resource[F, Gauge[F, Double]]
 
   /** Create and register a gauge that records [[scala.Long]] values against a metrics registry
     *
@@ -159,7 +160,7 @@ trait MetricRegistry[F[_]] {
       name: Gauge.Name,
       help: Metric.Help,
       commonLabels: Metric.CommonLabels
-  ): F[Gauge[F, Long]]
+  ): Resource[F, Gauge[F, Long]]
 
   /** Create and register a labelled gauge that records [[scala.Double]] values against a metrics registry
     *
@@ -185,7 +186,7 @@ trait MetricRegistry[F[_]] {
       help: Metric.Help,
       commonLabels: Metric.CommonLabels,
       labelNames: IndexedSeq[Label.Name]
-  )(f: A => IndexedSeq[String]): F[Gauge.Labelled[F, Double, A]]
+  )(f: A => IndexedSeq[String]): Resource[F, Gauge.Labelled[F, Double, A]]
 
   /** Create and register a labelled gauge that records [[scala.Long]] values against a metrics registry
     *
@@ -211,7 +212,7 @@ trait MetricRegistry[F[_]] {
       help: Metric.Help,
       commonLabels: Metric.CommonLabels,
       labelNames: IndexedSeq[Label.Name]
-  )(f: A => IndexedSeq[String]): F[Gauge.Labelled[F, Long, A]]
+  )(f: A => IndexedSeq[String]): Resource[F, Gauge.Labelled[F, Long, A]]
 
   /** Create and register a histogram that records [[scala.Double]] values against a metrics registry
     *
@@ -234,7 +235,7 @@ trait MetricRegistry[F[_]] {
       help: Metric.Help,
       commonLabels: Metric.CommonLabels,
       buckets: NonEmptySeq[Double]
-  ): F[Histogram[F, Double]]
+  ): Resource[F, Histogram[F, Double]]
 
   /** Create and register a histogram that records [[scala.Long]] values against a metrics registry
     *
@@ -257,7 +258,7 @@ trait MetricRegistry[F[_]] {
       help: Metric.Help,
       commonLabels: Metric.CommonLabels,
       buckets: NonEmptySeq[Long]
-  ): F[Histogram[F, Long]]
+  ): Resource[F, Histogram[F, Long]]
 
   /** Create and register a labelled histogram against a metrics registry
     *
@@ -286,7 +287,7 @@ trait MetricRegistry[F[_]] {
       commonLabels: Metric.CommonLabels,
       labelNames: IndexedSeq[Label.Name],
       buckets: NonEmptySeq[Double]
-  )(f: A => IndexedSeq[String]): F[Histogram.Labelled[F, Double, A]]
+  )(f: A => IndexedSeq[String]): Resource[F, Histogram.Labelled[F, Double, A]]
 
   /** Create and register a labelled histogram against a metrics registry
     *
@@ -315,7 +316,7 @@ trait MetricRegistry[F[_]] {
       commonLabels: Metric.CommonLabels,
       labelNames: IndexedSeq[Label.Name],
       buckets: NonEmptySeq[Long]
-  )(f: A => IndexedSeq[String]): F[Histogram.Labelled[F, Long, A]]
+  )(f: A => IndexedSeq[String]): Resource[F, Histogram.Labelled[F, Long, A]]
 
   /** Create and register a summary that records [[scala.Double]] values against a metrics registry
     *
@@ -348,7 +349,7 @@ trait MetricRegistry[F[_]] {
       quantiles: Seq[QuantileDefinition],
       maxAge: FiniteDuration,
       ageBuckets: Summary.AgeBuckets
-  ): F[Summary[F, Double]]
+  ): Resource[F, Summary[F, Double]]
 
   /** Create and register a summary that records [[scala.Long]] values against a metrics registry
     *
@@ -381,7 +382,7 @@ trait MetricRegistry[F[_]] {
       quantiles: Seq[QuantileDefinition],
       maxAge: FiniteDuration,
       ageBuckets: Summary.AgeBuckets
-  ): F[Summary[F, Long]]
+  ): Resource[F, Summary[F, Long]]
 
   /** Create and register a summary that records [[scala.Double]] values against a metrics registry
     *
@@ -420,7 +421,7 @@ trait MetricRegistry[F[_]] {
       quantiles: Seq[QuantileDefinition],
       maxAge: FiniteDuration,
       ageBuckets: Summary.AgeBuckets
-  )(f: A => IndexedSeq[String]): F[Summary.Labelled[F, Double, A]]
+  )(f: A => IndexedSeq[String]): Resource[F, Summary.Labelled[F, Double, A]]
 
   /** Create and register a summary that records [[scala.Long]] values against a metrics registry
     *
@@ -459,7 +460,7 @@ trait MetricRegistry[F[_]] {
       quantiles: Seq[QuantileDefinition],
       maxAge: FiniteDuration,
       ageBuckets: Summary.AgeBuckets
-  )(f: A => IndexedSeq[String]): F[Summary.Labelled[F, Long, A]]
+  )(f: A => IndexedSeq[String]): Resource[F, Summary.Labelled[F, Long, A]]
 
   /** Create and register an info metric against a metrics registry
     *
@@ -476,9 +477,10 @@ trait MetricRegistry[F[_]] {
       prefix: Option[Metric.Prefix],
       name: Info.Name,
       help: Metric.Help
-  ): F[Info[F, Map[Label.Name, String]]]
+  ): Resource[F, Info[F, Map[Label.Name, String]]]
 
-  final def mapK[G[_]: Functor](fk: F ~> G): MetricRegistry[G] = MetricRegistry.mapK(this, fk)
+  final def mapK[G[_]](fk: F ~> G)(implicit F: MonadCancel[F, _], G: MonadCancel[G, _]): MetricRegistry[G] =
+    MetricRegistry.mapK(this, fk)
 }
 
 object MetricRegistry {
@@ -490,7 +492,7 @@ object MetricRegistry {
           name: Counter.Name,
           help: Metric.Help,
           commonLabels: CommonLabels
-      ): F[Counter[F, Double]] = F.pure(Counter.noop)
+      ): Resource[F, Counter[F, Double]] = Resource.pure(Counter.noop)
 
       override protected[prometheus4cats] def createAndRegisterLabelledDoubleCounter[A](
           prefix: Option[Metric.Prefix],
@@ -498,24 +500,24 @@ object MetricRegistry {
           help: Metric.Help,
           commonLabels: CommonLabels,
           labelNames: IndexedSeq[Label.Name]
-      )(f: A => IndexedSeq[String]): F[Counter.Labelled[F, Double, A]] =
-        F.pure(Counter.Labelled.noop)
+      )(f: A => IndexedSeq[String]): Resource[F, Counter.Labelled[F, Double, A]] =
+        Resource.pure(Counter.Labelled.noop)
 
       override protected[prometheus4cats] def createAndRegisterDoubleGauge(
           prefix: Option[Metric.Prefix],
           name: Gauge.Name,
           help: Metric.Help,
           commonLabels: CommonLabels
-      ): F[Gauge[F, Double]] =
-        F.pure(Gauge.noop)
+      ): Resource[F, Gauge[F, Double]] =
+        Resource.pure(Gauge.noop)
 
       override protected[prometheus4cats] def createAndRegisterLongGauge(
           prefix: Option[Metric.Prefix],
           name: Gauge.Name,
           help: Metric.Help,
           commonLabels: CommonLabels
-      ): F[Gauge[F, Long]] =
-        F.pure(Gauge.noop)
+      ): Resource[F, Gauge[F, Long]] =
+        Resource.pure(Gauge.noop)
 
       override protected[prometheus4cats] def createAndRegisterLabelledDoubleGauge[A](
           prefix: Option[Metric.Prefix],
@@ -523,8 +525,8 @@ object MetricRegistry {
           help: Metric.Help,
           commonLabels: CommonLabels,
           labelNames: IndexedSeq[Label.Name]
-      )(f: A => IndexedSeq[String]): F[Gauge.Labelled[F, Double, A]] =
-        F.pure(Gauge.Labelled.noop)
+      )(f: A => IndexedSeq[String]): Resource[F, Gauge.Labelled[F, Double, A]] =
+        Resource.pure(Gauge.Labelled.noop)
 
       override protected[prometheus4cats] def createAndRegisterDoubleHistogram(
           prefix: Option[Metric.Prefix],
@@ -532,7 +534,7 @@ object MetricRegistry {
           help: Metric.Help,
           commonLabels: CommonLabels,
           buckets: NonEmptySeq[Double]
-      ): F[Histogram[F, Double]] = F.pure(Histogram.noop)
+      ): Resource[F, Histogram[F, Double]] = Resource.pure(Histogram.noop)
 
       override protected[prometheus4cats] def createAndRegisterLabelledDoubleHistogram[A](
           prefix: Option[Metric.Prefix],
@@ -541,15 +543,15 @@ object MetricRegistry {
           commonLabels: CommonLabels,
           labelNames: IndexedSeq[Label.Name],
           buckets: NonEmptySeq[Double]
-      )(f: A => IndexedSeq[String]): F[Histogram.Labelled[F, Double, A]] =
-        F.pure(Histogram.Labelled.noop)
+      )(f: A => IndexedSeq[String]): Resource[F, Histogram.Labelled[F, Double, A]] =
+        Resource.pure(Histogram.Labelled.noop)
 
       override protected[prometheus4cats] def createAndRegisterLongCounter(
           prefix: Option[Metric.Prefix],
           name: Counter.Name,
           help: Metric.Help,
           commonLabels: CommonLabels
-      ): F[Counter[F, Long]] = F.pure(Counter.noop)
+      ): Resource[F, Counter[F, Long]] = Resource.pure(Counter.noop)
 
       override protected[prometheus4cats] def createAndRegisterLabelledLongCounter[A](
           prefix: Option[Metric.Prefix],
@@ -557,8 +559,8 @@ object MetricRegistry {
           help: Metric.Help,
           commonLabels: CommonLabels,
           labelNames: IndexedSeq[Label.Name]
-      )(f: A => IndexedSeq[String]): F[Counter.Labelled[F, Long, A]] =
-        F.pure(Counter.Labelled.noop)
+      )(f: A => IndexedSeq[String]): Resource[F, Counter.Labelled[F, Long, A]] =
+        Resource.pure(Counter.Labelled.noop)
 
       override protected[prometheus4cats] def createAndRegisterLabelledLongGauge[A](
           prefix: Option[Metric.Prefix],
@@ -566,8 +568,8 @@ object MetricRegistry {
           help: Metric.Help,
           commonLabels: CommonLabels,
           labelNames: IndexedSeq[Label.Name]
-      )(f: A => IndexedSeq[String]): F[Gauge.Labelled[F, Long, A]] =
-        F.pure(Gauge.Labelled.noop)
+      )(f: A => IndexedSeq[String]): Resource[F, Gauge.Labelled[F, Long, A]] =
+        Resource.pure(Gauge.Labelled.noop)
 
       override protected[prometheus4cats] def createAndRegisterLongHistogram(
           prefix: Option[Metric.Prefix],
@@ -575,7 +577,7 @@ object MetricRegistry {
           help: Metric.Help,
           commonLabels: CommonLabels,
           buckets: NonEmptySeq[Long]
-      ): F[Histogram[F, Long]] = F.pure(Histogram.noop)
+      ): Resource[F, Histogram[F, Long]] = Resource.pure(Histogram.noop)
 
       override protected[prometheus4cats] def createAndRegisterLabelledLongHistogram[A](
           prefix: Option[Metric.Prefix],
@@ -584,7 +586,8 @@ object MetricRegistry {
           commonLabels: CommonLabels,
           labelNames: IndexedSeq[Label.Name],
           buckets: NonEmptySeq[Long]
-      )(f: A => IndexedSeq[String]): F[Histogram.Labelled[F, Long, A]] = F.pure(Histogram.Labelled.noop)
+      )(f: A => IndexedSeq[String]): Resource[F, Histogram.Labelled[F, Long, A]] =
+        Resource.pure(Histogram.Labelled.noop)
 
       override protected[prometheus4cats] def createAndRegisterDoubleSummary(
           prefix: Option[Metric.Prefix],
@@ -594,7 +597,7 @@ object MetricRegistry {
           quantiles: Seq[QuantileDefinition],
           maxAge: FiniteDuration,
           ageBuckets: Summary.AgeBuckets
-      ): F[Summary[F, Double]] = F.pure(Summary.noop)
+      ): Resource[F, Summary[F, Double]] = Resource.pure(Summary.noop)
 
       override protected[prometheus4cats] def createAndRegisterLongSummary(
           prefix: Option[Metric.Prefix],
@@ -604,7 +607,7 @@ object MetricRegistry {
           quantiles: Seq[QuantileDefinition],
           maxAge: FiniteDuration,
           ageBuckets: Summary.AgeBuckets
-      ): F[Summary[F, Long]] = F.pure(Summary.noop)
+      ): Resource[F, Summary[F, Long]] = Resource.pure(Summary.noop)
 
       override protected[prometheus4cats] def createAndRegisterLabelledDoubleSummary[A](
           prefix: Option[Metric.Prefix],
@@ -615,7 +618,7 @@ object MetricRegistry {
           quantiles: Seq[QuantileDefinition],
           maxAge: FiniteDuration,
           ageBuckets: Summary.AgeBuckets
-      )(f: A => IndexedSeq[String]): F[Summary.Labelled[F, Double, A]] = F.pure(Summary.Labelled.noop)
+      )(f: A => IndexedSeq[String]): Resource[F, Summary.Labelled[F, Double, A]] = Resource.pure(Summary.Labelled.noop)
 
       override protected[prometheus4cats] def createAndRegisterLabelledLongSummary[A](
           prefix: Option[Metric.Prefix],
@@ -626,28 +629,27 @@ object MetricRegistry {
           quantiles: Seq[QuantileDefinition],
           maxAge: FiniteDuration,
           ageBuckets: Summary.AgeBuckets
-      )(f: A => IndexedSeq[String]): F[Summary.Labelled[F, Long, A]] = F.pure(Summary.Labelled.noop)
+      )(f: A => IndexedSeq[String]): Resource[F, Summary.Labelled[F, Long, A]] = Resource.pure(Summary.Labelled.noop)
 
       override protected[prometheus4cats] def createAndRegisterInfo(
           prefix: Option[Metric.Prefix],
           name: Info.Name,
           help: Metric.Help
-      ): F[Info[F, Map[Label.Name, String]]] = F.pure(Info.noop)
+      ): Resource[F, Info[F, Map[Label.Name, String]]] = Resource.pure(Info.noop)
     }
 
-  private[prometheus4cats] def mapK[F[_], G[_]: Functor](
+  private[prometheus4cats] def mapK[F[_], G[_]](
       self: MetricRegistry[F],
       fk: F ~> G
-  ): MetricRegistry[G] =
+  )(implicit F: MonadCancel[F, _], G: MonadCancel[G, _]): MetricRegistry[G] =
     new MetricRegistry[G] {
       override protected[prometheus4cats] def createAndRegisterDoubleCounter(
           prefix: Option[Metric.Prefix],
           name: Counter.Name,
           help: Metric.Help,
           commonLabels: CommonLabels
-      ): G[Counter[G, Double]] = fk(
-        self.createAndRegisterDoubleCounter(prefix, name, help, commonLabels)
-      ).map(_.mapK(fk))
+      ): Resource[G, Counter[G, Double]] =
+        self.createAndRegisterDoubleCounter(prefix, name, help, commonLabels).mapK(fk).map(_.mapK(fk))
 
       override protected[prometheus4cats] def createAndRegisterLabelledDoubleCounter[A](
           prefix: Option[Metric.Prefix],
@@ -655,33 +657,39 @@ object MetricRegistry {
           help: Metric.Help,
           commonLabels: CommonLabels,
           labelNames: IndexedSeq[Label.Name]
-      )(f: A => IndexedSeq[String]): G[Counter.Labelled[G, Double, A]] = fk(
-        self.createAndRegisterLabelledDoubleCounter(
-          prefix,
-          name,
-          help,
-          commonLabels,
-          labelNames
-        )(f)
-      ).map(_.mapK(fk))
+      )(f: A => IndexedSeq[String]): Resource[G, Counter.Labelled[G, Double, A]] =
+        self
+          .createAndRegisterLabelledDoubleCounter(
+            prefix,
+            name,
+            help,
+            commonLabels,
+            labelNames
+          )(f)
+          .mapK(fk)
+          .map(_.mapK(fk))
 
       override protected[prometheus4cats] def createAndRegisterDoubleGauge(
           prefix: Option[Metric.Prefix],
           name: Gauge.Name,
           help: Metric.Help,
           commonLabels: CommonLabels
-      ): G[Gauge[G, Double]] = fk(
-        self.createAndRegisterDoubleGauge(prefix, name, help, commonLabels)
-      ).map(_.mapK(fk))
+      ): Resource[G, Gauge[G, Double]] =
+        self
+          .createAndRegisterDoubleGauge(prefix, name, help, commonLabels)
+          .mapK(fk)
+          .map(_.mapK(fk))
 
       override protected[prometheus4cats] def createAndRegisterLongGauge(
           prefix: Option[Metric.Prefix],
           name: Gauge.Name,
           help: Metric.Help,
           commonLabels: CommonLabels
-      ): G[Gauge[G, Long]] = fk(
-        self.createAndRegisterLongGauge(prefix, name, help, commonLabels)
-      ).map(_.mapK(fk))
+      ): Resource[G, Gauge[G, Long]] =
+        self
+          .createAndRegisterLongGauge(prefix, name, help, commonLabels)
+          .mapK(fk)
+          .map(_.mapK(fk))
 
       override protected[prometheus4cats] def createAndRegisterLabelledDoubleGauge[A](
           prefix: Option[Metric.Prefix],
@@ -689,15 +697,17 @@ object MetricRegistry {
           help: Metric.Help,
           commonLabels: CommonLabels,
           labelNames: IndexedSeq[Label.Name]
-      )(f: A => IndexedSeq[String]): G[Gauge.Labelled[G, Double, A]] = fk(
-        self.createAndRegisterLabelledDoubleGauge(
-          prefix,
-          name,
-          help,
-          commonLabels,
-          labelNames
-        )(f)
-      ).map(_.mapK(fk))
+      )(f: A => IndexedSeq[String]): Resource[G, Gauge.Labelled[G, Double, A]] =
+        self
+          .createAndRegisterLabelledDoubleGauge(
+            prefix,
+            name,
+            help,
+            commonLabels,
+            labelNames
+          )(f)
+          .mapK(fk)
+          .map(_.mapK(fk))
 
       override protected[prometheus4cats] def createAndRegisterDoubleHistogram(
           prefix: Option[Metric.Prefix],
@@ -705,15 +715,17 @@ object MetricRegistry {
           help: Metric.Help,
           commonLabels: CommonLabels,
           buckets: NonEmptySeq[Double]
-      ): G[Histogram[G, Double]] = fk(
-        self.createAndRegisterDoubleHistogram(
-          prefix,
-          name,
-          help,
-          commonLabels,
-          buckets
-        )
-      ).map(_.mapK(fk))
+      ): Resource[G, Histogram[G, Double]] =
+        self
+          .createAndRegisterDoubleHistogram(
+            prefix,
+            name,
+            help,
+            commonLabels,
+            buckets
+          )
+          .mapK(fk)
+          .map(_.mapK(fk))
 
       override protected[prometheus4cats] def createAndRegisterLabelledDoubleHistogram[A](
           prefix: Option[Metric.Prefix],
@@ -722,23 +734,26 @@ object MetricRegistry {
           commonLabels: CommonLabels,
           labelNames: IndexedSeq[Label.Name],
           buckets: NonEmptySeq[Double]
-      )(f: A => IndexedSeq[String]): G[Histogram.Labelled[G, Double, A]] = fk(
-        self.createAndRegisterLabelledDoubleHistogram(
-          prefix,
-          name,
-          help,
-          commonLabels,
-          labelNames,
-          buckets
-        )(f)
-      ).map(_.mapK(fk))
+      )(f: A => IndexedSeq[String]): Resource[G, Histogram.Labelled[G, Double, A]] =
+        self
+          .createAndRegisterLabelledDoubleHistogram(
+            prefix,
+            name,
+            help,
+            commonLabels,
+            labelNames,
+            buckets
+          )(f)
+          .mapK(fk)
+          .map(_.mapK(fk))
 
       override protected[prometheus4cats] def createAndRegisterLongCounter(
           prefix: Option[Metric.Prefix],
           name: Counter.Name,
           help: Metric.Help,
           commonLabels: CommonLabels
-      ): G[Counter[G, Long]] = fk(self.createAndRegisterLongCounter(prefix, name, help, commonLabels)).map(_.mapK(fk))
+      ): Resource[G, Counter[G, Long]] =
+        self.createAndRegisterLongCounter(prefix, name, help, commonLabels).mapK(fk).map(_.mapK(fk))
 
       override protected[prometheus4cats] def createAndRegisterLabelledLongCounter[A](
           prefix: Option[Metric.Prefix],
@@ -746,8 +761,11 @@ object MetricRegistry {
           help: Metric.Help,
           commonLabels: CommonLabels,
           labelNames: IndexedSeq[Label.Name]
-      )(f: A => IndexedSeq[String]): G[Counter.Labelled[G, Long, A]] =
-        fk(self.createAndRegisterLabelledLongCounter(prefix, name, help, commonLabels, labelNames)(f)).map(_.mapK(fk))
+      )(f: A => IndexedSeq[String]): Resource[G, Counter.Labelled[G, Long, A]] =
+        self
+          .createAndRegisterLabelledLongCounter(prefix, name, help, commonLabels, labelNames)(f)
+          .mapK(fk)
+          .map(_.mapK(fk))
 
       override protected[prometheus4cats] def createAndRegisterLabelledLongGauge[A](
           prefix: Option[Metric.Prefix],
@@ -755,8 +773,11 @@ object MetricRegistry {
           help: Metric.Help,
           commonLabels: CommonLabels,
           labelNames: IndexedSeq[Label.Name]
-      )(f: A => IndexedSeq[String]): G[Gauge.Labelled[G, Long, A]] =
-        fk(self.createAndRegisterLabelledLongGauge(prefix, name, help, commonLabels, labelNames)(f)).map(_.mapK(fk))
+      )(f: A => IndexedSeq[String]): Resource[G, Gauge.Labelled[G, Long, A]] =
+        self
+          .createAndRegisterLabelledLongGauge(prefix, name, help, commonLabels, labelNames)(f)
+          .mapK(fk)
+          .map(_.mapK(fk))
 
       override protected[prometheus4cats] def createAndRegisterLongHistogram(
           prefix: Option[Metric.Prefix],
@@ -764,8 +785,8 @@ object MetricRegistry {
           help: Metric.Help,
           commonLabels: CommonLabels,
           buckets: NonEmptySeq[Long]
-      ): G[Histogram[G, Long]] =
-        fk(self.createAndRegisterLongHistogram(prefix, name, help, commonLabels, buckets)).map(_.mapK(fk))
+      ): Resource[G, Histogram[G, Long]] =
+        self.createAndRegisterLongHistogram(prefix, name, help, commonLabels, buckets).mapK(fk).map(_.mapK(fk))
 
       override protected[prometheus4cats] def createAndRegisterLabelledLongHistogram[A](
           prefix: Option[Metric.Prefix],
@@ -774,8 +795,10 @@ object MetricRegistry {
           commonLabels: CommonLabels,
           labelNames: IndexedSeq[Label.Name],
           buckets: NonEmptySeq[Long]
-      )(f: A => IndexedSeq[String]): G[Histogram.Labelled[G, Long, A]] =
-        fk(self.createAndRegisterLabelledLongHistogram(prefix, name, help, commonLabels, labelNames, buckets)(f))
+      )(f: A => IndexedSeq[String]): Resource[G, Histogram.Labelled[G, Long, A]] =
+        self
+          .createAndRegisterLabelledLongHistogram(prefix, name, help, commonLabels, labelNames, buckets)(f)
+          .mapK(fk)
           .map(_.mapK(fk))
 
       override protected[prometheus4cats] def createAndRegisterDoubleSummary(
@@ -786,9 +809,11 @@ object MetricRegistry {
           quantiles: Seq[QuantileDefinition],
           maxAge: FiniteDuration,
           ageBuckets: Summary.AgeBuckets
-      ): G[Summary[G, Double]] = fk(
-        self.createAndRegisterDoubleSummary(prefix, name, help, commonLabels, quantiles, maxAge, ageBuckets)
-      ).map(_.mapK(fk))
+      ): Resource[G, Summary[G, Double]] =
+        self
+          .createAndRegisterDoubleSummary(prefix, name, help, commonLabels, quantiles, maxAge, ageBuckets)
+          .mapK(fk)
+          .map(_.mapK(fk))
 
       override protected[prometheus4cats] def createAndRegisterLongSummary(
           prefix: Option[Metric.Prefix],
@@ -798,9 +823,11 @@ object MetricRegistry {
           quantiles: Seq[QuantileDefinition],
           maxAge: FiniteDuration,
           ageBuckets: Summary.AgeBuckets
-      ): G[Summary[G, Long]] = fk(
-        self.createAndRegisterLongSummary(prefix, name, help, commonLabels, quantiles, maxAge, ageBuckets)
-      ).map(_.mapK(fk))
+      ): Resource[G, Summary[G, Long]] =
+        self
+          .createAndRegisterLongSummary(prefix, name, help, commonLabels, quantiles, maxAge, ageBuckets)
+          .mapK(fk)
+          .map(_.mapK(fk))
 
       override protected[prometheus4cats] def createAndRegisterLabelledDoubleSummary[A](
           prefix: Option[Metric.Prefix],
@@ -811,18 +838,20 @@ object MetricRegistry {
           quantiles: Seq[QuantileDefinition],
           maxAge: FiniteDuration,
           ageBuckets: Summary.AgeBuckets
-      )(f: A => IndexedSeq[String]): G[Summary.Labelled[G, Double, A]] = fk(
-        self.createAndRegisterLabelledDoubleSummary(
-          prefix,
-          name,
-          help,
-          commonLabels,
-          labelNames,
-          quantiles,
-          maxAge,
-          ageBuckets
-        )(f)
-      ).map(_.mapK(fk))
+      )(f: A => IndexedSeq[String]): Resource[G, Summary.Labelled[G, Double, A]] =
+        self
+          .createAndRegisterLabelledDoubleSummary(
+            prefix,
+            name,
+            help,
+            commonLabels,
+            labelNames,
+            quantiles,
+            maxAge,
+            ageBuckets
+          )(f)
+          .mapK(fk)
+          .map(_.mapK(fk))
 
       override protected[prometheus4cats] def createAndRegisterLabelledLongSummary[A](
           prefix: Option[Metric.Prefix],
@@ -833,24 +862,27 @@ object MetricRegistry {
           quantiles: Seq[QuantileDefinition],
           maxAge: FiniteDuration,
           ageBuckets: Summary.AgeBuckets
-      )(f: A => IndexedSeq[String]): G[Summary.Labelled[G, Long, A]] = fk(
-        self.createAndRegisterLabelledLongSummary(
-          prefix,
-          name,
-          help,
-          commonLabels,
-          labelNames,
-          quantiles,
-          maxAge,
-          ageBuckets
-        )(f)
-      ).map(_.mapK(fk))
+      )(f: A => IndexedSeq[String]): Resource[G, Summary.Labelled[G, Long, A]] =
+        self
+          .createAndRegisterLabelledLongSummary(
+            prefix,
+            name,
+            help,
+            commonLabels,
+            labelNames,
+            quantiles,
+            maxAge,
+            ageBuckets
+          )(f)
+          .mapK(fk)
+          .map(_.mapK(fk))
 
       override protected[prometheus4cats] def createAndRegisterInfo(
           prefix: Option[Metric.Prefix],
           name: Info.Name,
           help: Metric.Help
-      ): G[Info[G, Map[Label.Name, String]]] = fk(self.createAndRegisterInfo(prefix, name, help)).map(_.mapK(fk))
+      ): Resource[G, Info[G, Map[Label.Name, String]]] =
+        self.createAndRegisterInfo(prefix, name, help).mapK(fk).map(_.mapK(fk))
 
     }
 }

--- a/core/src/main/scala/prometheus4cats/internal/summary/SummaryDsl.scala
+++ b/core/src/main/scala/prometheus4cats/internal/summary/SummaryDsl.scala
@@ -16,6 +16,7 @@
 
 package prometheus4cats.internal.summary
 
+import cats.effect.kernel.Resource
 import prometheus4cats.Summary.QuantileDefinition
 import prometheus4cats._
 import prometheus4cats.internal._
@@ -26,7 +27,7 @@ class SummaryDsl[F[_], A] private[prometheus4cats] (
     quantiles: Seq[QuantileDefinition] = SummaryDsl.defaultQuantiles,
     maxAgeValue: FiniteDuration = SummaryDsl.defaultMaxAge,
     ageBucketsValue: Summary.AgeBuckets = Summary.AgeBuckets.Default,
-    makeSummary: (Seq[QuantileDefinition], FiniteDuration, Summary.AgeBuckets) => F[Summary[F, A]],
+    makeSummary: (Seq[QuantileDefinition], FiniteDuration, Summary.AgeBuckets) => Resource[F, Summary[F, A]],
     makeLabelledSummary: (
         Seq[QuantileDefinition],
         FiniteDuration,
@@ -78,8 +79,8 @@ object SummaryDsl {
       quantiles: Seq[QuantileDefinition] = SummaryDsl.defaultQuantiles,
       maxAgeValue: FiniteDuration = SummaryDsl.defaultMaxAge,
       ageBucketsValue: Summary.AgeBuckets = Summary.AgeBuckets.Default,
-      makeSummary: (Seq[QuantileDefinition], FiniteDuration, Summary.AgeBuckets) => F[Summary[F, A]],
-      makeSummaryCallback: F[A0] => F[Unit],
+      makeSummary: (Seq[QuantileDefinition], FiniteDuration, Summary.AgeBuckets) => Resource[F, Summary[F, A]],
+      makeSummaryCallback: F[A0] => Resource[F, Unit],
       makeLabelledSummary: (
           Seq[QuantileDefinition],
           FiniteDuration,
@@ -111,7 +112,7 @@ class AgeBucketsStep[F[_], A] private[summary] (
     quantiles: Seq[QuantileDefinition],
     maxAgeValue: FiniteDuration,
     ageBucketsValue: Summary.AgeBuckets,
-    makeSummary: (Seq[QuantileDefinition], FiniteDuration, Summary.AgeBuckets) => F[Summary[F, A]],
+    makeSummary: (Seq[QuantileDefinition], FiniteDuration, Summary.AgeBuckets) => Resource[F, Summary[F, A]],
     makeLabelledSummary: (
         Seq[QuantileDefinition],
         FiniteDuration,

--- a/core/src/main/scala/prometheus4cats/util/DoubleCallbackRegistry.scala
+++ b/core/src/main/scala/prometheus4cats/util/DoubleCallbackRegistry.scala
@@ -18,6 +18,7 @@ package prometheus4cats.util
 
 import cats.Functor
 import cats.data.NonEmptySeq
+import cats.effect.kernel.Resource
 import cats.syntax.functor._
 import prometheus4cats._
 
@@ -30,7 +31,7 @@ trait DoubleCallbackRegistry[F[_]] extends CallbackRegistry[F] {
       help: Metric.Help,
       commonLabels: Metric.CommonLabels,
       callback: F[Long]
-  ): F[Unit] = registerDoubleCounterCallback(prefix, name, help, commonLabels, callback.map(_.toDouble))
+  ): Resource[F, Unit] = registerDoubleCounterCallback(prefix, name, help, commonLabels, callback.map(_.toDouble))
 
   override protected[prometheus4cats] def registerLabelledLongCounterCallback[A](
       prefix: Option[Metric.Prefix],
@@ -39,7 +40,7 @@ trait DoubleCallbackRegistry[F[_]] extends CallbackRegistry[F] {
       commonLabels: Metric.CommonLabels,
       labelNames: IndexedSeq[Label.Name],
       callback: F[(Long, A)]
-  )(f: A => IndexedSeq[String]): F[Unit] = registerLabelledDoubleCounterCallback(
+  )(f: A => IndexedSeq[String]): Resource[F, Unit] = registerLabelledDoubleCounterCallback(
     prefix,
     name,
     help,
@@ -54,7 +55,7 @@ trait DoubleCallbackRegistry[F[_]] extends CallbackRegistry[F] {
       help: Metric.Help,
       commonLabels: Metric.CommonLabels,
       callback: F[Long]
-  ): F[Unit] = registerDoubleGaugeCallback(prefix, name, help, commonLabels, callback.map(_.toDouble))
+  ): Resource[F, Unit] = registerDoubleGaugeCallback(prefix, name, help, commonLabels, callback.map(_.toDouble))
 
   override protected[prometheus4cats] def registerLabelledLongGaugeCallback[A](
       prefix: Option[Metric.Prefix],
@@ -63,7 +64,7 @@ trait DoubleCallbackRegistry[F[_]] extends CallbackRegistry[F] {
       commonLabels: Metric.CommonLabels,
       labelNames: IndexedSeq[Label.Name],
       callback: F[(Long, A)]
-  )(f: A => IndexedSeq[String]): F[Unit] = registerLabelledDoubleGaugeCallback(
+  )(f: A => IndexedSeq[String]): Resource[F, Unit] = registerLabelledDoubleGaugeCallback(
     prefix,
     name,
     help,
@@ -79,7 +80,7 @@ trait DoubleCallbackRegistry[F[_]] extends CallbackRegistry[F] {
       commonLabels: Metric.CommonLabels,
       buckets: NonEmptySeq[Long],
       callback: F[Histogram.Value[Long]]
-  ): F[Unit] = registerDoubleHistogramCallback(
+  ): Resource[F, Unit] = registerDoubleHistogramCallback(
     prefix,
     name,
     help,
@@ -96,7 +97,7 @@ trait DoubleCallbackRegistry[F[_]] extends CallbackRegistry[F] {
       labelNames: IndexedSeq[Label.Name],
       buckets: NonEmptySeq[Long],
       callback: F[(Histogram.Value[Long], A)]
-  )(f: A => IndexedSeq[String]): F[Unit] = registerLabelledDoubleHistogramCallback(
+  )(f: A => IndexedSeq[String]): Resource[F, Unit] = registerLabelledDoubleHistogramCallback(
     prefix,
     name,
     help,
@@ -112,7 +113,7 @@ trait DoubleCallbackRegistry[F[_]] extends CallbackRegistry[F] {
       help: Metric.Help,
       commonLabels: Metric.CommonLabels,
       callback: F[Summary.Value[Long]]
-  ): F[Unit] = registerDoubleSummaryCallback(
+  ): Resource[F, Unit] = registerDoubleSummaryCallback(
     prefix,
     name,
     help,
@@ -127,7 +128,7 @@ trait DoubleCallbackRegistry[F[_]] extends CallbackRegistry[F] {
       commonLabels: Metric.CommonLabels,
       labelNames: IndexedSeq[Label.Name],
       callback: F[(Summary.Value[Long], A)]
-  )(f: A => IndexedSeq[String]): F[Unit] = registerLabelledDoubleSummaryCallback(
+  )(f: A => IndexedSeq[String]): Resource[F, Unit] = registerLabelledDoubleSummaryCallback(
     prefix,
     name,
     help,

--- a/core/src/main/scala/prometheus4cats/util/DoubleMetricRegistry.scala
+++ b/core/src/main/scala/prometheus4cats/util/DoubleMetricRegistry.scala
@@ -16,22 +16,20 @@
 
 package prometheus4cats.util
 
-import cats.Functor
 import cats.data.NonEmptySeq
-import cats.syntax.functor._
+import cats.effect.kernel.Resource
 import prometheus4cats._
 
 import scala.concurrent.duration.FiniteDuration
 
 trait DoubleMetricRegistry[F[_]] extends MetricRegistry[F] {
-  implicit protected val F: Functor[F]
-
   override protected[prometheus4cats] def createAndRegisterLongCounter(
       prefix: Option[Metric.Prefix],
       name: Counter.Name,
       help: Metric.Help,
       commonLabels: Metric.CommonLabels
-  ): F[Counter[F, Long]] = createAndRegisterDoubleCounter(prefix, name, help, commonLabels).map(_.contramap(_.toDouble))
+  ): Resource[F, Counter[F, Long]] =
+    createAndRegisterDoubleCounter(prefix, name, help, commonLabels).map(_.contramap(_.toDouble))
 
   override protected[prometheus4cats] def createAndRegisterLabelledLongCounter[A](
       prefix: Option[Metric.Prefix],
@@ -39,7 +37,7 @@ trait DoubleMetricRegistry[F[_]] extends MetricRegistry[F] {
       help: Metric.Help,
       commonLabels: Metric.CommonLabels,
       labelNames: IndexedSeq[Label.Name]
-  )(f: A => IndexedSeq[String]): F[Counter.Labelled[F, Long, A]] =
+  )(f: A => IndexedSeq[String]): Resource[F, Counter.Labelled[F, Long, A]] =
     createAndRegisterLabelledDoubleCounter(prefix, name, help, commonLabels, labelNames)(f).map(_.contramap(_.toDouble))
 
   override protected[prometheus4cats] def createAndRegisterLongGauge(
@@ -47,7 +45,8 @@ trait DoubleMetricRegistry[F[_]] extends MetricRegistry[F] {
       name: Gauge.Name,
       help: Metric.Help,
       commonLabels: Metric.CommonLabels
-  ): F[Gauge[F, Long]] = createAndRegisterDoubleGauge(prefix, name, help, commonLabels).map(_.contramap(_.toDouble))
+  ): Resource[F, Gauge[F, Long]] =
+    createAndRegisterDoubleGauge(prefix, name, help, commonLabels).map(_.contramap(_.toDouble))
 
   override protected[prometheus4cats] def createAndRegisterLabelledLongGauge[A](
       prefix: Option[Metric.Prefix],
@@ -55,7 +54,7 @@ trait DoubleMetricRegistry[F[_]] extends MetricRegistry[F] {
       help: Metric.Help,
       commonLabels: Metric.CommonLabels,
       labelNames: IndexedSeq[Label.Name]
-  )(f: A => IndexedSeq[String]): F[Gauge.Labelled[F, Long, A]] =
+  )(f: A => IndexedSeq[String]): Resource[F, Gauge.Labelled[F, Long, A]] =
     createAndRegisterLabelledDoubleGauge(prefix, name, help, commonLabels, labelNames)(f).map(_.contramap(_.toDouble))
 
   override protected[prometheus4cats] def createAndRegisterLongHistogram(
@@ -64,7 +63,7 @@ trait DoubleMetricRegistry[F[_]] extends MetricRegistry[F] {
       help: Metric.Help,
       commonLabels: Metric.CommonLabels,
       buckets: NonEmptySeq[Long]
-  ): F[Histogram[F, Long]] =
+  ): Resource[F, Histogram[F, Long]] =
     createAndRegisterDoubleHistogram(prefix, name, help, commonLabels, buckets.map(_.toDouble))
       .map(_.contramap(_.toDouble))
 
@@ -75,7 +74,7 @@ trait DoubleMetricRegistry[F[_]] extends MetricRegistry[F] {
       commonLabels: Metric.CommonLabels,
       labelNames: IndexedSeq[Label.Name],
       buckets: NonEmptySeq[Long]
-  )(f: A => IndexedSeq[String]): F[Histogram.Labelled[F, Long, A]] =
+  )(f: A => IndexedSeq[String]): Resource[F, Histogram.Labelled[F, Long, A]] =
     createAndRegisterLabelledDoubleHistogram(prefix, name, help, commonLabels, labelNames, buckets.map(_.toDouble))(f)
       .map(
         _.contramap(_.toDouble)
@@ -89,7 +88,7 @@ trait DoubleMetricRegistry[F[_]] extends MetricRegistry[F] {
       quantiles: Seq[Summary.QuantileDefinition],
       maxAge: FiniteDuration,
       ageBuckets: Summary.AgeBuckets
-  ): F[Summary[F, Long]] =
+  ): Resource[F, Summary[F, Long]] =
     createAndRegisterDoubleSummary(prefix, name, help, commonLabels, quantiles, maxAge, ageBuckets).map(
       _.contramap(_.toDouble)
     )
@@ -103,7 +102,7 @@ trait DoubleMetricRegistry[F[_]] extends MetricRegistry[F] {
       quantiles: Seq[Summary.QuantileDefinition],
       maxAge: FiniteDuration,
       ageBuckets: Summary.AgeBuckets
-  )(f: A => IndexedSeq[String]): F[Summary.Labelled[F, Long, A]] =
+  )(f: A => IndexedSeq[String]): Resource[F, Summary.Labelled[F, Long, A]] =
     createAndRegisterLabelledDoubleSummary(prefix, name, help, commonLabels, labelNames, quantiles, maxAge, ageBuckets)(
       f
     ).map(_.contramap(_.toDouble))

--- a/core/src/test/scala/prometheus4cats/MetricsFactoryDslTest.scala
+++ b/core/src/test/scala/prometheus4cats/MetricsFactoryDslTest.scala
@@ -30,7 +30,6 @@ object MetricsFactoryDslTest {
 
   val doubleGaugeBuilder = gaugeBuilder.ofDouble.help("help")
   doubleGaugeBuilder.build
-  doubleGaugeBuilder.resource
   doubleGaugeBuilder.asCurrentTimeRecorder
   doubleGaugeBuilder.asCurrentTimeRecorder(_.toUnit(TimeUnit.NANOSECONDS))
   doubleGaugeBuilder.contramap[Int](_.toDouble).build
@@ -52,7 +51,6 @@ object MetricsFactoryDslTest {
 
   val longGaugeBuilder = gaugeBuilder.ofLong.help("help")
   longGaugeBuilder.build
-  longGaugeBuilder.resource
   longGaugeBuilder.asCurrentTimeRecorder
   longGaugeBuilder.asCurrentTimeRecorder(_.toDays)
   longGaugeBuilder.label[String]("label1").label[Int]("label2").label[BigInteger]("label3", _.toString).build
@@ -62,7 +60,6 @@ object MetricsFactoryDslTest {
 
   val doubleCounterBuilder = counterBuilder.ofDouble.help("help")
   doubleCounterBuilder.build
-  doubleCounterBuilder.resource
   doubleCounterBuilder.asOutcomeRecorder.build
   doubleCounterBuilder.unsafeLabels(Label.Name("label1"), Label.Name("label2")).build
 
@@ -74,7 +71,6 @@ object MetricsFactoryDslTest {
 
   val longCounterBuilder = counterBuilder.ofLong.help("help")
   longCounterBuilder.build
-  longCounterBuilder.resource
   longCounterBuilder.label[String]("label1").label[Int]("label2").label[BigInteger]("label3", _.toString).build
   longCounterBuilder.unsafeLabels(Label.Name("label1"), Label.Name("label2")).build
 
@@ -82,7 +78,6 @@ object MetricsFactoryDslTest {
 
   val doubleHistogramBuilder = histogramBuilder.ofDouble.help("help").defaultHttpBuckets
   doubleHistogramBuilder.build
-  doubleHistogramBuilder.resource
   doubleHistogramBuilder.asTimer.build
   doubleHistogramBuilder
     .label[String]("label1")
@@ -97,14 +92,12 @@ object MetricsFactoryDslTest {
 
   val longHistogramBuilder = histogramBuilder.ofLong.help("help").buckets(1, 2)
   longHistogramBuilder.build
-  longHistogramBuilder.resource
   longHistogramBuilder.label[String]("label1").label[Int]("label2").label[BigInteger]("label3", _.toString).build
   longHistogramBuilder.unsafeLabels(Label.Name("label1"), Label.Name("label2")).build
 
   val infoBuilder = factory.info("test_info").help("help")
   infoBuilder.contramap[List[(Label.Name, String)]](_.toMap)
   infoBuilder.build
-  infoBuilder.resource
 
   val doubleSummaryBuilder =
     factory

--- a/docs/metrics/derived-metric-types.md
+++ b/docs/metrics/derived-metric-types.md
@@ -32,7 +32,7 @@ operations.
 #### Obtaining from a `Histogram`
 
 ```scala mdoc:silent
-val simpleTimerHistogram: IO[Timer.Aux[IO, Histogram]] = factory
+val simpleTimerHistogram: Resource[IO, Timer.Aux[IO, Histogram]] = factory
   .histogram("time")
   .ofDouble
   .help("Records the how long an opertation took")
@@ -42,7 +42,7 @@ val simpleTimerHistogram: IO[Timer.Aux[IO, Histogram]] = factory
 ```
 
 ```scala mdoc:silent
-val labelledTimerHistogram: IO[Timer.Labelled.Aux[IO, String, Histogram.Labelled]] = factory
+val labelledTimerHistogram: Resource[IO, Timer.Labelled.Aux[IO, String, Histogram.Labelled]] = factory
   .histogram("time")
   .ofDouble
   .help("Records the how long an opertation took")
@@ -55,7 +55,7 @@ val labelledTimerHistogram: IO[Timer.Labelled.Aux[IO, String, Histogram.Labelled
 #### Obtaining from a `Summary`
 
 ```scala mdoc:silent
-val simpleTimerSummary: IO[Timer.Aux[IO, Summary]] = factory
+val simpleTimerSummary: Resource[IO, Timer.Aux[IO, Summary]] = factory
   .summary("time")
   .ofDouble
   .help("Records the how long an opertation took")
@@ -64,7 +64,7 @@ val simpleTimerSummary: IO[Timer.Aux[IO, Summary]] = factory
 ```
 
 ```scala mdoc:silent
-val labelledTimerSummary: IO[Timer.Labelled.Aux[IO, String, Summary.Labelled]] = factory
+val labelledTimerSummary: Resource[IO, Timer.Labelled.Aux[IO, String, Summary.Labelled]] = factory
   .summary("time")
   .ofDouble
   .help("Records the how long an opertation took")
@@ -76,7 +76,7 @@ val labelledTimerSummary: IO[Timer.Labelled.Aux[IO, String, Summary.Labelled]] =
 #### Obtaining from a `Gauge`
 
 ```scala mdoc:silent
-val simpleTimerGauge: IO[Timer.Aux[IO, Gauge]] = factory
+val simpleTimerGauge: Resource[IO, Timer.Aux[IO, Gauge]] = factory
   .gauge("time")
   .ofDouble
   .help("Records the how long an opertation took")
@@ -85,7 +85,7 @@ val simpleTimerGauge: IO[Timer.Aux[IO, Gauge]] = factory
 ```
 
 ```scala mdoc:silent
-val labelledTimerGauge: IO[Timer.Labelled.Aux[IO, String, Gauge.Labelled]] = factory
+val labelledTimerGauge: Resource[IO, Timer.Labelled.Aux[IO, String, Gauge.Labelled]] = factory
   .gauge("time")
   .ofDouble
   .help("Records the how long an opertation took")
@@ -102,7 +102,7 @@ system time.
 #### Obtaining from a `Gauge`
 
 ```scala mdoc:silent
-val simpleCurrentTimeRecorderGauge: IO[CurrentTimeRecorder[IO]] = factory
+val simpleCurrentTimeRecorderGauge: Resource[IO, CurrentTimeRecorder[IO]] = factory
   .gauge("current_time")
   .ofDouble
   .help("Records the how long an opertation took")
@@ -112,7 +112,7 @@ val simpleCurrentTimeRecorderGauge: IO[CurrentTimeRecorder[IO]] = factory
 
 ```scala mdoc:silent
 val labelledCurrentTimeRecorderGauge:
-  IO[CurrentTimeRecorder.Labelled[IO, String]] =
+  Resource[IO, CurrentTimeRecorder.Labelled[IO, String]] =
     factory
       .gauge("current_time")
       .ofDouble
@@ -142,7 +142,7 @@ To help disambiguate the difference in behaviour the `OutcomeRecorder` type will
 #### Obtaining from a `Counter`
 
 ```scala mdoc:silent
-val simpleOutcomeCounter: IO[OutcomeRecorder.Aux[IO, Long, Counter.Labelled]] = factory
+val simpleOutcomeCounter: Resource[IO, OutcomeRecorder.Aux[IO, Long, Counter.Labelled]] = factory
   .counter("outcome_total")
   .ofLong
   .help("Records the outcome of some operation")
@@ -152,7 +152,7 @@ val simpleOutcomeCounter: IO[OutcomeRecorder.Aux[IO, Long, Counter.Labelled]] = 
 
 ```scala mdoc:silent
 val labelledOutcomeCounter:
-  IO[OutcomeRecorder.Labelled.Aux[IO, Long, String, Counter.Labelled]] = factory
+  Resource[IO, OutcomeRecorder.Labelled.Aux[IO, Long, String, Counter.Labelled]] = factory
     .counter("outcome_total")
     .ofLong
     .help("Records the outcome of some operation")
@@ -164,7 +164,7 @@ val labelledOutcomeCounter:
 #### Obtaining from a `Gauge`
 
 ```scala mdoc:silent
-val simpleOutcomeGauge: IO[OutcomeRecorder.Aux[IO, Long, Gauge.Labelled]] = factory
+val simpleOutcomeGauge: Resource[IO, OutcomeRecorder.Aux[IO, Long, Gauge.Labelled]] = factory
   .gauge("outcome")
   .ofLong
   .help("Records the outcome of some operation")
@@ -174,7 +174,7 @@ val simpleOutcomeGauge: IO[OutcomeRecorder.Aux[IO, Long, Gauge.Labelled]] = fact
 
 ```scala mdoc:silent
 val labelledOutcomeGauge:
-  IO[OutcomeRecorder.Labelled.Aux[IO, Long, String, Gauge.Labelled]] = factory
+  Resource[IO, OutcomeRecorder.Labelled.Aux[IO, Long, String, Gauge.Labelled]] = factory
     .gauge("outcome")
     .ofLong
     .help("Records the outcome of some operation")


### PR DESCRIPTION
This returns each metric as a resource, meaning that it gets de-registered from the registry upon resource finalisation.