### PR TITLE
Remove `name` as an illegal label name

### DIFF
--- a/core/src/main/scala/prometheus4cats/Label.scala
+++ b/core/src/main/scala/prometheus4cats/Label.scala
@@ -34,7 +34,7 @@ object Label {
     // prevents macro compilation problems with the status label
     private[prometheus4cats] val outcomeStatus = new Name("outcome_status")
 
-    private val invalidNames: Set[String] = Set("quantile", "le", "name")
+    private val invalidNames: Set[String] = Set("quantile", "le")
 
     protected val regex: Pattern = "^[a-zA-Z_:][a-zA-Z0-9_:]*$".r.pattern
 


### PR DESCRIPTION
Prometheus does not have this restriction, so safe to remove.