### PR TITLE
Fix multi callback

### DIFF
--- a/java/src/main/scala/prometheus4cats/javasimpleclient/JavaMetricRegistry.scala
+++ b/java/src/main/scala/prometheus4cats/javasimpleclient/JavaMetricRegistry.scala
@@ -482,7 +482,7 @@ class JavaMetricRegistry[F[_]: Async: Logger] private (
           case Some(_) =>
             ApplicativeThrow[F].raiseError[Unit](
               new RuntimeException(
-                s"A callback with the same name as '$renderedFullName' is already registered with different labels and/or type"
+                s"A metric with the same name as '$renderedFullName' is already registered with different labels and/or type"
               )
             )
         }

--- a/java/src/main/scala/prometheus4cats/javasimpleclient/JavaMetricRegistry.scala
+++ b/java/src/main/scala/prometheus4cats/javasimpleclient/JavaMetricRegistry.scala
@@ -441,7 +441,7 @@ class JavaMetricRegistry[F[_]: Async: Logger] private (
     name,
     commonLabels,
     IndexedSeq.empty,
-    callback.map(b => NonEmptyList.one(b -> ()))
+    callback.map[NonEmptyList[(B, Unit)]](b => NonEmptyList.one((b, ())))
   )(
     _ => IndexedSeq.empty,
     (name, labelNames, labelValues, b) =>
@@ -619,7 +619,7 @@ class JavaMetricRegistry[F[_]: Async: Logger] private (
       name,
       commonLabels,
       IndexedSeq.empty,
-      callback.map(b => NonEmptyList.one(b -> ()))
+      callback.map[NonEmptyList[(Histogram.Value[Double], Unit)]](b => NonEmptyList.one((b, ())))
     )(_ => IndexedSeq.empty, makeLabelledSamples)
   }
 

