### PR TITLE
Allow multiple values to be passed on a labelled callback

### DIFF
--- a/core/src/main/scala/prometheus4cats/CallbackRegistry.scala
+++ b/core/src/main/scala/prometheus4cats/CallbackRegistry.scala
@@ -16,7 +16,7 @@
 
 package prometheus4cats
 
-import cats.data.NonEmptySeq
+import cats.data.{NonEmptyList, NonEmptySeq}
 import cats.effect.MonadCancel
 import cats.effect.kernel.Resource
 import cats.~>
@@ -88,7 +88,7 @@ trait CallbackRegistry[F[_]] {
     *   a function from `A` to an [[scala.IndexedSeq]] of [[java.lang.String]] that provides label values, which must be
     *   paired with their corresponding name in the [[scala.IndexedSeq]] of [[Label.Name]]s
     * @param callback
-    *   Some effectful operation that returns a [[scala.Long]]
+    *   Some effectful operation that returns a [[cats.data.NonEmptyList]] of [[scala.Double]] and label value tuples
     * @return
     *   An empty side effect to indicate that the callback has been registered
     */
@@ -98,7 +98,7 @@ trait CallbackRegistry[F[_]] {
       help: Metric.Help,
       commonLabels: Metric.CommonLabels,
       labelNames: IndexedSeq[Label.Name],
-      callback: F[(Double, A)]
+      callback: F[NonEmptyList[(Double, A)]]
   )(f: A => IndexedSeq[String]): Resource[F, Unit]
 
   /** Register a labelled counter value that records [[scala.Long]] values against a metrics registry
@@ -117,7 +117,7 @@ trait CallbackRegistry[F[_]] {
     *   a function from `A` to an [[scala.IndexedSeq]] of [[java.lang.String]] that provides label values, which must be
     *   paired with their corresponding name in the [[scala.IndexedSeq]] of [[Label.Name]]s
     * @param callback
-    *   Some effectful operation that returns a [[scala.Double]]
+    *   Some effectful operation that returns a [[cats.data.NonEmptyList]] of [[scala.Long]] and label value tuples
     * @return
     *   An empty side effect to indicate that the callback has been registered
     */
@@ -127,7 +127,7 @@ trait CallbackRegistry[F[_]] {
       help: Metric.Help,
       commonLabels: Metric.CommonLabels,
       labelNames: IndexedSeq[Label.Name],
-      callback: F[(Long, A)]
+      callback: F[NonEmptyList[(Long, A)]]
   )(f: A => IndexedSeq[String]): Resource[F, Unit]
 
   /** Register a gauge value that records [[scala.Double]] values against a callback registry
@@ -192,7 +192,7 @@ trait CallbackRegistry[F[_]] {
     *   a function from `A` to an [[scala.IndexedSeq]] of [[java.lang.String]] that provides label values, which must be
     *   paired with their corresponding name in the [[scala.IndexedSeq]] of [[Label.Name]]s
     * @param callback
-    *   Some effectful operation that returns a [[scala.Double]]
+    *   Some effectful operation that returns a [[cats.data.NonEmptyList]] of [[scala.Double]] and label value tuples
     * @return
     *   An empty side effect to indicate that the callback has been registered
     */
@@ -202,7 +202,7 @@ trait CallbackRegistry[F[_]] {
       help: Metric.Help,
       commonLabels: Metric.CommonLabels,
       labelNames: IndexedSeq[Label.Name],
-      callback: F[(Double, A)]
+      callback: F[NonEmptyList[(Double, A)]]
   )(f: A => IndexedSeq[String]): Resource[F, Unit]
 
   /** Register a labelled gauge value that records [[scala.Long]] values against a metrics registry
@@ -221,7 +221,7 @@ trait CallbackRegistry[F[_]] {
     *   a function from `A` to an [[scala.IndexedSeq]] of [[java.lang.String]] that provides label values, which must be
     *   paired with their corresponding name in the [[scala.IndexedSeq]] of [[Label.Name]]s
     * @param callback
-    *   Some effectful operation that returns a [[scala.Long]]
+    *   Some effectful operation that returns a [[cats.data.NonEmptyList]] of [[scala.Long]] and label value tuples
     * @return
     *   An empty side effect to indicate that the callback has been registered
     */
@@ -231,7 +231,7 @@ trait CallbackRegistry[F[_]] {
       help: Metric.Help,
       commonLabels: Metric.CommonLabels,
       labelNames: IndexedSeq[Label.Name],
-      callback: F[(Long, A)]
+      callback: F[NonEmptyList[(Long, A)]]
   )(f: A => IndexedSeq[String]): Resource[F, Unit]
 
   /** Register a histogram value that records [[scala.Double]] values against a callback registry
@@ -298,7 +298,8 @@ trait CallbackRegistry[F[_]] {
     *   a function from `A` to an [[scala.IndexedSeq]] of [[java.lang.String]] that provides label values, which must be
     *   paired with their corresponding name in the [[scala.IndexedSeq]] of [[Label.Name]]s
     * @param callback
-    *   Some effectful operation that returns a [[Histogram.Value]] parameterised with [[scala.Double]]
+    *   Some effectful operation that returns a [[cats.data.NonEmptyList]] of [[Histogram.Value]] parameterised with
+    *   [[scala.Double]] and label value tuples
     * @return
     *   An empty side effect to indicate that the callback has been registered
     */
@@ -309,7 +310,7 @@ trait CallbackRegistry[F[_]] {
       commonLabels: Metric.CommonLabels,
       labelNames: IndexedSeq[Label.Name],
       buckets: NonEmptySeq[Double],
-      callback: F[(Histogram.Value[Double], A)]
+      callback: F[NonEmptyList[(Histogram.Value[Double], A)]]
   )(f: A => IndexedSeq[String]): Resource[F, Unit]
 
   /** Register a labelled histogram value that records [[scala.Long]] values against a metrics registry
@@ -328,7 +329,8 @@ trait CallbackRegistry[F[_]] {
     *   a function from `A` to an [[scala.IndexedSeq]] of [[java.lang.String]] that provides label values, which must be
     *   paired with their corresponding name in the [[scala.IndexedSeq]] of [[Label.Name]]s
     * @param callback
-    *   Some effectful operation that returns a [[Histogram.Value]] parameterised with [[scala.Long]]
+    *   Some effectful operation that returns a [[cats.data.NonEmptyList]] of [[Histogram.Value]] parameterised with
+    *   [[scala.Long]] and label value tuples
     * @return
     *   An empty side effect to indicate that the callback has been registered
     */
@@ -339,7 +341,7 @@ trait CallbackRegistry[F[_]] {
       commonLabels: Metric.CommonLabels,
       labelNames: IndexedSeq[Label.Name],
       buckets: NonEmptySeq[Long],
-      callback: F[(Histogram.Value[Long], A)]
+      callback: F[NonEmptyList[(Histogram.Value[Long], A)]]
   )(f: A => IndexedSeq[String]): Resource[F, Unit]
 
   /** Register a summary value that records [[scala.Double]] values against a metrics registry
@@ -401,7 +403,8 @@ trait CallbackRegistry[F[_]] {
     * @param labelNames
     *   an [[scala.IndexedSeq]] of [[Label.Name]]s to annotate the metric with
     * @param callback
-    *   Some effectful operation that returns a [[Summary.Value]] parameterised with [[scala.Double]]
+    *   Some effectful operation that returns a [[cats.data.NonEmptyList]] of [[Summary.Value]] parameterised with
+    *   [[scala.Double]] and label value tuples
     * @param f
     *   a function from `A` to an [[scala.IndexedSeq]] of [[java.lang.String]] that provides label values, which must be
     *   paired with their corresponding name in the [[scala.IndexedSeq]] of [[Label.Name]]s
@@ -414,7 +417,7 @@ trait CallbackRegistry[F[_]] {
       help: Metric.Help,
       commonLabels: Metric.CommonLabels,
       labelNames: IndexedSeq[Label.Name],
-      callback: F[(Summary.Value[Double], A)]
+      callback: F[NonEmptyList[(Summary.Value[Double], A)]]
   )(f: A => IndexedSeq[String]): Resource[F, Unit]
 
   /** Register a labelled summary value that records [[scala.Long]] values against a metrics registry
@@ -430,7 +433,8 @@ trait CallbackRegistry[F[_]] {
     * @param labelNames
     *   an [[scala.IndexedSeq]] of [[Label.Name]]s to annotate the metric with
     * @param callback
-    *   Some effectful operation that returns a [[Summary.Value]] parameterised with [[scala.Long]]
+    *   Some effectful operation that returns a [[cats.data.NonEmptyList]] of [[Summary.Value]] parameterised with
+    *   [[scala.Long]] and label value tuples
     * @param f
     *   a function from `A` to an [[scala.IndexedSeq]] of [[java.lang.String]] that provides label values, which must be
     *   paired with their corresponding name in the [[scala.IndexedSeq]] of [[Label.Name]]s
@@ -443,7 +447,7 @@ trait CallbackRegistry[F[_]] {
       help: Metric.Help,
       commonLabels: Metric.CommonLabels,
       labelNames: IndexedSeq[Label.Name],
-      callback: F[(Summary.Value[Long], A)]
+      callback: F[NonEmptyList[(Summary.Value[Long], A)]]
   )(f: A => IndexedSeq[String]): Resource[F, Unit]
 
   protected[prometheus4cats] def registerMetricCollectionCallback(
@@ -485,7 +489,7 @@ object CallbackRegistry {
         help: Metric.Help,
         commonLabels: Metric.CommonLabels,
         labelNames: IndexedSeq[Label.Name],
-        callback: F[(Double, A)]
+        callback: F[NonEmptyList[(Double, A)]]
     )(f: A => IndexedSeq[String]): Resource[F, Unit] = Resource.unit
 
     override protected[prometheus4cats] def registerLabelledLongCounterCallback[A](
@@ -494,7 +498,7 @@ object CallbackRegistry {
         help: Metric.Help,
         commonLabels: Metric.CommonLabels,
         labelNames: IndexedSeq[Label.Name],
-        callback: F[(Long, A)]
+        callback: F[NonEmptyList[(Long, A)]]
     )(f: A => IndexedSeq[String]): Resource[F, Unit] = Resource.unit
 
     override protected[prometheus4cats] def registerDoubleGaugeCallback(
@@ -519,7 +523,7 @@ object CallbackRegistry {
         help: Metric.Help,
         commonLabels: Metric.CommonLabels,
         labelNames: IndexedSeq[Label.Name],
-        callback: F[(Double, A)]
+        callback: F[NonEmptyList[(Double, A)]]
     )(f: A => IndexedSeq[String]): Resource[F, Unit] = Resource.unit
 
     override protected[prometheus4cats] def registerLabelledLongGaugeCallback[A](
@@ -528,7 +532,7 @@ object CallbackRegistry {
         help: Metric.Help,
         commonLabels: Metric.CommonLabels,
         labelNames: IndexedSeq[Label.Name],
-        callback: F[(Long, A)]
+        callback: F[NonEmptyList[(Long, A)]]
     )(f: A => IndexedSeq[String]): Resource[F, Unit] = Resource.unit
 
     override protected[prometheus4cats] def registerDoubleHistogramCallback(
@@ -556,7 +560,7 @@ object CallbackRegistry {
         commonLabels: Metric.CommonLabels,
         labelNames: IndexedSeq[Label.Name],
         buckets: NonEmptySeq[Double],
-        callback: F[(Histogram.Value[Double], A)]
+        callback: F[NonEmptyList[(Histogram.Value[Double], A)]]
     )(f: A => IndexedSeq[String]): Resource[F, Unit] = Resource.unit
 
     override protected[prometheus4cats] def registerLabelledLongHistogramCallback[A](
@@ -566,7 +570,7 @@ object CallbackRegistry {
         commonLabels: Metric.CommonLabels,
         labelNames: IndexedSeq[Label.Name],
         buckets: NonEmptySeq[Long],
-        callback: F[(Histogram.Value[Long], A)]
+        callback: F[NonEmptyList[(Histogram.Value[Long], A)]]
     )(f: A => IndexedSeq[String]): Resource[F, Unit] = Resource.unit
 
     override protected[prometheus4cats] def registerDoubleSummaryCallback(
@@ -591,7 +595,7 @@ object CallbackRegistry {
         help: Metric.Help,
         commonLabels: Metric.CommonLabels,
         labelNames: IndexedSeq[Label.Name],
-        callback: F[(Summary.Value[Double], A)]
+        callback: F[NonEmptyList[(Summary.Value[Double], A)]]
     )(f: A => IndexedSeq[String]): Resource[F, Unit] = Resource.unit
 
     override protected[prometheus4cats] def registerLabelledLongSummaryCallback[A](
@@ -600,7 +604,7 @@ object CallbackRegistry {
         help: Metric.Help,
         commonLabels: Metric.CommonLabels,
         labelNames: IndexedSeq[Label.Name],
-        callback: F[(Summary.Value[Long], A)]
+        callback: F[NonEmptyList[(Summary.Value[Long], A)]]
     )(f: A => IndexedSeq[String]): Resource[F, Unit] = Resource.unit
 
     override protected[prometheus4cats] def registerMetricCollectionCallback(
@@ -638,7 +642,7 @@ object CallbackRegistry {
           help: Metric.Help,
           commonLabels: Metric.CommonLabels,
           labelNames: IndexedSeq[Label.Name],
-          callback: G[(Double, A)]
+          callback: G[NonEmptyList[(Double, A)]]
       )(f: A => IndexedSeq[String]): Resource[G, Unit] = self
         .registerLabelledDoubleCounterCallback(prefix, name, help, commonLabels, labelNames, gk(callback))(f)
         .mapK(fk)
@@ -649,7 +653,7 @@ object CallbackRegistry {
           help: Metric.Help,
           commonLabels: Metric.CommonLabels,
           labelNames: IndexedSeq[Label.Name],
-          callback: G[(Long, A)]
+          callback: G[NonEmptyList[(Long, A)]]
       )(f: A => IndexedSeq[String]): Resource[G, Unit] =
         self.registerLabelledLongCounterCallback(prefix, name, help, commonLabels, labelNames, gk(callback))(f).mapK(fk)
 
@@ -675,7 +679,7 @@ object CallbackRegistry {
           help: Metric.Help,
           commonLabels: Metric.CommonLabels,
           labelNames: IndexedSeq[Label.Name],
-          callback: G[(Double, A)]
+          callback: G[NonEmptyList[(Double, A)]]
       )(f: A => IndexedSeq[String]): Resource[G, Unit] =
         self.registerLabelledDoubleGaugeCallback(prefix, name, help, commonLabels, labelNames, gk(callback))(f).mapK(fk)
 
@@ -685,7 +689,7 @@ object CallbackRegistry {
           help: Metric.Help,
           commonLabels: Metric.CommonLabels,
           labelNames: IndexedSeq[Label.Name],
-          callback: G[(Long, A)]
+          callback: G[NonEmptyList[(Long, A)]]
       )(f: A => IndexedSeq[String]): Resource[G, Unit] =
         self.registerLabelledLongGaugeCallback(prefix, name, help, commonLabels, labelNames, gk(callback))(f).mapK(fk)
 
@@ -716,7 +720,7 @@ object CallbackRegistry {
           commonLabels: Metric.CommonLabels,
           labelNames: IndexedSeq[Label.Name],
           buckets: NonEmptySeq[Double],
-          callback: G[(Histogram.Value[Double], A)]
+          callback: G[NonEmptyList[(Histogram.Value[Double], A)]]
       )(f: A => IndexedSeq[String]): Resource[G, Unit] =
         self
           .registerLabelledDoubleHistogramCallback(
@@ -737,7 +741,7 @@ object CallbackRegistry {
           commonLabels: Metric.CommonLabels,
           labelNames: IndexedSeq[Label.Name],
           buckets: NonEmptySeq[Long],
-          callback: G[(Histogram.Value[Long], A)]
+          callback: G[NonEmptyList[(Histogram.Value[Long], A)]]
       )(f: A => IndexedSeq[String]): Resource[G, Unit] =
         self
           .registerLabelledLongHistogramCallback(
@@ -791,7 +795,7 @@ object CallbackRegistry {
           help: Metric.Help,
           commonLabels: Metric.CommonLabels,
           labelNames: IndexedSeq[Label.Name],
-          callback: G[(Summary.Value[Double], A)]
+          callback: G[NonEmptyList[(Summary.Value[Double], A)]]
       )(f: A => IndexedSeq[String]): Resource[G, Unit] =
         self
           .registerLabelledDoubleSummaryCallback(
@@ -810,7 +814,7 @@ object CallbackRegistry {
           help: Metric.Help,
           commonLabels: Metric.CommonLabels,
           labelNames: IndexedSeq[Label.Name],
-          callback: G[(Summary.Value[Long], A)]
+          callback: G[NonEmptyList[(Summary.Value[Long], A)]]
       )(f: A => IndexedSeq[String]): Resource[G, Unit] =
         self
           .registerLabelledLongSummaryCallback(

--- a/core/src/main/scala/prometheus4cats/MetricFactory.scala
+++ b/core/src/main/scala/prometheus4cats/MetricFactory.scala
@@ -16,6 +16,7 @@
 
 package prometheus4cats
 
+import cats.data.NonEmptyList
 import cats.effect.MonadCancel
 import cats.effect.kernel.Resource
 import cats.{Applicative, ~>}
@@ -296,7 +297,7 @@ object MetricFactory {
                 metricRegistry.createAndRegisterLabelledLongGauge(prefix, name, help, commonLabels, labels)(f)
             },
             new LabelledCallbackPartiallyApplied[F, Long] {
-              override def apply[B](labels: IndexedSeq[Label.Name], callback: F[(Long, B)])(
+              override def apply[B](labels: IndexedSeq[Label.Name], callback: F[NonEmptyList[(Long, B)]])(
                   f: B => IndexedSeq[String]
               ): Resource[F, Unit] =
                 callbackRegistry.registerLabelledLongGaugeCallback(prefix, name, help, commonLabels, labels, callback)(
@@ -316,7 +317,7 @@ object MetricFactory {
                 metricRegistry.createAndRegisterLabelledDoubleGauge(prefix, name, help, commonLabels, labels)(f)
             },
             new LabelledCallbackPartiallyApplied[F, Double] {
-              override def apply[B](labels: IndexedSeq[Label.Name], callback: F[(Double, B)])(
+              override def apply[B](labels: IndexedSeq[Label.Name], callback: F[NonEmptyList[(Double, B)]])(
                   f: B => IndexedSeq[String]
               ): Resource[F, Unit] =
                 callbackRegistry.registerLabelledDoubleGaugeCallback(
@@ -349,7 +350,7 @@ object MetricFactory {
                 metricRegistry.createAndRegisterLabelledLongCounter(prefix, name, help, commonLabels, labels)(f)
             },
             new LabelledCallbackPartiallyApplied[F, Long] {
-              override def apply[B](labels: IndexedSeq[Label.Name], callback: F[(Long, B)])(
+              override def apply[B](labels: IndexedSeq[Label.Name], callback: F[NonEmptyList[(Long, B)]])(
                   f: B => IndexedSeq[String]
               ): Resource[F, Unit] =
                 callbackRegistry
@@ -370,7 +371,7 @@ object MetricFactory {
                 metricRegistry.createAndRegisterLabelledDoubleCounter(prefix, name, help, commonLabels, labels)(f)
             },
             new LabelledCallbackPartiallyApplied[F, Double] {
-              override def apply[B](labels: IndexedSeq[Label.Name], callback: F[(Double, B)])(
+              override def apply[B](labels: IndexedSeq[Label.Name], callback: F[NonEmptyList[(Double, B)]])(
                   f: B => IndexedSeq[String]
               ): Resource[F, Unit] =
                 callbackRegistry.registerLabelledDoubleCounterCallback(
@@ -409,7 +410,10 @@ object MetricFactory {
                       .createAndRegisterLabelledLongHistogram(prefix, name, help, commonLabels, labels, buckets)(f)
                 },
                 new LabelledCallbackPartiallyApplied[F, Histogram.Value[Long]] {
-                  override def apply[B](labels: IndexedSeq[Label.Name], callback: F[(Histogram.Value[Long], B)])(
+                  override def apply[B](
+                      labels: IndexedSeq[Label.Name],
+                      callback: F[NonEmptyList[(Histogram.Value[Long], B)]]
+                  )(
                       f: B => IndexedSeq[String]
                   ): Resource[F, Unit] =
                     callbackRegistry
@@ -444,7 +448,10 @@ object MetricFactory {
                     .createAndRegisterLabelledDoubleHistogram(prefix, name, help, commonLabels, labels, buckets)(f)
               },
               new LabelledCallbackPartiallyApplied[F, Histogram.Value[Double]] {
-                override def apply[B](labels: IndexedSeq[Label.Name], callback: F[(Histogram.Value[Double], B)])(
+                override def apply[B](
+                    labels: IndexedSeq[Label.Name],
+                    callback: F[NonEmptyList[(Histogram.Value[Double], B)]]
+                )(
                     f: B => IndexedSeq[String]
                 ): Resource[F, Unit] =
                   callbackRegistry
@@ -493,7 +500,10 @@ object MetricFactory {
                   )(f)
               },
             makeLabelledSummaryCallback = new LabelledCallbackPartiallyApplied[F, Summary.Value[Long]] {
-              override def apply[B](labels: IndexedSeq[Label.Name], callback: F[(Summary.Value[Long], B)])(
+              override def apply[B](
+                  labels: IndexedSeq[Label.Name],
+                  callback: F[NonEmptyList[(Summary.Value[Long], B)]]
+              )(
                   f: B => IndexedSeq[String]
               ): Resource[F, Unit] =
                 callbackRegistry.registerLabelledLongSummaryCallback(
@@ -530,7 +540,10 @@ object MetricFactory {
                   )(f)
               },
             makeLabelledSummaryCallback = new LabelledCallbackPartiallyApplied[F, Summary.Value[Double]] {
-              override def apply[B](labels: IndexedSeq[Label.Name], callback: F[(Summary.Value[Double], B)])(
+              override def apply[B](
+                  labels: IndexedSeq[Label.Name],
+                  callback: F[NonEmptyList[(Summary.Value[Double], B)]]
+              )(
                   f: B => IndexedSeq[String]
               ): Resource[F, Unit] =
                 callbackRegistry.registerLabelledDoubleSummaryCallback(

--- a/core/src/main/scala/prometheus4cats/util/DoubleCallbackRegistry.scala
+++ b/core/src/main/scala/prometheus4cats/util/DoubleCallbackRegistry.scala
@@ -17,7 +17,7 @@
 package prometheus4cats.util
 
 import cats.Functor
-import cats.data.NonEmptySeq
+import cats.data.{NonEmptyList, NonEmptySeq}
 import cats.effect.kernel.Resource
 import cats.syntax.functor._
 import prometheus4cats._
@@ -39,14 +39,14 @@ trait DoubleCallbackRegistry[F[_]] extends CallbackRegistry[F] {
       help: Metric.Help,
       commonLabels: Metric.CommonLabels,
       labelNames: IndexedSeq[Label.Name],
-      callback: F[(Long, A)]
+      callback: F[NonEmptyList[(Long, A)]]
   )(f: A => IndexedSeq[String]): Resource[F, Unit] = registerLabelledDoubleCounterCallback(
     prefix,
     name,
     help,
     commonLabels,
     labelNames,
-    callback.map { case (v, a) => v.toDouble -> a }
+    callback.map(_.map { case (v, a) => v.toDouble -> a })
   )(f)
 
   override protected[prometheus4cats] def registerLongGaugeCallback(
@@ -63,14 +63,14 @@ trait DoubleCallbackRegistry[F[_]] extends CallbackRegistry[F] {
       help: Metric.Help,
       commonLabels: Metric.CommonLabels,
       labelNames: IndexedSeq[Label.Name],
-      callback: F[(Long, A)]
+      callback: F[NonEmptyList[(Long, A)]]
   )(f: A => IndexedSeq[String]): Resource[F, Unit] = registerLabelledDoubleGaugeCallback(
     prefix,
     name,
     help,
     commonLabels,
     labelNames,
-    callback.map { case (v, a) => v.toDouble -> a }
+    callback.map(_.map { case (v, a) => v.toDouble -> a })
   )(f)
 
   override protected[prometheus4cats] def registerLongHistogramCallback(
@@ -96,7 +96,7 @@ trait DoubleCallbackRegistry[F[_]] extends CallbackRegistry[F] {
       commonLabels: Metric.CommonLabels,
       labelNames: IndexedSeq[Label.Name],
       buckets: NonEmptySeq[Long],
-      callback: F[(Histogram.Value[Long], A)]
+      callback: F[NonEmptyList[(Histogram.Value[Long], A)]]
   )(f: A => IndexedSeq[String]): Resource[F, Unit] = registerLabelledDoubleHistogramCallback(
     prefix,
     name,
@@ -104,7 +104,7 @@ trait DoubleCallbackRegistry[F[_]] extends CallbackRegistry[F] {
     commonLabels,
     labelNames,
     buckets.map(_.toDouble),
-    callback.map { case (v, a) => v.map(_.toDouble) -> a }
+    callback.map(_.map { case (v, a) => v.map(_.toDouble) -> a })
   )(f)
 
   override protected[prometheus4cats] def registerLongSummaryCallback(
@@ -127,13 +127,13 @@ trait DoubleCallbackRegistry[F[_]] extends CallbackRegistry[F] {
       help: Metric.Help,
       commonLabels: Metric.CommonLabels,
       labelNames: IndexedSeq[Label.Name],
-      callback: F[(Summary.Value[Long], A)]
+      callback: F[NonEmptyList[(Summary.Value[Long], A)]]
   )(f: A => IndexedSeq[String]): Resource[F, Unit] = registerLabelledDoubleSummaryCallback(
     prefix,
     name,
     help,
     commonLabels,
     labelNames,
-    callback.map { case (v, a) => v.map(_.toDouble) -> a }
+    callback.map(_.map { case (v, a) => v.map(_.toDouble) -> a })
   )(f)
 }

--- a/java/src/test/scala/prometheus4cats/javasimpleclient/JavaMetricRegistrySuite.scala
+++ b/java/src/test/scala/prometheus4cats/javasimpleclient/JavaMetricRegistrySuite.scala
@@ -17,7 +17,7 @@
 package prometheus4cats.javasimpleclient
 
 import cats.Show
-import cats.data.NonEmptySeq
+import cats.data.{NonEmptyList, NonEmptySeq}
 import cats.effect.IO
 import cats.effect.kernel.Resource
 import cats.syntax.either._
@@ -228,7 +228,7 @@ class JavaMetricRegistrySuite
                 help,
                 commonLabels,
                 labels.toIndexedSeq,
-                IO(0.0 -> Map.empty[Label.Name, String])
+                IO(NonEmptyList.one(0.0 -> Map.empty[Label.Name, String]))
               )(_.values.toIndexedSeq)
 
             (callback >> metric).use_
@@ -273,7 +273,7 @@ class JavaMetricRegistrySuite
                 help,
                 commonLabels,
                 labels.toIndexedSeq,
-                IO(0.0 -> Map.empty[Label.Name, String])
+                IO(NonEmptyList.one(0.0 -> Map.empty[Label.Name, String]))
               )(_.values.toIndexedSeq)
 
             (metric >> callback).use_
@@ -309,7 +309,7 @@ class JavaMetricRegistrySuite
                 help,
                 commonLabels,
                 labels.toIndexedSeq,
-                IO(0.0 -> Map.empty[Label.Name, String])
+                IO(NonEmptyList.one(0.0 -> Map.empty[Label.Name, String]))
               )(_.values.toIndexedSeq)
 
             (callback >> callback).use_

--- a/testkit/src/main/scala/prometheus4cats/testkit/CallbackRegistrySuite.scala
+++ b/testkit/src/main/scala/prometheus4cats/testkit/CallbackRegistrySuite.scala
@@ -16,7 +16,7 @@
 
 package prometheus4cats.testkit
 
-import cats.data.NonEmptySeq
+import cats.data.{NonEmptyList, NonEmptySeq}
 import cats.effect.IO
 import cats.effect.kernel.Resource
 import munit.CatsEffectSuite
@@ -82,7 +82,7 @@ trait CallbackRegistrySuite[State] extends RegistrySuite[State] { self: CatsEffe
                 help,
                 commonLabels,
                 labels.keys.toIndexedSeq,
-                IO(value -> labels)
+                IO(NonEmptyList.one(value -> labels))
               )(_.values.toIndexedSeq)
               .surround(
                 get.map(res => if (value >= 0) assertEquals(res, Some(value)) else assertEquals(res, Some(0.0)))
@@ -142,7 +142,7 @@ trait CallbackRegistrySuite[State] extends RegistrySuite[State] { self: CatsEffe
                 help,
                 commonLabels,
                 labels.keys.toIndexedSeq,
-                IO(value -> labels)
+                IO(NonEmptyList.one(value -> labels))
               )(_.values.toIndexedSeq)
               .surround(
                 get.map(assertEquals(_, Some(value)))
@@ -227,7 +227,7 @@ trait CallbackRegistrySuite[State] extends RegistrySuite[State] { self: CatsEffe
                 commonLabels,
                 labels.keys.toIndexedSeq,
                 buckets,
-                IO(Histogram.Value(sum, bucketValues) -> labels)
+                IO(NonEmptyList.one(Histogram.Value(sum, bucketValues) -> labels))
               )(_.values.toIndexedSeq)
               .surround(
                 get.map(res => assertEquals(res, Some(expected)))
@@ -297,7 +297,7 @@ trait CallbackRegistrySuite[State] extends RegistrySuite[State] { self: CatsEffe
                 help,
                 commonLabels,
                 labels.keys.toIndexedSeq,
-                IO((Summary.Value(count, sum, quantiles.map { case (q, v) => q.value -> v }), labels))
+                IO(NonEmptyList.one(Summary.Value(count, sum, quantiles.map { case (q, v) => q.value -> v }) -> labels))
               )(_.values.toIndexedSeq)
               .surround(get.map { case (q, c, s) =>
                 assertEquals(q, Some(quantiles.map { case (q, v) => q.value.toString -> v }))


### PR DESCRIPTION
It struck me, while porting the event sourcing SDK to Prometheus4Cats, that when recording a labelled callback you're almost always going to want to return multiple values, otherwise you may as well just set the labels you want in `CommonLabels`