### PR TITLE
Fix intellij implicit resolution

### DIFF
--- a/java/src/main/scala/prometheus4cats/javasimpleclient/package.scala
+++ b/java/src/main/scala/prometheus4cats/javasimpleclient/package.scala
@@ -32,4 +32,5 @@ package object javasimpleclient {
     case (prefix, name) =>
       NameUtils.makeName(prefix, name)
   }
+
 }


### PR DESCRIPTION
IJ seems to not be able to find `InitLast` implicits when they are type bounds on methods, adding it an implicit parameter works fine.

This
![image](https://user-images.githubusercontent.com/1926225/199476269-681ceb2e-3911-4fad-80fc-5a6a2504f1bc.png)

Becomes 

![image](https://user-images.githubusercontent.com/1926225/199476385-36f8abe8-209f-43c9-b22a-68b765fbfd2b.png)