--- a/java/src/main/scala/prometheus4cats/javasimpleclient/JavaMetricRegistry.scala
+++ b/java/src/main/scala/prometheus4cats/javasimpleclient/JavaMetricRegistry.scala
@@ -454,7 +454,7 @@ class JavaMetricRegistry[F[_]: Async: Logger] private (
       metricPrefix: Option[Metric.Prefix],
       name: A,
       callback: F[NonEmptyList[Collector.MetricFamilySamples]]
-  ) = {
+  ): Resource[F, Unit] = {
     lazy val n = counterName(name)
 
     lazy val fullName: StateKey = (metricPrefix, n)

--- a/java/src/main/scala/prometheus4cats/javasimpleclient/JavaMetricRegistry.scala
+++ b/java/src/main/scala/prometheus4cats/javasimpleclient/JavaMetricRegistry.scala
@@ -150,14 +150,16 @@ class JavaMetricRegistry[F[_]: Async: Logger] private (
       ref.get
         .flatMap[(State, Collector)] { (metrics: State) =>
           metrics.get(fullName) match {
-            case Some((_, collector)) =>
-              val collectorType = if (collector.isRight) "metric" else "callback"
+            case Some((_, Right(collector))) =>
+//              val collectorType = if (collector.isRight) "metric" else "callback"
 
               ApplicativeThrow[F].raiseError(
                 new RuntimeException(
-                  s"A $collectorType with the same name as '$renderedFullName' is already registered with different labels and/or type"
+                  s"A metric with the same name as '$renderedFullName' is already registered with different labels and/or type"
                 )
               )
+            case Some((_, Left(_))) =>
+              ???
             case None =>
               Sync[F]
                 .delay(registry.register(collector))

--- a/java/src/main/scala/prometheus4cats/javasimpleclient/JavaMetricRegistry.scala
+++ b/java/src/main/scala/prometheus4cats/javasimpleclient/JavaMetricRegistry.scala
@@ -465,7 +465,7 @@ class JavaMetricRegistry[F[_]: Async: Logger] private (
         override def collect(): util.List[MetricFamilySamples] =
           timeoutCallback(
             callbacks.get.flatMap(_.toList.flatTraverse { case (_, cb) => cb.map(_.toList) }.map(_.asJava)),
-            util.List.of[Collector.MetricFamilySamples](),
+            util.Collections.emptyList[Collector.MetricFamilySamples](),
             n
           )
 

--- a/java/src/main/scala/prometheus4cats/javasimpleclient/JavaMetricRegistry.scala
+++ b/java/src/main/scala/prometheus4cats/javasimpleclient/JavaMetricRegistry.scala
@@ -85,7 +85,7 @@ class JavaMetricRegistry[F[_]: Async: Logger] private (
     // possibly throwing and therefore needing to be wrapped in a `Sync.delay`. This would be fine, but the actual
     // state must be pure and the collector is needed for that.
     val acquire = sem.permit.surround(
-      callbackState.get.flatMap{st =>
+      callbackState.get.flatMap { st =>
         st.get(fullName) match {
           case None => Applicative[F].unit
           case Some(_) =>
@@ -511,7 +511,6 @@ class JavaMetricRegistry[F[_]: Async: Logger] private (
           }
     )
 
-
     Resource
       .make(acquire) { token =>
         sem.permit.surround(callbackState.get.flatMap { state =>
@@ -614,7 +613,7 @@ class JavaMetricRegistry[F[_]: Async: Logger] private (
   ): Resource[F, Unit] = {
     val makeLabelledSamples = HistogramUtils.labelledHistogramSamples(help, buckets)
 
-    Resource.eval(callback.flatMap(x => Async[F].delay(println(x)))) >> registerLabelled(
+    registerLabelled(
       MetricType.Histogram,
       prefix,
       name,
@@ -669,7 +668,8 @@ class JavaMetricRegistry[F[_]: Async: Logger] private (
               v.quantiles.values.toList.map(_.asInstanceOf[java.lang.Double]).asJava
             ),
       (n, lns, lvs, v) =>
-        if (v.quantiles.isEmpty) new SummaryMetricFamily(n, help.value, lns.asJava).addMetric(lvs.asJava, v.count, v.sum)
+        if (v.quantiles.isEmpty)
+          new SummaryMetricFamily(n, help.value, lns.asJava).addMetric(lvs.asJava, v.count, v.sum)
         else
           new SummaryMetricFamily(
             n,
@@ -677,7 +677,12 @@ class JavaMetricRegistry[F[_]: Async: Logger] private (
             lns.asJava,
             v.quantiles.keys.toList.map(_.asInstanceOf[java.lang.Double]).asJava
           )
-            .addMetric(lvs.asJava, v.count, v.sum, v.quantiles.values.toList.map(_.asInstanceOf[java.lang.Double]).asJava)
+            .addMetric(
+              lvs.asJava,
+              v.count,
+              v.sum,
+              v.quantiles.values.toList.map(_.asInstanceOf[java.lang.Double]).asJava
+            )
     )
 
   override protected[prometheus4cats] def registerLabelledDoubleSummaryCallback[A](
@@ -691,7 +696,8 @@ class JavaMetricRegistry[F[_]: Async: Logger] private (
     registerLabelled(MetricType.Summary, prefix, name, commonLabels, labelNames, callback)(
       f,
       (n, lns, lvs, v) =>
-        if (v.quantiles.isEmpty) new SummaryMetricFamily(n, help.value, lns.asJava).addMetric(lvs.asJava, v.count, v.sum)
+        if (v.quantiles.isEmpty)
+          new SummaryMetricFamily(n, help.value, lns.asJava).addMetric(lvs.asJava, v.count, v.sum)
         else
           new SummaryMetricFamily(
             n,
@@ -699,7 +705,12 @@ class JavaMetricRegistry[F[_]: Async: Logger] private (
             lns.asJava,
             v.quantiles.keys.toList.map(_.asInstanceOf[java.lang.Double]).asJava
           )
-            .addMetric(lvs.asJava, v.count, v.sum, v.quantiles.values.toList.map(_.asInstanceOf[java.lang.Double]).asJava)
+            .addMetric(
+              lvs.asJava,
+              v.count,
+              v.sum,
+              v.quantiles.values.toList.map(_.asInstanceOf[java.lang.Double]).asJava
+            )
     )
 
   override protected[prometheus4cats] def registerMetricCollectionCallback(

--- a/java/src/main/scala/prometheus4cats/javasimpleclient/JavaMetricRegistry.scala
+++ b/java/src/main/scala/prometheus4cats/javasimpleclient/JavaMetricRegistry.scala
@@ -449,7 +449,7 @@ class JavaMetricRegistry[F[_]: Async: Logger] private (
       else makeLabelledFamily(name, labelNames, labelValues, b)
   )
 
-  private def registerCallback2[A: Show](
+  private def registerCallback[A: Show](
       metricType: MetricType,
       metricPrefix: Option[Metric.Prefix],
       name: A,
@@ -547,11 +547,11 @@ class JavaMetricRegistry[F[_]: Async: Logger] private (
       (labelNames ++ commonLabels.value.keys.toIndexedSeq).map(_.value).toList
     lazy val commonLabelValues: IndexedSeq[String] = commonLabels.value.values.toIndexedSeq
 
-    val x: F[NonEmptyList[MetricFamilySamples]] = callback.map(_.map { case (value, labels) =>
+    val samples: F[NonEmptyList[MetricFamilySamples]] = callback.map(_.map { case (value, labels) =>
       makeLabelledFamily(stringName, commonLabelNames, (f(labels) ++ commonLabelValues).toList, value)
     })
 
-    registerCallback2(metricType, prefix, name, x)
+    registerCallback(metricType, prefix, name, samples)
   }
 
   override protected[prometheus4cats] def registerDoubleCounterCallback(

--- a/java/src/main/scala/prometheus4cats/javasimpleclient/JavaMetricRegistry.scala
+++ b/java/src/main/scala/prometheus4cats/javasimpleclient/JavaMetricRegistry.scala
@@ -799,9 +799,8 @@ object JavaMetricRegistry {
               metrics.values
                 .map(_._2)
                 .toList
-                .traverse_ {
-                  // TODO unregister callbacks
-                  case (collector, _) => Utils.unregister(collector, promRegistry)
+                .traverse_ { case (collector, _) =>
+                  Utils.unregister(collector, promRegistry)
                 }
             else Applicative[F].unit
           }

--- a/java/src/main/scala/prometheus4cats/javasimpleclient/internal/HistogramUtils.scala
+++ b/java/src/main/scala/prometheus4cats/javasimpleclient/internal/HistogramUtils.scala
@@ -43,7 +43,6 @@ object HistogramUtils {
     }
   }
 
-  // TODO unify this with the above
   private[javasimpleclient] def labelledHistogramSamples(
       help: Metric.Help,
       buckets: NonEmptySeq[Double]

--- a/java/src/main/scala/prometheus4cats/javasimpleclient/internal/HistogramUtils.scala
+++ b/java/src/main/scala/prometheus4cats/javasimpleclient/internal/HistogramUtils.scala
@@ -81,7 +81,7 @@ object HistogramUtils {
     }
   }
 
-  //TODO unify this with the above
+  // TODO unify this with the above
   private[javasimpleclient] def labelledHistogramSamples(
       help: Metric.Help,
       buckets: NonEmptySeq[Double]

--- a/java/src/main/scala/prometheus4cats/javasimpleclient/internal/HistogramUtils.scala
+++ b/java/src/main/scala/prometheus4cats/javasimpleclient/internal/HistogramUtils.scala
@@ -16,8 +16,6 @@
 
 package prometheus4cats.javasimpleclient.internal
 
-import java.util
-
 import cats.data.NonEmptySeq
 import io.prometheus.client.Collector
 import io.prometheus.client.Collector.{MetricFamilySamples, Type}
@@ -36,48 +34,12 @@ object HistogramUtils {
       buckets: NonEmptySeq[Double]
   ): Seq[(Histogram.Value[Double], IndexedSeq[String])] => Collector.MetricFamilySamples = {
     lazy val stringName = NameUtils.makeName(prefix, name)
-
     lazy val allLabelNames = labelNames.map(_.value).toList ++ commonLabels.keys.map(_.value).toList
-
-    lazy val labelNamesJava: util.List[String] = allLabelNames.asJava
-    lazy val labelNamesWithLe: util.List[String] = ("le" :: allLabelNames).asJava
-    lazy val commonLabelValues = commonLabels.values.toList
-
-    lazy val bucketsWithInf = buckets.map(Collector.doubleToGoString) :+ "+Inf"
     values => {
-      val metrics = values.flatMap { case (value, labelVs) =>
-        val labelValues = labelVs.toList ++ commonLabelValues
-        val labelValuesJava = labelValues.asJava
-
-        val bucketSamples = bucketsWithInf.zipWith(value.bucketValues) { (bucketString, bucketValue) =>
-          val allLabelValues = bucketString :: labelValues
-
-          new MetricFamilySamples.Sample(
-            s"${stringName}_bucket",
-            labelNamesWithLe,
-            allLabelValues.asJava,
-            bucketValue
-          )
-        }
-
-        bucketSamples.toSeq.toIndexedSeq ++ IndexedSeq(
-          new MetricFamilySamples.Sample(
-            s"${stringName}_count",
-            labelNamesJava,
-            labelValuesJava,
-            value.bucketValues.last
-          ),
-          new MetricFamilySamples.Sample(
-            s"${stringName}_sum",
-            labelNamesJava,
-            labelValuesJava,
-            value.sum
-          )
-        )
-
+      val samples = values.flatMap { case (value, labelValues) =>
+        metricSamples(buckets, stringName, allLabelNames, labelValues.toList, value)
       }
-
-      new MetricFamilySamples(stringName, "", Type.HISTOGRAM, help.value, metrics.asJava)
+      new MetricFamilySamples(stringName, "", Type.HISTOGRAM, help.value, samples.asJava)
     }
   }
 
@@ -87,38 +49,45 @@ object HistogramUtils {
       buckets: NonEmptySeq[Double]
   ): (String, List[String], List[String], Histogram.Value[Double]) => Collector.MetricFamilySamples = {
     case (name, labelNames, labelValues, value) =>
-      val enhancedLabelNames = "le" :: labelNames
+      val samples = metricSamples(buckets, name, labelNames, labelValues, value)
+      new MetricFamilySamples(name, "", Type.HISTOGRAM, help.value, samples.asJava)
+  }
 
-      lazy val bucketsWithInf = buckets.map(Collector.doubleToGoString) :+ "+Inf"
-      val metrics = {
-        val bucketSamples = bucketsWithInf.zipWith(value.bucketValues) { (bucketString, bucketValue) =>
-          val enhancedLabelValues = bucketString :: labelValues
+  private def metricSamples(
+      buckets: NonEmptySeq[Double],
+      name: String,
+      labelNames: List[String],
+      labelValues: List[String],
+      value: Histogram.Value[Double]
+  ): List[MetricFamilySamples.Sample] = {
+    val enhancedLabelNames = "le" :: labelNames
 
-          new MetricFamilySamples.Sample(
-            s"${name}_bucket",
-            enhancedLabelNames.asJava,
-            enhancedLabelValues.asJava,
-            bucketValue
-          )
-        }
+    val bucketsWithInf = buckets.map(Collector.doubleToGoString) :+ "+Inf"
+    val bucketSamples = bucketsWithInf.zipWith(value.bucketValues) { (bucketString, bucketValue) =>
+      val enhancedLabelValues = bucketString :: labelValues
 
-        bucketSamples.toSeq.toIndexedSeq ++ IndexedSeq(
-          new MetricFamilySamples.Sample(
-            s"${name}_count",
-            labelNames.asJava,
-            labelValues.asJava,
-            value.bucketValues.last
-          ),
-          new MetricFamilySamples.Sample(
-            s"${name}_sum",
-            labelNames.asJava,
-            labelValues.asJava,
-            value.sum
-          )
-        )
+      new MetricFamilySamples.Sample(
+        s"${name}_bucket",
+        enhancedLabelNames.asJava,
+        enhancedLabelValues.asJava,
+        bucketValue
+      )
+    }
 
-      }
+    (bucketSamples.toSeq ++ List(
+      new MetricFamilySamples.Sample(
+        s"${name}_count",
+        labelNames.asJava,
+        labelValues.asJava,
+        value.bucketValues.last
+      ),
+      new MetricFamilySamples.Sample(
+        s"${name}_sum",
+        labelNames.asJava,
+        labelValues.asJava,
+        value.sum
+      )
+    )).toList
 
-      new MetricFamilySamples(name, "", Type.HISTOGRAM, help.value, metrics.asJava)
   }
 }

--- a/java/src/main/scala/prometheus4cats/javasimpleclient/package.scala
+++ b/java/src/main/scala/prometheus4cats/javasimpleclient/package.scala
@@ -17,6 +17,8 @@
 package prometheus4cats
 
 import cats.Show
+import cats.data.NonEmptyList
+import cats.effect.kernel.{Ref, Unique}
 import io.prometheus.client.{Collector, SimpleCollector}
 import prometheus4cats.javasimpleclient.models.MetricType
 import prometheus4cats.util.NameUtils
@@ -24,7 +26,7 @@ import prometheus4cats.util.NameUtils
 package object javasimpleclient {
   private[javasimpleclient] type StateKey = (Option[Metric.Prefix], String) // TODO allow specific names maybe
   private[javasimpleclient] type MetricID = (IndexedSeq[Label.Name], MetricType)
-  private[javasimpleclient] type StateValue = (MetricID, Either[Collector, SimpleCollector[_]])
+  private[javasimpleclient] type StateValue = (MetricID, Either[Set[Collector], (SimpleCollector[_], Int)])
 
   private[javasimpleclient] type State = Map[StateKey, StateValue]
 
@@ -32,5 +34,8 @@ package object javasimpleclient {
     case (prefix, name) =>
       NameUtils.makeName(prefix, name)
   }
+
+  type CallbackState[F[_]] =
+    Map[StateKey, (MetricType, Ref[F, Map[Unique.Token, F[NonEmptyList[Collector.MetricFamilySamples]]]], Collector)]
 
 }

--- a/java/src/main/scala/prometheus4cats/javasimpleclient/package.scala
+++ b/java/src/main/scala/prometheus4cats/javasimpleclient/package.scala
@@ -26,7 +26,7 @@ import prometheus4cats.util.NameUtils
 package object javasimpleclient {
   private[javasimpleclient] type StateKey = (Option[Metric.Prefix], String) // TODO allow specific names maybe
   private[javasimpleclient] type MetricID = (IndexedSeq[Label.Name], MetricType)
-  private[javasimpleclient] type StateValue = (MetricID, Either[Set[Collector], (SimpleCollector[_], Int)])
+  private[javasimpleclient] type StateValue = (MetricID, (SimpleCollector[_], Int))
 
   private[javasimpleclient] type State = Map[StateKey, StateValue]
 

--- a/java/src/test/scala/prometheus4cats/javasimpleclient/JavaMetricRegistrySuite.scala
+++ b/java/src/test/scala/prometheus4cats/javasimpleclient/JavaMetricRegistrySuite.scala
@@ -34,6 +34,7 @@ import prometheus4cats.testkit.{CallbackRegistrySuite, MetricRegistrySuite}
 import prometheus4cats.util.NameUtils
 
 import scala.jdk.CollectionConverters._
+import scala.concurrent.duration._
 
 class JavaMetricRegistrySuite
     extends CatsEffectSuite
@@ -48,7 +49,7 @@ class JavaMetricRegistrySuite
     JavaMetricRegistry.fromSimpleClientRegistry[IO](state)
 
   override def callbackRegistryResource(state: CollectorRegistry): Resource[IO, CallbackRegistry[IO]] =
-    JavaMetricRegistry.fromSimpleClientRegistry[IO](state)
+    JavaMetricRegistry.fromSimpleClientRegistry[IO](state, callbackTimeout = 100.millis)
 
   def getMetricValue[A: Show](
       state: CollectorRegistry,

--- a/java/src/test/scala/prometheus4cats/javasimpleclient/JavaMetricRegistrySuite.scala
+++ b/java/src/test/scala/prometheus4cats/javasimpleclient/JavaMetricRegistrySuite.scala
@@ -290,42 +290,6 @@ class JavaMetricRegistrySuite
     }
   }
 
-  test("fails to build a callback when a callback of the same name exists") {
-    forAllF {
-      (
-          prefix: Option[Metric.Prefix],
-          name: Counter.Name,
-          help: Metric.Help,
-          commonLabels: Metric.CommonLabels,
-          labels: Set[Label.Name]
-      ) =>
-        stateResource
-          .flatMap(JavaMetricRegistry.fromSimpleClientRegistry(_))
-          .use { reg =>
-            val callback = reg
-              .registerLabelledDoubleCounterCallback[Map[Label.Name, String]](
-                prefix,
-                name,
-                help,
-                commonLabels,
-                labels.toIndexedSeq,
-                IO(NonEmptyList.one(0.0 -> Map.empty[Label.Name, String]))
-              )(_.values.toIndexedSeq)
-
-            (callback >> callback).use_
-          }
-          .attempt
-          .map { res =>
-            assertEquals(
-              res.leftMap(_.getMessage),
-              Left(
-                s"A callback with the same name as '${NameUtils.makeName(prefix, name)}' is already registered with different labels and/or type"
-              )
-            )
-          }
-    }
-  }
-
   test("fails when a metric with the same name and different labels") {
     forAllF {
       (

--- a/java/src/test/scala/prometheus4cats/javasimpleclient/JavaMetricRegistrySuite.scala
+++ b/java/src/test/scala/prometheus4cats/javasimpleclient/JavaMetricRegistrySuite.scala
@@ -39,6 +39,7 @@ class JavaMetricRegistrySuite
     extends CatsEffectSuite
     with MetricRegistrySuite[CollectorRegistry]
     with CallbackRegistrySuite[CollectorRegistry] {
+
   implicit val logger: Logger[IO] = NoOpLogger.impl
 
   override val stateResource: Resource[IO, CollectorRegistry] = Resource.eval(IO.delay(new CollectorRegistry()))

--- a/testkit/src/main/scala/prometheus4cats/testkit/CallbackRegistrySuite.scala
+++ b/testkit/src/main/scala/prometheus4cats/testkit/CallbackRegistrySuite.scala
@@ -44,7 +44,7 @@ trait CallbackRegistrySuite[State] extends RegistrySuite[State] { self: CatsEffe
       ) =>
         stateResource.use { state =>
           callbackRegistryResource(state).use { reg =>
-            val get = IO.cede >> getCounterValue(
+            val get = getCounterValue(
               state,
               prefix,
               name,
@@ -75,7 +75,7 @@ trait CallbackRegistrySuite[State] extends RegistrySuite[State] { self: CatsEffe
       ) =>
         stateResource.use { state =>
           callbackRegistryResource(state).use { reg =>
-            val get = IO.cede >> getCounterValue(state, prefix, name, help, commonLabels, labels)
+            val get = getCounterValue(state, prefix, name, help, commonLabels, labels)
 
             reg
               .registerLabelledDoubleCounterCallback[Map[Label.Name, String]](
@@ -104,7 +104,7 @@ trait CallbackRegistrySuite[State] extends RegistrySuite[State] { self: CatsEffe
           value: Double
       ) =>
         stateResource.use { state =>
-          val get = IO.cede >> getGaugeValue(
+          val get = getGaugeValue(
             state,
             prefix,
             name,
@@ -135,7 +135,7 @@ trait CallbackRegistrySuite[State] extends RegistrySuite[State] { self: CatsEffe
       ) =>
         stateResource.use { state =>
           callbackRegistryResource(state).use { reg =>
-            val get = IO.cede >> getGaugeValue(state, prefix, name, help, commonLabels, labels)
+            val get = getGaugeValue(state, prefix, name, help, commonLabels, labels)
 
             reg
               .registerLabelledDoubleGaugeCallback[Map[Label.Name, String]](
@@ -176,7 +176,7 @@ trait CallbackRegistrySuite[State] extends RegistrySuite[State] { self: CatsEffe
               if (value > 0) NonEmptySeq.of(0.0, 1.0, 1.0)
               else NonEmptySeq.of(1.0, 1.0, 1.0)
 
-            val get = IO.cede >> getHistogramValue(state, prefix, name, help, commonLabels, buckets)
+            val get = getHistogramValue(state, prefix, name, help, commonLabels, buckets)
 
             reg
               .registerDoubleHistogramCallback(
@@ -219,7 +219,7 @@ trait CallbackRegistrySuite[State] extends RegistrySuite[State] { self: CatsEffe
               if (value > 0) NonEmptySeq.of(0.0, 1.0, 1.0)
               else NonEmptySeq.of(1.0, 1.0, 1.0)
 
-            val get = IO.cede >> getHistogramValue(state, prefix, name, help, commonLabels, buckets, labels)
+            val get = getHistogramValue(state, prefix, name, help, commonLabels, buckets, labels)
 
             reg
               .registerLabelledDoubleHistogramCallback[Map[Label.Name, String]](
@@ -252,7 +252,7 @@ trait CallbackRegistrySuite[State] extends RegistrySuite[State] { self: CatsEffe
       ) =>
         stateResource.use { state =>
           callbackRegistryResource(state).use { reg =>
-            val get = IO.cede >> getSummaryValue(state, prefix, name, help, commonLabels, Map.empty)
+            val get = getSummaryValue(state, prefix, name, help, commonLabels, Map.empty)
 
             reg
               .registerDoubleSummaryCallback(
@@ -290,7 +290,7 @@ trait CallbackRegistrySuite[State] extends RegistrySuite[State] { self: CatsEffe
       ) =>
         stateResource.use { state =>
           callbackRegistryResource(state).use { reg =>
-            val get = IO.cede >> getSummaryValue(state, prefix, name, help, commonLabels, labels)
+            val get = getSummaryValue(state, prefix, name, help, commonLabels, labels)
 
             reg
               .registerLabelledDoubleSummaryCallback[Map[Label.Name, String]](
@@ -475,7 +475,7 @@ trait CallbackRegistrySuite[State] extends RegistrySuite[State] { self: CatsEffe
               )(_.values.toIndexedSeq)
 
             callback.use { _ =>
-              def get(label: String) = IO.cede >> getCounterValue(
+              def get(label: String) = getCounterValue(
                 state,
                 prefix,
                 name,
@@ -523,7 +523,7 @@ trait CallbackRegistrySuite[State] extends RegistrySuite[State] { self: CatsEffe
               )(_.values.toIndexedSeq)
 
             (callback1 >> callback2).use { _ =>
-              def get(label: String) = IO.cede >> getCounterValue(
+              def get(label: String) = getCounterValue(
                 state,
                 prefix,
                 name,

--- a/testkit/src/main/scala/prometheus4cats/testkit/CallbackRegistrySuite.scala
+++ b/testkit/src/main/scala/prometheus4cats/testkit/CallbackRegistrySuite.scala
@@ -43,7 +43,7 @@ trait CallbackRegistrySuite[State] extends RegistrySuite[State] { self: CatsEffe
       ) =>
         stateResource.use { state =>
           callbackRegistryResource(state).use { reg =>
-            val get = getCounterValue(
+            val get = IO.cede >> getCounterValue(
               state,
               prefix,
               name,
@@ -74,7 +74,7 @@ trait CallbackRegistrySuite[State] extends RegistrySuite[State] { self: CatsEffe
       ) =>
         stateResource.use { state =>
           callbackRegistryResource(state).use { reg =>
-            val get = getCounterValue(state, prefix, name, help, commonLabels, labels)
+            val get = IO.cede >> getCounterValue(state, prefix, name, help, commonLabels, labels)
 
             reg
               .registerLabelledDoubleCounterCallback[Map[Label.Name, String]](
@@ -103,7 +103,7 @@ trait CallbackRegistrySuite[State] extends RegistrySuite[State] { self: CatsEffe
           value: Double
       ) =>
         stateResource.use { state =>
-          val get = getGaugeValue(
+          val get = IO.cede >> getGaugeValue(
             state,
             prefix,
             name,
@@ -134,7 +134,7 @@ trait CallbackRegistrySuite[State] extends RegistrySuite[State] { self: CatsEffe
       ) =>
         stateResource.use { state =>
           callbackRegistryResource(state).use { reg =>
-            val get = getGaugeValue(state, prefix, name, help, commonLabels, labels)
+            val get = IO.cede >> getGaugeValue(state, prefix, name, help, commonLabels, labels)
 
             reg
               .registerLabelledDoubleGaugeCallback[Map[Label.Name, String]](
@@ -175,7 +175,7 @@ trait CallbackRegistrySuite[State] extends RegistrySuite[State] { self: CatsEffe
               if (value > 0) NonEmptySeq.of(0.0, 1.0, 1.0)
               else NonEmptySeq.of(1.0, 1.0, 1.0)
 
-            val get = getHistogramValue(state, prefix, name, help, commonLabels, buckets)
+            val get = IO.cede >> getHistogramValue(state, prefix, name, help, commonLabels, buckets)
 
             reg
               .registerDoubleHistogramCallback(
@@ -218,7 +218,7 @@ trait CallbackRegistrySuite[State] extends RegistrySuite[State] { self: CatsEffe
               if (value > 0) NonEmptySeq.of(0.0, 1.0, 1.0)
               else NonEmptySeq.of(1.0, 1.0, 1.0)
 
-            val get = getHistogramValue(state, prefix, name, help, commonLabels, buckets, labels)
+            val get = IO.cede >> getHistogramValue(state, prefix, name, help, commonLabels, buckets, labels)
 
             reg
               .registerLabelledDoubleHistogramCallback[Map[Label.Name, String]](
@@ -251,7 +251,7 @@ trait CallbackRegistrySuite[State] extends RegistrySuite[State] { self: CatsEffe
       ) =>
         stateResource.use { state =>
           callbackRegistryResource(state).use { reg =>
-            val get = getSummaryValue(state, prefix, name, help, commonLabels, Map.empty)
+            val get = IO.cede >> getSummaryValue(state, prefix, name, help, commonLabels, Map.empty)
 
             reg
               .registerDoubleSummaryCallback(
@@ -289,7 +289,7 @@ trait CallbackRegistrySuite[State] extends RegistrySuite[State] { self: CatsEffe
       ) =>
         stateResource.use { state =>
           callbackRegistryResource(state).use { reg =>
-            val get = getSummaryValue(state, prefix, name, help, commonLabels, labels)
+            val get = IO.cede >> getSummaryValue(state, prefix, name, help, commonLabels, labels)
 
             reg
               .registerLabelledDoubleSummaryCallback[Map[Label.Name, String]](

--- a/testkit/src/main/scala/prometheus4cats/testkit/CallbackRegistrySuite.scala
+++ b/testkit/src/main/scala/prometheus4cats/testkit/CallbackRegistrySuite.scala
@@ -25,6 +25,7 @@ import org.scalacheck.{Arbitrary, Gen}
 import prometheus4cats._
 
 trait CallbackRegistrySuite[State] extends RegistrySuite[State] { self: CatsEffectSuite =>
+
   implicit val quantileValuesArb: Arbitrary[Map[Summary.Quantile, Double]] = Arbitrary(
     Gen.mapOf[Summary.Quantile, Double](Arbitrary.arbitrary[(Summary.Quantile, Double)])
   )

--- a/testkit/src/main/scala/prometheus4cats/testkit/MetricRegistrySuite.scala
+++ b/testkit/src/main/scala/prometheus4cats/testkit/MetricRegistrySuite.scala
@@ -529,7 +529,7 @@ trait MetricRegistrySuite[State] extends RegistrySuite[State] { self: CatsEffect
               )
 
             create.use { s =>
-              s.observe(value) >> create.use_ >> get.map(_._2.isDefined) assert
+              s.observe(value) >> create.use_ >> get.map(_._2.isDefined).assert
             } >> get.assertEquals((None, None, None))
           }
         }


### PR DESCRIPTION
Allow registering multiple callbacks with the same name/labels. Also implement reference counting to solve lifecycle issues when multiple scopes open the same metric resource.

Addresses https://github.com/permutive-engineering/prometheus4cats/issues/38.