### PR TITLE
Merge "labelled" & "not-labelled" metric classes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -73,6 +73,7 @@ lazy val core = project
       }
       .toList
       .flatten,
+    scalacOptions += "-Wconf:cat=unused-nowarn:s",
     scalacOptions := {
       // Scala 3 macros won't compile with the default Typelevel settings
       if (tlIsScala3.value) Seq("-Ykind-projector") else scalacOptions.value

--- a/core/src/main/scala/prometheus4cats/CallbackRegistry.scala
+++ b/core/src/main/scala/prometheus4cats/CallbackRegistry.scala
@@ -25,52 +25,6 @@ import cats.~>
   */
 trait CallbackRegistry[F[_]] {
 
-  /** Register a counter value that records [[scala.Double]] values against a callback registry
-    *
-    * @param prefix
-    *   optional [[Metric.Prefix]] to be prepended to the metric name
-    * @param name
-    *   [[Counter.Name]] metric name
-    * @param help
-    *   [[Metric.Help]] string to describe the metric
-    * @param commonLabels
-    *   [[Metric.CommonLabels]] map of common labels to be added to the metric
-    * @param callback
-    *   Some effectful operation that returns a [[scala.Double]]
-    * @return
-    *   An empty side effect to indicate that the callback has been registered
-    */
-  def registerDoubleCounterCallback(
-      prefix: Option[Metric.Prefix],
-      name: Counter.Name,
-      help: Metric.Help,
-      commonLabels: Metric.CommonLabels,
-      callback: F[Double]
-  ): Resource[F, Unit]
-
-  /** Register a counter value that records [[scala.Long]] values against a callback registry
-    *
-    * @param prefix
-    *   optional [[Metric.Prefix]] to be prepended to the metric name
-    * @param name
-    *   [[Counter.Name]] metric name
-    * @param help
-    *   [[Metric.Help]] string to describe the metric
-    * @param commonLabels
-    *   [[Metric.CommonLabels]] map of common labels to be added to the metric
-    * @param callback
-    *   Some effectful operation that returns a [[scala.Long]]
-    * @return
-    *   An empty side effect to indicate that the callback has been registered
-    */
-  def registerLongCounterCallback(
-      prefix: Option[Metric.Prefix],
-      name: Counter.Name,
-      help: Metric.Help,
-      commonLabels: Metric.CommonLabels,
-      callback: F[Long]
-  ): Resource[F, Unit]
-
   /** Register a labelled counter value that records [[scala.Double]] values against a metrics registry
     *
     * @param prefix
@@ -91,7 +45,7 @@ trait CallbackRegistry[F[_]] {
     * @return
     *   An empty side effect to indicate that the callback has been registered
     */
-  def registerLabelledDoubleCounterCallback[A](
+  def registerDoubleCounterCallback[A](
       prefix: Option[Metric.Prefix],
       name: Counter.Name,
       help: Metric.Help,
@@ -120,7 +74,7 @@ trait CallbackRegistry[F[_]] {
     * @return
     *   An empty side effect to indicate that the callback has been registered
     */
-  def registerLabelledLongCounterCallback[A](
+  def registerLongCounterCallback[A](
       prefix: Option[Metric.Prefix],
       name: Counter.Name,
       help: Metric.Help,
@@ -128,52 +82,6 @@ trait CallbackRegistry[F[_]] {
       labelNames: IndexedSeq[Label.Name],
       callback: F[NonEmptyList[(Long, A)]]
   )(f: A => IndexedSeq[String]): Resource[F, Unit]
-
-  /** Register a gauge value that records [[scala.Double]] values against a callback registry
-    *
-    * @param prefix
-    *   optional [[Metric.Prefix]] to be prepended to the metric name
-    * @param name
-    *   [[Counter.Name]] metric name
-    * @param help
-    *   [[Metric.Help]] string to describe the metric
-    * @param commonLabels
-    *   [[Metric.CommonLabels]] map of common labels to be added to the metric
-    * @param callback
-    *   Some effectful operation that returns a [[scala.Double]]
-    * @return
-    *   An empty side effect to indicate that the callback has been registered
-    */
-  def registerDoubleGaugeCallback(
-      prefix: Option[Metric.Prefix],
-      name: Gauge.Name,
-      help: Metric.Help,
-      commonLabels: Metric.CommonLabels,
-      callback: F[Double]
-  ): Resource[F, Unit]
-
-  /** Register a gauge value that records [[scala.Long]] values against a callback registry
-    *
-    * @param prefix
-    *   optional [[Metric.Prefix]] to be prepended to the metric name
-    * @param name
-    *   [[Counter.Name]] metric name
-    * @param help
-    *   [[Metric.Help]] string to describe the metric
-    * @param commonLabels
-    *   [[Metric.CommonLabels]] map of common labels to be added to the metric
-    * @param callback
-    *   Some effectful operation that returns a [[scala.Long]]
-    * @return
-    *   An empty side effect to indicate that the callback has been registered
-    */
-  def registerLongGaugeCallback(
-      prefix: Option[Metric.Prefix],
-      name: Gauge.Name,
-      help: Metric.Help,
-      commonLabels: Metric.CommonLabels,
-      callback: F[Long]
-  ): Resource[F, Unit]
 
   /** Register a labelled gauge value that records [[scala.Double]] values against a metrics registry
     *
@@ -195,7 +103,7 @@ trait CallbackRegistry[F[_]] {
     * @return
     *   An empty side effect to indicate that the callback has been registered
     */
-  def registerLabelledDoubleGaugeCallback[A](
+  def registerDoubleGaugeCallback[A](
       prefix: Option[Metric.Prefix],
       name: Gauge.Name,
       help: Metric.Help,
@@ -224,7 +132,7 @@ trait CallbackRegistry[F[_]] {
     * @return
     *   An empty side effect to indicate that the callback has been registered
     */
-  def registerLabelledLongGaugeCallback[A](
+  def registerLongGaugeCallback[A](
       prefix: Option[Metric.Prefix],
       name: Gauge.Name,
       help: Metric.Help,
@@ -232,54 +140,6 @@ trait CallbackRegistry[F[_]] {
       labelNames: IndexedSeq[Label.Name],
       callback: F[NonEmptyList[(Long, A)]]
   )(f: A => IndexedSeq[String]): Resource[F, Unit]
-
-  /** Register a histogram value that records [[scala.Double]] values against a callback registry
-    *
-    * @param prefix
-    *   optional [[Metric.Prefix]] to be prepended to the metric name
-    * @param name
-    *   [[Counter.Name]] metric name
-    * @param help
-    *   [[Metric.Help]] string to describe the metric
-    * @param commonLabels
-    *   [[Metric.CommonLabels]] map of common labels to be added to the metric
-    * @param callback
-    *   Some effectful operation that returns a [[Histogram.Value]] parameterised with [[scala.Double]]
-    * @return
-    *   An empty side effect to indicate that the callback has been registered
-    */
-  def registerDoubleHistogramCallback(
-      prefix: Option[Metric.Prefix],
-      name: Histogram.Name,
-      help: Metric.Help,
-      commonLabels: Metric.CommonLabels,
-      buckets: NonEmptySeq[Double],
-      callback: F[Histogram.Value[Double]]
-  ): Resource[F, Unit]
-
-  /** Register a histogram value that records [[scala.Long]] values against a callback registry
-    *
-    * @param prefix
-    *   optional [[Metric.Prefix]] to be prepended to the metric name
-    * @param name
-    *   [[Counter.Name]] metric name
-    * @param help
-    *   [[Metric.Help]] string to describe the metric
-    * @param commonLabels
-    *   [[Metric.CommonLabels]] map of common labels to be added to the metric
-    * @param callback
-    *   Some effectful operation that returns a [[Histogram.Value]] parameterised with [[scala.Long]]
-    * @return
-    *   An empty side effect to indicate that the callback has been registered
-    */
-  def registerLongHistogramCallback(
-      prefix: Option[Metric.Prefix],
-      name: Histogram.Name,
-      help: Metric.Help,
-      commonLabels: Metric.CommonLabels,
-      buckets: NonEmptySeq[Long],
-      callback: F[Histogram.Value[Long]]
-  ): Resource[F, Unit]
 
   /** Register a labelled histogram value that records [[scala.Double]] values against a metrics registry
     *
@@ -302,7 +162,7 @@ trait CallbackRegistry[F[_]] {
     * @return
     *   An empty side effect to indicate that the callback has been registered
     */
-  def registerLabelledDoubleHistogramCallback[A](
+  def registerDoubleHistogramCallback[A](
       prefix: Option[Metric.Prefix],
       name: Histogram.Name,
       help: Metric.Help,
@@ -333,7 +193,7 @@ trait CallbackRegistry[F[_]] {
     * @return
     *   An empty side effect to indicate that the callback has been registered
     */
-  def registerLabelledLongHistogramCallback[A](
+  def registerLongHistogramCallback[A](
       prefix: Option[Metric.Prefix],
       name: Histogram.Name,
       help: Metric.Help,
@@ -342,52 +202,6 @@ trait CallbackRegistry[F[_]] {
       buckets: NonEmptySeq[Long],
       callback: F[NonEmptyList[(Histogram.Value[Long], A)]]
   )(f: A => IndexedSeq[String]): Resource[F, Unit]
-
-  /** Register a summary value that records [[scala.Double]] values against a metrics registry
-    *
-    * @param prefix
-    *   optional [[Metric.Prefix]] to be prepended to the metric name
-    * @param name
-    *   [[Summary.Name]] metric name
-    * @param help
-    *   [[Metric.Help]] string to describe the metric
-    * @param commonLabels
-    *   [[Metric.CommonLabels]] map of common labels to be added to the metric
-    * @param callback
-    *   Some effectful operation that returns a [[Summary.Value]] parameterised with [[scala.Double]]
-    * @return
-    *   An empty side effect to indicate that the callback has been registered
-    */
-  def registerDoubleSummaryCallback(
-      prefix: Option[Metric.Prefix],
-      name: Summary.Name,
-      help: Metric.Help,
-      commonLabels: Metric.CommonLabels,
-      callback: F[Summary.Value[Double]]
-  ): Resource[F, Unit]
-
-  /** Register a summary value that records [[scala.Long]] values against a metrics registry
-    *
-    * @param prefix
-    *   optional [[Metric.Prefix]] to be prepended to the metric name
-    * @param name
-    *   [[Summary.Name]] metric name
-    * @param help
-    *   [[Metric.Help]] string to describe the metric
-    * @param commonLabels
-    *   [[Metric.CommonLabels]] map of common labels to be added to the metric
-    * @param callback
-    *   Some effectful operation that returns a [[Summary.Value]] parameterised with [[scala.Long]]
-    * @return
-    *   An empty side effect to indicate that the callback has been registered
-    */
-  def registerLongSummaryCallback(
-      prefix: Option[Metric.Prefix],
-      name: Summary.Name,
-      help: Metric.Help,
-      commonLabels: Metric.CommonLabels,
-      callback: F[Summary.Value[Long]]
-  ): Resource[F, Unit]
 
   /** Register a labelled summary value that records [[scala.Double]] values against a metrics registry
     *
@@ -410,7 +224,7 @@ trait CallbackRegistry[F[_]] {
     * @return
     *   a [[Summary]] wrapped in whatever side effect that was performed in registering it
     */
-  def registerLabelledDoubleSummaryCallback[A](
+  def registerDoubleSummaryCallback[A](
       prefix: Option[Metric.Prefix],
       name: Summary.Name,
       help: Metric.Help,
@@ -440,7 +254,7 @@ trait CallbackRegistry[F[_]] {
     * @return
     *   a [[Summary]] wrapped in whatever side effect that was performed in registering it
     */
-  def registerLabelledLongSummaryCallback[A](
+  def registerLongSummaryCallback[A](
       prefix: Option[Metric.Prefix],
       name: Summary.Name,
       help: Metric.Help,
@@ -466,23 +280,8 @@ trait CallbackRegistry[F[_]] {
 
 object CallbackRegistry {
   def noop[F[_]]: CallbackRegistry[F] = new CallbackRegistry[F] {
-    override def registerDoubleCounterCallback(
-        prefix: Option[Metric.Prefix],
-        name: Counter.Name,
-        help: Metric.Help,
-        commonLabels: Metric.CommonLabels,
-        callback: F[Double]
-    ): Resource[F, Unit] = Resource.unit
 
-    override def registerLongCounterCallback(
-        prefix: Option[Metric.Prefix],
-        name: Counter.Name,
-        help: Metric.Help,
-        commonLabels: Metric.CommonLabels,
-        callback: F[Long]
-    ): Resource[F, Unit] = Resource.unit
-
-    override def registerLabelledDoubleCounterCallback[A](
+    override def registerDoubleCounterCallback[A](
         prefix: Option[Metric.Prefix],
         name: Counter.Name,
         help: Metric.Help,
@@ -491,7 +290,7 @@ object CallbackRegistry {
         callback: F[NonEmptyList[(Double, A)]]
     )(f: A => IndexedSeq[String]): Resource[F, Unit] = Resource.unit
 
-    override def registerLabelledLongCounterCallback[A](
+    override def registerLongCounterCallback[A](
         prefix: Option[Metric.Prefix],
         name: Counter.Name,
         help: Metric.Help,
@@ -500,23 +299,7 @@ object CallbackRegistry {
         callback: F[NonEmptyList[(Long, A)]]
     )(f: A => IndexedSeq[String]): Resource[F, Unit] = Resource.unit
 
-    override def registerDoubleGaugeCallback(
-        prefix: Option[Metric.Prefix],
-        name: Gauge.Name,
-        help: Metric.Help,
-        commonLabels: Metric.CommonLabels,
-        callback: F[Double]
-    ): Resource[F, Unit] = Resource.unit
-
-    override def registerLongGaugeCallback(
-        prefix: Option[Metric.Prefix],
-        name: Gauge.Name,
-        help: Metric.Help,
-        commonLabels: Metric.CommonLabels,
-        callback: F[Long]
-    ): Resource[F, Unit] = Resource.unit
-
-    override def registerLabelledDoubleGaugeCallback[A](
+    override def registerDoubleGaugeCallback[A](
         prefix: Option[Metric.Prefix],
         name: Gauge.Name,
         help: Metric.Help,
@@ -525,7 +308,7 @@ object CallbackRegistry {
         callback: F[NonEmptyList[(Double, A)]]
     )(f: A => IndexedSeq[String]): Resource[F, Unit] = Resource.unit
 
-    override def registerLabelledLongGaugeCallback[A](
+    override def registerLongGaugeCallback[A](
         prefix: Option[Metric.Prefix],
         name: Gauge.Name,
         help: Metric.Help,
@@ -534,25 +317,7 @@ object CallbackRegistry {
         callback: F[NonEmptyList[(Long, A)]]
     )(f: A => IndexedSeq[String]): Resource[F, Unit] = Resource.unit
 
-    override def registerDoubleHistogramCallback(
-        prefix: Option[Metric.Prefix],
-        name: Histogram.Name,
-        help: Metric.Help,
-        commonLabels: Metric.CommonLabels,
-        buckets: NonEmptySeq[Double],
-        callback: F[Histogram.Value[Double]]
-    ): Resource[F, Unit] = Resource.unit
-
-    override def registerLongHistogramCallback(
-        prefix: Option[Metric.Prefix],
-        name: Histogram.Name,
-        help: Metric.Help,
-        commonLabels: Metric.CommonLabels,
-        buckets: NonEmptySeq[Long],
-        callback: F[Histogram.Value[Long]]
-    ): Resource[F, Unit] = Resource.unit
-
-    override def registerLabelledDoubleHistogramCallback[A](
+    override def registerDoubleHistogramCallback[A](
         prefix: Option[Metric.Prefix],
         name: Histogram.Name,
         help: Metric.Help,
@@ -562,7 +327,7 @@ object CallbackRegistry {
         callback: F[NonEmptyList[(Histogram.Value[Double], A)]]
     )(f: A => IndexedSeq[String]): Resource[F, Unit] = Resource.unit
 
-    override def registerLabelledLongHistogramCallback[A](
+    override def registerLongHistogramCallback[A](
         prefix: Option[Metric.Prefix],
         name: Histogram.Name,
         help: Metric.Help,
@@ -572,23 +337,7 @@ object CallbackRegistry {
         callback: F[NonEmptyList[(Histogram.Value[Long], A)]]
     )(f: A => IndexedSeq[String]): Resource[F, Unit] = Resource.unit
 
-    override def registerDoubleSummaryCallback(
-        prefix: Option[Metric.Prefix],
-        name: Summary.Name,
-        help: Metric.Help,
-        commonLabels: Metric.CommonLabels,
-        callback: F[Summary.Value[Double]]
-    ): Resource[F, Unit] = Resource.unit
-
-    override def registerLongSummaryCallback(
-        prefix: Option[Metric.Prefix],
-        name: Summary.Name,
-        help: Metric.Help,
-        commonLabels: Metric.CommonLabels,
-        callback: F[Summary.Value[Long]]
-    ): Resource[F, Unit] = Resource.unit
-
-    override def registerLabelledDoubleSummaryCallback[A](
+    override def registerDoubleSummaryCallback[A](
         prefix: Option[Metric.Prefix],
         name: Summary.Name,
         help: Metric.Help,
@@ -597,7 +346,7 @@ object CallbackRegistry {
         callback: F[NonEmptyList[(Summary.Value[Double], A)]]
     )(f: A => IndexedSeq[String]): Resource[F, Unit] = Resource.unit
 
-    override def registerLabelledLongSummaryCallback[A](
+    override def registerLongSummaryCallback[A](
         prefix: Option[Metric.Prefix],
         name: Summary.Name,
         help: Metric.Help,
@@ -619,23 +368,8 @@ object CallbackRegistry {
       gk: G ~> F
   )(implicit F: MonadCancel[F, _], G: MonadCancel[G, _]): CallbackRegistry[G] =
     new CallbackRegistry[G] {
-      override def registerDoubleCounterCallback(
-          prefix: Option[Metric.Prefix],
-          name: Counter.Name,
-          help: Metric.Help,
-          commonLabels: Metric.CommonLabels,
-          callback: G[Double]
-      ): Resource[G, Unit] = self.registerDoubleCounterCallback(prefix, name, help, commonLabels, gk(callback)).mapK(fk)
 
-      override def registerLongCounterCallback(
-          prefix: Option[Metric.Prefix],
-          name: Counter.Name,
-          help: Metric.Help,
-          commonLabels: Metric.CommonLabels,
-          callback: G[Long]
-      ): Resource[G, Unit] = self.registerLongCounterCallback(prefix, name, help, commonLabels, gk(callback)).mapK(fk)
-
-      override def registerLabelledDoubleCounterCallback[A](
+      override def registerDoubleCounterCallback[A](
           prefix: Option[Metric.Prefix],
           name: Counter.Name,
           help: Metric.Help,
@@ -643,10 +377,10 @@ object CallbackRegistry {
           labelNames: IndexedSeq[Label.Name],
           callback: G[NonEmptyList[(Double, A)]]
       )(f: A => IndexedSeq[String]): Resource[G, Unit] = self
-        .registerLabelledDoubleCounterCallback(prefix, name, help, commonLabels, labelNames, gk(callback))(f)
+        .registerDoubleCounterCallback(prefix, name, help, commonLabels, labelNames, gk(callback))(f)
         .mapK(fk)
 
-      override def registerLabelledLongCounterCallback[A](
+      override def registerLongCounterCallback[A](
           prefix: Option[Metric.Prefix],
           name: Counter.Name,
           help: Metric.Help,
@@ -654,25 +388,9 @@ object CallbackRegistry {
           labelNames: IndexedSeq[Label.Name],
           callback: G[NonEmptyList[(Long, A)]]
       )(f: A => IndexedSeq[String]): Resource[G, Unit] =
-        self.registerLabelledLongCounterCallback(prefix, name, help, commonLabels, labelNames, gk(callback))(f).mapK(fk)
+        self.registerLongCounterCallback(prefix, name, help, commonLabels, labelNames, gk(callback))(f).mapK(fk)
 
-      override def registerDoubleGaugeCallback(
-          prefix: Option[Metric.Prefix],
-          name: Gauge.Name,
-          help: Metric.Help,
-          commonLabels: Metric.CommonLabels,
-          callback: G[Double]
-      ): Resource[G, Unit] = self.registerDoubleGaugeCallback(prefix, name, help, commonLabels, gk(callback)).mapK(fk)
-
-      override def registerLongGaugeCallback(
-          prefix: Option[Metric.Prefix],
-          name: Gauge.Name,
-          help: Metric.Help,
-          commonLabels: Metric.CommonLabels,
-          callback: G[Long]
-      ): Resource[G, Unit] = self.registerLongGaugeCallback(prefix, name, help, commonLabels, gk(callback)).mapK(fk)
-
-      override def registerLabelledDoubleGaugeCallback[A](
+      override def registerDoubleGaugeCallback[A](
           prefix: Option[Metric.Prefix],
           name: Gauge.Name,
           help: Metric.Help,
@@ -680,9 +398,9 @@ object CallbackRegistry {
           labelNames: IndexedSeq[Label.Name],
           callback: G[NonEmptyList[(Double, A)]]
       )(f: A => IndexedSeq[String]): Resource[G, Unit] =
-        self.registerLabelledDoubleGaugeCallback(prefix, name, help, commonLabels, labelNames, gk(callback))(f).mapK(fk)
+        self.registerDoubleGaugeCallback(prefix, name, help, commonLabels, labelNames, gk(callback))(f).mapK(fk)
 
-      override def registerLabelledLongGaugeCallback[A](
+      override def registerLongGaugeCallback[A](
           prefix: Option[Metric.Prefix],
           name: Gauge.Name,
           help: Metric.Help,
@@ -690,29 +408,9 @@ object CallbackRegistry {
           labelNames: IndexedSeq[Label.Name],
           callback: G[NonEmptyList[(Long, A)]]
       )(f: A => IndexedSeq[String]): Resource[G, Unit] =
-        self.registerLabelledLongGaugeCallback(prefix, name, help, commonLabels, labelNames, gk(callback))(f).mapK(fk)
+        self.registerLongGaugeCallback(prefix, name, help, commonLabels, labelNames, gk(callback))(f).mapK(fk)
 
-      override def registerDoubleHistogramCallback(
-          prefix: Option[Metric.Prefix],
-          name: Histogram.Name,
-          help: Metric.Help,
-          commonLabels: Metric.CommonLabels,
-          buckets: NonEmptySeq[Double],
-          callback: G[Histogram.Value[Double]]
-      ): Resource[G, Unit] =
-        self.registerDoubleHistogramCallback(prefix, name, help, commonLabels, buckets, gk(callback)).mapK(fk)
-
-      override def registerLongHistogramCallback(
-          prefix: Option[Metric.Prefix],
-          name: Histogram.Name,
-          help: Metric.Help,
-          commonLabels: Metric.CommonLabels,
-          buckets: NonEmptySeq[Long],
-          callback: G[Histogram.Value[Long]]
-      ): Resource[G, Unit] =
-        self.registerLongHistogramCallback(prefix, name, help, commonLabels, buckets, gk(callback)).mapK(fk)
-
-      override def registerLabelledDoubleHistogramCallback[A](
+      override def registerDoubleHistogramCallback[A](
           prefix: Option[Metric.Prefix],
           name: Histogram.Name,
           help: Metric.Help,
@@ -722,7 +420,7 @@ object CallbackRegistry {
           callback: G[NonEmptyList[(Histogram.Value[Double], A)]]
       )(f: A => IndexedSeq[String]): Resource[G, Unit] =
         self
-          .registerLabelledDoubleHistogramCallback(
+          .registerDoubleHistogramCallback(
             prefix,
             name,
             help,
@@ -733,7 +431,7 @@ object CallbackRegistry {
           )(f)
           .mapK(fk)
 
-      override def registerLabelledLongHistogramCallback[A](
+      override def registerLongHistogramCallback[A](
           prefix: Option[Metric.Prefix],
           name: Histogram.Name,
           help: Metric.Help,
@@ -743,7 +441,7 @@ object CallbackRegistry {
           callback: G[NonEmptyList[(Histogram.Value[Long], A)]]
       )(f: A => IndexedSeq[String]): Resource[G, Unit] =
         self
-          .registerLabelledLongHistogramCallback(
+          .registerLongHistogramCallback(
             prefix,
             name,
             help,
@@ -754,41 +452,7 @@ object CallbackRegistry {
           )(f)
           .mapK(fk)
 
-      override def registerDoubleSummaryCallback(
-          prefix: Option[Metric.Prefix],
-          name: Summary.Name,
-          help: Metric.Help,
-          commonLabels: Metric.CommonLabels,
-          callback: G[Summary.Value[Double]]
-      ): Resource[G, Unit] =
-        self
-          .registerDoubleSummaryCallback(
-            prefix,
-            name,
-            help,
-            commonLabels,
-            gk(callback)
-          )
-          .mapK(fk)
-
-      override def registerLongSummaryCallback(
-          prefix: Option[Metric.Prefix],
-          name: Summary.Name,
-          help: Metric.Help,
-          commonLabels: Metric.CommonLabels,
-          callback: G[Summary.Value[Long]]
-      ): Resource[G, Unit] =
-        self
-          .registerLongSummaryCallback(
-            prefix,
-            name,
-            help,
-            commonLabels,
-            gk(callback)
-          )
-          .mapK(fk)
-
-      override def registerLabelledDoubleSummaryCallback[A](
+      override def registerDoubleSummaryCallback[A](
           prefix: Option[Metric.Prefix],
           name: Summary.Name,
           help: Metric.Help,
@@ -797,7 +461,7 @@ object CallbackRegistry {
           callback: G[NonEmptyList[(Summary.Value[Double], A)]]
       )(f: A => IndexedSeq[String]): Resource[G, Unit] =
         self
-          .registerLabelledDoubleSummaryCallback(
+          .registerDoubleSummaryCallback(
             prefix,
             name,
             help,
@@ -807,7 +471,7 @@ object CallbackRegistry {
           )(f)
           .mapK(fk)
 
-      override def registerLabelledLongSummaryCallback[A](
+      override def registerLongSummaryCallback[A](
           prefix: Option[Metric.Prefix],
           name: Summary.Name,
           help: Metric.Help,
@@ -816,7 +480,7 @@ object CallbackRegistry {
           callback: G[NonEmptyList[(Summary.Value[Long], A)]]
       )(f: A => IndexedSeq[String]): Resource[G, Unit] =
         self
-          .registerLabelledLongSummaryCallback(
+          .registerLongSummaryCallback(
             prefix,
             name,
             help,

--- a/core/src/main/scala/prometheus4cats/CallbackRegistry.scala
+++ b/core/src/main/scala/prometheus4cats/CallbackRegistry.scala
@@ -408,7 +408,7 @@ trait CallbackRegistry[F[_]] {
     *   a function from `A` to an [[scala.IndexedSeq]] of [[java.lang.String]] that provides label values, which must be
     *   paired with their corresponding name in the [[scala.IndexedSeq]] of [[Label.Name]]s
     * @return
-    *   a [[Summary.Labelled]] wrapped in whatever side effect that was performed in registering it
+    *   a [[Summary]] wrapped in whatever side effect that was performed in registering it
     */
   def registerLabelledDoubleSummaryCallback[A](
       prefix: Option[Metric.Prefix],
@@ -438,7 +438,7 @@ trait CallbackRegistry[F[_]] {
     *   a function from `A` to an [[scala.IndexedSeq]] of [[java.lang.String]] that provides label values, which must be
     *   paired with their corresponding name in the [[scala.IndexedSeq]] of [[Label.Name]]s
     * @return
-    *   a [[Summary.Labelled]] wrapped in whatever side effect that was performed in registering it
+    *   a [[Summary]] wrapped in whatever side effect that was performed in registering it
     */
   def registerLabelledLongSummaryCallback[A](
       prefix: Option[Metric.Prefix],

--- a/core/src/main/scala/prometheus4cats/Counter.scala
+++ b/core/src/main/scala/prometheus4cats/Counter.scala
@@ -55,15 +55,15 @@ sealed abstract class Counter[F[_], -A, B] extends Metric[A] with Metric.Labelle
 
 object Counter {
 
-  implicit class CounterSyntax[F[_]: FlatMap, -A](counter: Counter[F, A, Unit]) {
+  implicit class CounterSyntax[F[_], -A](counter: Counter[F, A, Unit]) {
     final def inc: F[Unit] = incWithExemplar(None)
 
     final def inc(n: A): F[Unit] = incWithExemplar(n, None)
 
-    final def incWithExemplar(implicit exemplar: Exemplar[F]): F[Unit] =
+    final def incWithExemplar(implicit F: FlatMap[F], exemplar: Exemplar[F]): F[Unit] =
       exemplar.get.flatMap(incWithExemplar)
 
-    final def incWithExemplar(n: A)(implicit exemplar: Exemplar[F]): F[Unit] =
+    final def incWithExemplar(n: A)(implicit F: FlatMap[F], exemplar: Exemplar[F]): F[Unit] =
       exemplar.get.flatMap(incWithExemplar(n, _))
 
     final def incWithExemplar(exemplar: Option[Exemplar.Labels]): F[Unit] = counter.incWithExemplarImpl((), exemplar)
@@ -71,15 +71,15 @@ object Counter {
       counter.incWithExemplarImpl(n, (), exemplar)
   }
 
-  implicit class LabelledCounterSyntax[F[_]: FlatMap, -A, B](counter: Counter[F, A, B])(implicit ev: Unit =:!= B) {
+  implicit class LabelledCounterSyntax[F[_], -A, B](counter: Counter[F, A, B])(implicit ev: Unit =:!= B) {
     final def inc(labels: B): F[Unit] = incWithExemplar(labels, None)
 
     final def inc(n: A, labels: B): F[Unit] = incWithExemplar(n, labels, None)
 
-    final def incWithExemplar(labels: B)(implicit exemplar: Exemplar[F]): F[Unit] =
+    final def incWithExemplar(labels: B)(implicit F: FlatMap[F], exemplar: Exemplar[F]): F[Unit] =
       exemplar.get.flatMap(incWithExemplar(labels, _))
 
-    final def incWithExemplar(n: A, labels: B)(implicit exemplar: Exemplar[F]): F[Unit] =
+    final def incWithExemplar(n: A, labels: B)(implicit F: FlatMap[F], exemplar: Exemplar[F]): F[Unit] =
       exemplar.get.flatMap(incWithExemplar(n, labels, _))
 
     final def incWithExemplar(labels: B, exemplar: Option[Exemplar.Labels]): F[Unit] =

--- a/core/src/main/scala/prometheus4cats/Counter.scala
+++ b/core/src/main/scala/prometheus4cats/Counter.scala
@@ -17,62 +17,77 @@
 package prometheus4cats
 
 import cats.syntax.flatMap._
-import cats.{Applicative, Contravariant, FlatMap, Monad, ~>}
+import cats.{Applicative, Contravariant, FlatMap, ~>}
 
 import java.util.regex.Pattern
 
-sealed abstract class Counter[F[_]: FlatMap, -A, B] extends Metric[A] with Metric.Labelled[B] {
+sealed abstract class Counter[F[_], -A, B] extends Metric[A] with Metric.Labelled[B] {
   self =>
 
-  final def inc(labels: B): F[Unit] = incWithExemplar(labels, None)
-  final def inc(implicit ev: Unit =:= B): F[Unit] = inc(labels = ev(()))
+  protected def incWithExemplarImpl(labels: B, exemplar: Option[Exemplar.Labels]): F[Unit]
 
-  final def inc(n: A, labels: B): F[Unit] = incWithExemplar(n, labels, None)
-  final def inc(n: A)(implicit ev: Unit =:= B): F[Unit] = inc(n = n, labels = ev(()))
-
-  final def incWithExemplar(labels: B)(implicit exemplar: Exemplar[F]): F[Unit] =
-    exemplar.get.flatMap(incWithExemplar(labels, _))
-  final def incWithExemplar(implicit ev: Unit =:= B, exemplar: Exemplar[F]): F[Unit] = incWithExemplar(labels = ev(()))
-
-  final def incWithExemplar(n: A, labels: B)(implicit exemplar: Exemplar[F]): F[Unit] =
-    exemplar.get.flatMap(incWithExemplar(n, labels, _))
-  final def incWithExemplar(n: A)(implicit ev: Unit =:= B, exemplar: Exemplar[F]): F[Unit] =
-    incWithExemplar(n = n, labels = ev(()))
-
-  def incWithExemplar(labels: B, exemplar: Option[Exemplar.Labels]): F[Unit]
-  def incWithExemplar(exemplar: Option[Exemplar.Labels])(implicit ev: Unit =:= B): F[Unit] =
-    incWithExemplar(labels = ev(()), exemplar = exemplar)
-
-  def incWithExemplar(n: A, labels: B, exemplar: Option[Exemplar.Labels]): F[Unit]
-  def incWithExemplar(n: A, exemplar: Option[Exemplar.Labels])(implicit ev: Unit =:= B): F[Unit] =
-    incWithExemplar(n = n, labels = ev(()), exemplar = exemplar)
+  protected def incWithExemplarImpl(n: A, labels: B, exemplar: Option[Exemplar.Labels]): F[Unit]
 
   def contramap[C](f: C => A): Counter[F, C, B] = new Counter[F, C, B] {
-    override def incWithExemplar(labels: B, exemplar: Option[Exemplar.Labels]): F[Unit] =
-      self.incWithExemplar(labels, exemplar)
+    override def incWithExemplarImpl(labels: B, exemplar: Option[Exemplar.Labels]): F[Unit] =
+      self.incWithExemplarImpl(labels, exemplar)
 
-    override def incWithExemplar(n: C, labels: B, exemplar: Option[Exemplar.Labels]): F[Unit] =
-      self.incWithExemplar(f(n), labels, exemplar)
+    override def incWithExemplarImpl(n: C, labels: B, exemplar: Option[Exemplar.Labels]): F[Unit] =
+      self.incWithExemplarImpl(f(n), labels, exemplar)
   }
 
   def contramapLabels[C](f: C => B): Counter[F, A, C] = new Counter[F, A, C] {
-    override def incWithExemplar(labels: C, exemplar: Option[Exemplar.Labels]): F[Unit] =
-      self.incWithExemplar(f(labels), exemplar)
-    override def incWithExemplar(n: A, labels: C, exemplar: Option[Exemplar.Labels]): F[Unit] =
-      self.incWithExemplar(n, f(labels), exemplar)
+    override def incWithExemplarImpl(labels: C, exemplar: Option[Exemplar.Labels]): F[Unit] =
+      self.incWithExemplarImpl(f(labels), exemplar)
+    override def incWithExemplarImpl(n: A, labels: C, exemplar: Option[Exemplar.Labels]): F[Unit] =
+      self.incWithExemplarImpl(n, f(labels), exemplar)
   }
 
-  final def mapK[G[_]: FlatMap](fk: F ~> G): Counter[G, A, B] =
+  final def mapK[G[_]](fk: F ~> G): Counter[G, A, B] =
     new Counter[G, A, B] {
-      override def incWithExemplar(labels: B, exemplar: Option[Exemplar.Labels]): G[Unit] =
-        fk(self.incWithExemplar(labels, exemplar))
+      override def incWithExemplarImpl(labels: B, exemplar: Option[Exemplar.Labels]): G[Unit] =
+        fk(self.incWithExemplarImpl(labels, exemplar))
 
-      override def incWithExemplar(n: A, labels: B, exemplar: Option[Exemplar.Labels]): G[Unit] =
-        fk(self.incWithExemplar(n, labels, exemplar))
+      override def incWithExemplarImpl(n: A, labels: B, exemplar: Option[Exemplar.Labels]): G[Unit] =
+        fk(self.incWithExemplarImpl(n, labels, exemplar))
     }
 }
 
 object Counter {
+
+  implicit class CounterSyntax[F[_]: FlatMap, -A](counter: Counter[F, A, Unit]) {
+    final def inc: F[Unit] = incWithExemplar(None)
+
+    final def inc(n: A): F[Unit] = incWithExemplar(n, None)
+
+    final def incWithExemplar(implicit exemplar: Exemplar[F]): F[Unit] =
+      exemplar.get.flatMap(incWithExemplar)
+
+    final def incWithExemplar(n: A)(implicit exemplar: Exemplar[F]): F[Unit] =
+      exemplar.get.flatMap(incWithExemplar(n, _))
+
+    final def incWithExemplar(exemplar: Option[Exemplar.Labels]): F[Unit] = counter.incWithExemplarImpl((), exemplar)
+    final def incWithExemplar(n: A, exemplar: Option[Exemplar.Labels]): F[Unit] =
+      counter.incWithExemplarImpl(n, (), exemplar)
+  }
+
+  implicit class LabelledCounterSyntax[F[_]: FlatMap, -A, B](counter: Counter[F, A, B])(implicit ev: Unit =:!= B) {
+    final def inc(labels: B): F[Unit] = incWithExemplar(labels, None)
+
+    final def inc(n: A, labels: B): F[Unit] = incWithExemplar(n, labels, None)
+
+    final def incWithExemplar(labels: B)(implicit exemplar: Exemplar[F]): F[Unit] =
+      exemplar.get.flatMap(incWithExemplar(labels, _))
+
+    final def incWithExemplar(n: A, labels: B)(implicit exemplar: Exemplar[F]): F[Unit] =
+      exemplar.get.flatMap(incWithExemplar(n, labels, _))
+
+    final def incWithExemplar(labels: B, exemplar: Option[Exemplar.Labels]): F[Unit] =
+      counter.incWithExemplarImpl(labels, exemplar)
+
+    final def incWithExemplar(n: A, labels: B, exemplar: Option[Exemplar.Labels]): F[Unit] =
+      counter.incWithExemplarImpl(n, labels, exemplar)
+  }
 
   /** Refined value class for a counter name that has been parsed from a string
     */
@@ -95,25 +110,25 @@ object Counter {
       override def contramapLabels[A, B](fa: Counter[F, C, A])(f: B => A): Counter[F, C, B] = fa.contramapLabels(f)
     }
 
-  def make[F[_]: FlatMap, A, B](default: A, _inc: (A, B, Option[Exemplar.Labels]) => F[Unit]): Counter[F, A, B] =
+  def make[F[_], A, B](default: A, _inc: (A, B, Option[Exemplar.Labels]) => F[Unit]): Counter[F, A, B] =
     new Counter[F, A, B] {
-      override def incWithExemplar(labels: B, exemplar: Option[Exemplar.Labels]): F[Unit] =
+      override def incWithExemplarImpl(labels: B, exemplar: Option[Exemplar.Labels]): F[Unit] =
         _inc(default, labels, exemplar)
 
-      override def incWithExemplar(n: A, labels: B, exemplar: Option[Exemplar.Labels]): F[Unit] =
+      override def incWithExemplarImpl(n: A, labels: B, exemplar: Option[Exemplar.Labels]): F[Unit] =
         _inc(n, labels, exemplar)
     }
 
-  def make[F[_]: FlatMap, A, B](_inc: (A, B, Option[Exemplar.Labels]) => F[Unit])(implicit
+  def make[F[_], A, B](_inc: (A, B, Option[Exemplar.Labels]) => F[Unit])(implicit
       A: Numeric[A]
   ): Counter[F, A, B] =
     make(A.one, _inc)
 
-  def noop[F[_]: Monad, A, B]: Counter[F, A, B] = new Counter[F, A, B] {
-    override def incWithExemplar(labels: B, exemplar: Option[Exemplar.Labels]): F[Unit] =
+  def noop[F[_]: Applicative, A, B]: Counter[F, A, B] = new Counter[F, A, B] {
+    override def incWithExemplarImpl(labels: B, exemplar: Option[Exemplar.Labels]): F[Unit] =
       Applicative[F].unit
 
-    override def incWithExemplar(n: A, labels: B, exemplar: Option[Exemplar.Labels]): F[Unit] =
+    override def incWithExemplarImpl(n: A, labels: B, exemplar: Option[Exemplar.Labels]): F[Unit] =
       Applicative[F].unit
   }
 

--- a/core/src/main/scala/prometheus4cats/Counter.scala
+++ b/core/src/main/scala/prometheus4cats/Counter.scala
@@ -21,30 +21,55 @@ import cats.{Applicative, Contravariant, FlatMap, Monad, ~>}
 
 import java.util.regex.Pattern
 
-sealed abstract class Counter[F[_]: FlatMap, -A] extends Metric[A] { self =>
+sealed abstract class Counter[F[_]: FlatMap, -A, B] extends Metric[A] with Metric.Labelled[B] {
+  self =>
 
-  final def inc: F[Unit] = incWithExemplar(None)
-  final def inc(n: A): F[Unit] = incWithExemplar(n, None)
-  final def incWithExemplar(implicit exemplar: Exemplar[F]): F[Unit] = exemplar.get.flatMap(incWithExemplar)
-  final def incWithExemplar(n: A)(implicit exemplar: Exemplar[F]): F[Unit] = exemplar.get.flatMap(incWithExemplar(n, _))
+  final def inc(labels: B): F[Unit] = incWithExemplar(labels, None)
+  final def inc(implicit ev: Unit =:= B): F[Unit] = inc(labels = ev(()))
 
-  def incWithExemplar(n: A, exemplar: Option[Exemplar.Labels]): F[Unit]
-  def incWithExemplar(exemplar: Option[Exemplar.Labels]): F[Unit]
+  final def inc(n: A, labels: B): F[Unit] = incWithExemplar(n, labels, None)
+  final def inc(n: A)(implicit ev: Unit =:= B): F[Unit] = inc(n = n, labels = ev(()))
 
-  def contramap[B](f: B => A): Counter[F, B] = new Counter[F, B] {
-    override def incWithExemplar(n: B, exemplar: Option[Exemplar.Labels]): F[Unit] =
-      self.incWithExemplar(f(n), exemplar)
-    override def incWithExemplar(exemplar: Option[Exemplar.Labels]): F[Unit] = self.incWithExemplar(exemplar)
+  final def incWithExemplar(labels: B)(implicit exemplar: Exemplar[F]): F[Unit] =
+    exemplar.get.flatMap(incWithExemplar(labels, _))
+  final def incWithExemplar(implicit ev: Unit =:= B, exemplar: Exemplar[F]): F[Unit] = incWithExemplar(labels = ev(()))
+
+  final def incWithExemplar(n: A, labels: B)(implicit exemplar: Exemplar[F]): F[Unit] =
+    exemplar.get.flatMap(incWithExemplar(n, labels, _))
+  final def incWithExemplar(n: A)(implicit ev: Unit =:= B, exemplar: Exemplar[F]): F[Unit] =
+    incWithExemplar(n = n, labels = ev(()))
+
+  def incWithExemplar(labels: B, exemplar: Option[Exemplar.Labels]): F[Unit]
+  def incWithExemplar(exemplar: Option[Exemplar.Labels])(implicit ev: Unit =:= B): F[Unit] =
+    incWithExemplar(labels = ev(()), exemplar = exemplar)
+
+  def incWithExemplar(n: A, labels: B, exemplar: Option[Exemplar.Labels]): F[Unit]
+  def incWithExemplar(n: A, exemplar: Option[Exemplar.Labels])(implicit ev: Unit =:= B): F[Unit] =
+    incWithExemplar(n = n, labels = ev(()), exemplar = exemplar)
+
+  def contramap[C](f: C => A): Counter[F, C, B] = new Counter[F, C, B] {
+    override def incWithExemplar(labels: B, exemplar: Option[Exemplar.Labels]): F[Unit] =
+      self.incWithExemplar(labels, exemplar)
+
+    override def incWithExemplar(n: C, labels: B, exemplar: Option[Exemplar.Labels]): F[Unit] =
+      self.incWithExemplar(f(n), labels, exemplar)
   }
 
-  final def mapK[G[_]: FlatMap](fk: F ~> G): Counter[G, A] = new Counter[G, A] {
-    override def incWithExemplar(n: A, exemplar: Option[Exemplar.Labels]): G[Unit] = fk(
-      self.incWithExemplar(n, exemplar)
-    )
-    override def incWithExemplar(exemplar: Option[Exemplar.Labels]): G[Unit] = fk(
-      self.incWithExemplar(exemplar)
-    )
+  def contramapLabels[C](f: C => B): Counter[F, A, C] = new Counter[F, A, C] {
+    override def incWithExemplar(labels: C, exemplar: Option[Exemplar.Labels]): F[Unit] =
+      self.incWithExemplar(f(labels), exemplar)
+    override def incWithExemplar(n: A, labels: C, exemplar: Option[Exemplar.Labels]): F[Unit] =
+      self.incWithExemplar(n, f(labels), exemplar)
   }
+
+  final def mapK[G[_]: FlatMap](fk: F ~> G): Counter[G, A, B] =
+    new Counter[G, A, B] {
+      override def incWithExemplar(labels: B, exemplar: Option[Exemplar.Labels]): G[Unit] =
+        fk(self.incWithExemplar(labels, exemplar))
+
+      override def incWithExemplar(n: A, labels: B, exemplar: Option[Exemplar.Labels]): G[Unit] =
+        fk(self.incWithExemplar(n, labels, exemplar))
+    }
 }
 
 object Counter {
@@ -60,95 +85,36 @@ object Counter {
     override protected def make(a: String): Name = new Name(a)
   }
 
-  implicit def catsInstances[F[_]]: Contravariant[Counter[F, *]] = new Contravariant[Counter[F, *]] {
-    override def contramap[A, B](fa: Counter[F, A])(f: B => A): Counter[F, B] = fa.contramap(f)
-  }
-
-  def make[F[_]: FlatMap, A](default: A, _inc: (A, Option[Exemplar.Labels]) => F[Unit]): Counter[F, A] =
-    new Counter[F, A] {
-      override def incWithExemplar(n: A, exemplar: Option[Exemplar.Labels]): F[Unit] = _inc(n, exemplar)
-
-      override def incWithExemplar(exemplar: Option[Exemplar.Labels]): F[Unit] = _inc(default, exemplar)
+  implicit def catsInstances[F[_], C]: Contravariant[Counter[F, *, C]] =
+    new Contravariant[Counter[F, *, C]] {
+      override def contramap[A, B](fa: Counter[F, A, C])(f: B => A): Counter[F, B, C] = fa.contramap(f)
     }
 
-  def make[F[_]: FlatMap, A](_inc: (A, Option[Exemplar.Labels]) => F[Unit])(implicit A: Numeric[A]): Counter[F, A] =
-    make(A.one, _inc)
+  implicit def labelsContravariant[F[_], C]: LabelsContravariant[Counter[F, C, *]] =
+    new LabelsContravariant[Counter[F, C, *]] {
+      override def contramapLabels[A, B](fa: Counter[F, C, A])(f: B => A): Counter[F, C, B] = fa.contramapLabels(f)
+    }
 
-  def noop[F[_]: Monad, A]: Counter[F, A] = new Counter[F, A] {
-    override def incWithExemplar(n: A, exemplar: Option[Exemplar.Labels]): F[Unit] = Applicative[F].unit
-
-    override def incWithExemplar(exemplar: Option[Exemplar.Labels]): F[Unit] = Applicative[F].unit
-  }
-
-  sealed abstract class Labelled[F[_]: FlatMap, -A, -B] extends Metric[A] with Metric.Labelled[B] {
-    self =>
-    final def inc(labels: B): F[Unit] = incWithExemplar(labels, None)
-    final def inc(n: A, labels: B): F[Unit] = incWithExemplar(n, labels, None)
-    final def incWithExemplar(labels: B)(implicit exemplar: Exemplar[F]): F[Unit] =
-      exemplar.get.flatMap(incWithExemplar(labels, _))
-    final def incWithExemplar(n: A, labels: B)(implicit exemplar: Exemplar[F]): F[Unit] =
-      exemplar.get.flatMap(incWithExemplar(n, labels, _))
-
-    def incWithExemplar(labels: B, exemplar: Option[Exemplar.Labels]): F[Unit]
-    def incWithExemplar(n: A, labels: B, exemplar: Option[Exemplar.Labels]): F[Unit]
-
-    def contramap[C](f: C => A): Labelled[F, C, B] = new Labelled[F, C, B] {
+  def make[F[_]: FlatMap, A, B](default: A, _inc: (A, B, Option[Exemplar.Labels]) => F[Unit]): Counter[F, A, B] =
+    new Counter[F, A, B] {
       override def incWithExemplar(labels: B, exemplar: Option[Exemplar.Labels]): F[Unit] =
-        self.incWithExemplar(labels, exemplar)
-
-      override def incWithExemplar(n: C, labels: B, exemplar: Option[Exemplar.Labels]): F[Unit] =
-        self.incWithExemplar(f(n), labels, exemplar)
-    }
-
-    def contramapLabels[C](f: C => B): Labelled[F, A, C] = new Labelled[F, A, C] {
-      override def incWithExemplar(labels: C, exemplar: Option[Exemplar.Labels]): F[Unit] =
-        self.incWithExemplar(f(labels), exemplar)
-      override def incWithExemplar(n: A, labels: C, exemplar: Option[Exemplar.Labels]): F[Unit] =
-        self.incWithExemplar(n, f(labels), exemplar)
-    }
-
-    final def mapK[G[_]: FlatMap](fk: F ~> G): Counter.Labelled[G, A, B] =
-      new Labelled[G, A, B] {
-        override def incWithExemplar(labels: B, exemplar: Option[Exemplar.Labels]): G[Unit] =
-          fk(self.incWithExemplar(labels, exemplar))
-
-        override def incWithExemplar(n: A, labels: B, exemplar: Option[Exemplar.Labels]): G[Unit] =
-          fk(self.incWithExemplar(n, labels, exemplar))
-      }
-  }
-
-  object Labelled {
-    implicit def catsInstances[F[_], C]: Contravariant[Labelled[F, *, C]] =
-      new Contravariant[Labelled[F, *, C]] {
-        override def contramap[A, B](fa: Labelled[F, A, C])(f: B => A): Labelled[F, B, C] = fa.contramap(f)
-      }
-
-    implicit def labelsContravariant[F[_], C]: LabelsContravariant[Labelled[F, C, *]] =
-      new LabelsContravariant[Labelled[F, C, *]] {
-        override def contramapLabels[A, B](fa: Labelled[F, C, A])(f: B => A): Labelled[F, C, B] = fa.contramapLabels(f)
-      }
-
-    def make[F[_]: FlatMap, A, B](default: A, _inc: (A, B, Option[Exemplar.Labels]) => F[Unit]): Labelled[F, A, B] =
-      new Labelled[F, A, B] {
-        override def incWithExemplar(labels: B, exemplar: Option[Exemplar.Labels]): F[Unit] =
-          _inc(default, labels, exemplar)
-
-        override def incWithExemplar(n: A, labels: B, exemplar: Option[Exemplar.Labels]): F[Unit] =
-          _inc(n, labels, exemplar)
-      }
-
-    def make[F[_]: FlatMap, A, B](_inc: (A, B, Option[Exemplar.Labels]) => F[Unit])(implicit
-        A: Numeric[A]
-    ): Labelled[F, A, B] =
-      make(A.one, _inc)
-
-    def noop[F[_]: Monad, A, B]: Labelled[F, A, B] = new Labelled[F, A, B] {
-      override def incWithExemplar(labels: B, exemplar: Option[Exemplar.Labels]): F[Unit] =
-        Applicative[F].unit
+        _inc(default, labels, exemplar)
 
       override def incWithExemplar(n: A, labels: B, exemplar: Option[Exemplar.Labels]): F[Unit] =
-        Applicative[F].unit
+        _inc(n, labels, exemplar)
     }
+
+  def make[F[_]: FlatMap, A, B](_inc: (A, B, Option[Exemplar.Labels]) => F[Unit])(implicit
+      A: Numeric[A]
+  ): Counter[F, A, B] =
+    make(A.one, _inc)
+
+  def noop[F[_]: Monad, A, B]: Counter[F, A, B] = new Counter[F, A, B] {
+    override def incWithExemplar(labels: B, exemplar: Option[Exemplar.Labels]): F[Unit] =
+      Applicative[F].unit
+
+    override def incWithExemplar(n: A, labels: B, exemplar: Option[Exemplar.Labels]): F[Unit] =
+      Applicative[F].unit
   }
 
 }

--- a/core/src/main/scala/prometheus4cats/CurrentTimeRecorder.scala
+++ b/core/src/main/scala/prometheus4cats/CurrentTimeRecorder.scala
@@ -24,14 +24,20 @@ import scala.concurrent.duration.FiniteDuration
 
 /** A derived metric type that sets an underlying [[Gauge]] to the current system time.
   */
-sealed abstract class CurrentTimeRecorder[F[_]] { self =>
+trait CurrentTimeRecorder[F[_], A] extends Metric.Labelled[A] { self =>
 
   /** Set the underlying [[Gauge]] to the current system time.
     */
-  def mark: F[Unit]
+  def mark(labels: A): F[Unit]
 
-  def mapK[G[_]](fk: F ~> G): CurrentTimeRecorder[G] = new CurrentTimeRecorder[G] {
-    override def mark: G[Unit] = fk(self.mark)
+  def mark(implicit ev: Unit =:= A): F[Unit] = mark(labels = ev(()))
+
+  def contramapLabels[B](f: B => A): CurrentTimeRecorder[F, B] = new CurrentTimeRecorder[F, B] {
+    override def mark(labels: B): F[Unit] = self.mark(f(labels))
+  }
+
+  def mapK[G[_]](fk: F ~> G): CurrentTimeRecorder[G, A] = new CurrentTimeRecorder[G, A] {
+    override def mark(labels: A): G[Unit] = fk(self.mark(labels))
   }
 }
 
@@ -48,11 +54,11 @@ object CurrentTimeRecorder {
     *   a function to go from the current time represented in [[scala.concurrent.duration.FiniteDuration]] as a
     *   [[scala.Long]]
     */
-  def fromLongGauge[F[_]: FlatMap: Clock](
-      gauge: Gauge[F, Long, Unit]
-  )(f: FiniteDuration => Long): CurrentTimeRecorder[F] =
-    new CurrentTimeRecorder[F] {
-      override def mark: F[Unit] = Clock[F].monotonic.flatMap(dur => gauge.set(f(dur), labels = ()))
+  def fromLongGauge[F[_]: FlatMap: Clock, A](
+      gauge: Gauge[F, Long, A]
+  )(f: FiniteDuration => Long): CurrentTimeRecorder[F, A] =
+    new CurrentTimeRecorder[F, A] {
+      override def mark(labels: A): F[Unit] = Clock[F].monotonic.flatMap(dur => gauge.set(f(dur), labels))
     }
 
   /** Create a [[CurrentTimeRecorder]] from a [[Gauge]] that records [[scala.Double]] values
@@ -66,68 +72,16 @@ object CurrentTimeRecorder {
     *   a function to go from the current time represented in [[scala.concurrent.duration.FiniteDuration]] as a
     *   [[scala.Double]]
     */
-  def fromDoubleGauge[F[_]: FlatMap: Clock](
-      gauge: Gauge[F, Double, Unit]
-  )(f: FiniteDuration => Double): CurrentTimeRecorder[F] = new CurrentTimeRecorder[F] {
-    override def mark: F[Unit] = Clock[F].monotonic.flatMap(dur => gauge.set(f(dur), labels = ()))
+  def fromDoubleGauge[F[_]: FlatMap: Clock, A](
+      gauge: Gauge[F, Double, A]
+  )(f: FiniteDuration => Double): CurrentTimeRecorder[F, A] = new CurrentTimeRecorder[F, A] {
+    override def mark(labels: A): F[Unit] = Clock[F].monotonic.flatMap(dur => gauge.set(f(dur), labels))
   }
 
-  /** A derived metric type that sets an underlying [[Gauge]] to the current system time.
-    */
-  trait Labelled[F[_], -A] extends Metric.Labelled[A] { self =>
-
-    /** Set the underlying [[Gauge]] to the current system time.
-      */
-    def mark(labels: A): F[Unit]
-
-    def contramapLabels[B](f: B => A): Labelled[F, B] = new Labelled[F, B] {
-      override def mark(labels: B): F[Unit] = self.mark(f(labels))
+  implicit def labelsContravariant[F[_]]: LabelsContravariant[CurrentTimeRecorder[F, *]] =
+    new LabelsContravariant[CurrentTimeRecorder[F, *]] {
+      override def contramapLabels[A, B](fa: CurrentTimeRecorder[F, A])(f: B => A): CurrentTimeRecorder[F, B] =
+        fa.contramapLabels(f)
     }
 
-    def mapK[G[_]](fk: F ~> G): Labelled[G, A] = new Labelled[G, A] {
-      override def mark(labels: A): G[Unit] = fk(self.mark(labels))
-    }
-  }
-
-  object Labelled {
-    implicit def labelsContravariant[F[_]]: LabelsContravariant[Labelled[F, *]] =
-      new LabelsContravariant[Labelled[F, *]] {
-        override def contramapLabels[A, B](fa: Labelled[F, A])(f: B => A): Labelled[F, B] = fa.contramapLabels(f)
-      }
-
-    /** Create a [[CurrentTimeRecorder]] from a [[Gauge]] that records [[scala.Long]] values
-      *
-      * The best way to construct a [[CurrentTimeRecorder]] is to use the `asCurrentTimeRecorder` on the gauge DSL
-      * provided by [[MetricFactory]]
-      *
-      * @param gauge
-      *   the [[Gauge]] instance to set the current time value against
-      * @param f
-      *   a function to go from the current time represented in [[scala.concurrent.duration.FiniteDuration]] as a
-      *   [[scala.Long]]
-      */
-    def fromLongGauge[F[_]: FlatMap: Clock, A](
-        gauge: Gauge[F, Long, A]
-    )(f: FiniteDuration => Long): CurrentTimeRecorder.Labelled[F, A] =
-      new CurrentTimeRecorder.Labelled[F, A] {
-        override def mark(labels: A): F[Unit] = Clock[F].monotonic.flatMap(dur => gauge.set(f(dur), labels))
-      }
-
-    /** Create a [[CurrentTimeRecorder]] from a [[Gauge]] that records [[scala.Double]] values
-      *
-      * The best way to construct a [[CurrentTimeRecorder]] is to use the `asCurrentTimeRecorder` on the gauge DSL
-      * provided by [[MetricFactory]]
-      *
-      * @param gauge
-      *   the [[Gauge]] instance to set the current time value against
-      * @param f
-      *   a function to go from the current time represented in [[scala.concurrent.duration.FiniteDuration]] as a
-      *   [[scala.Double]]
-      */
-    def fromDoubleGauge[F[_]: FlatMap: Clock, A](
-        gauge: Gauge[F, Double, A]
-    )(f: FiniteDuration => Double): CurrentTimeRecorder.Labelled[F, A] = new CurrentTimeRecorder.Labelled[F, A] {
-      override def mark(labels: A): F[Unit] = Clock[F].monotonic.flatMap(dur => gauge.set(f(dur), labels))
-    }
-  }
 }

--- a/core/src/main/scala/prometheus4cats/Gauge.scala
+++ b/core/src/main/scala/prometheus4cats/Gauge.scala
@@ -16,9 +16,9 @@
 
 package prometheus4cats
 
-import java.util.regex.Pattern
-
 import cats.{Applicative, Contravariant, ~>}
+import prometheus4cats.internal.Refined
+import prometheus4cats.internal.Refined.Regex
 
 abstract class Gauge[F[_], -A, B] extends Metric[A] with Metric.Labelled[B] {
   self =>
@@ -119,14 +119,11 @@ object Gauge {
 
   /** Refined value class for a gauge name that has been parsed from a string
     */
-  final class Name private (val value: String) extends AnyVal with internal.Refined.Value[String] {
-    override def toString: String = s"""Gauge.Name("$value")"""
-  }
+  final class Name private (val value: String) extends AnyVal with Refined.Value[String]
 
-  object Name extends internal.Refined.StringRegexRefinement[Name] with internal.GaugeNameFromStringLiteral {
-    override protected val regex: Pattern = "^[a-zA-Z_:][a-zA-Z0-9_:]*$".r.pattern
-    override protected def make(a: String): Name = new Name(a)
-  }
+  object Name
+      extends Regex[Name]("^[a-zA-Z_:][a-zA-Z0-9_:]*$".r.pattern, new Name(_))
+      with internal.GaugeNameFromStringLiteral
 
   implicit def catsInstances[F[_], C]: Contravariant[Gauge[F, *, C]] =
     new Contravariant[Gauge[F, *, C]] {

--- a/core/src/main/scala/prometheus4cats/Gauge.scala
+++ b/core/src/main/scala/prometheus4cats/Gauge.scala
@@ -23,77 +23,99 @@ import cats.{Applicative, Contravariant, ~>}
 abstract class Gauge[F[_], -A, B] extends Metric[A] with Metric.Labelled[B] {
   self =>
 
-  def inc(labels: B): F[Unit]
-  def inc(implicit ev: Unit =:= B): F[Unit] = inc(labels = ev(()))
+  protected def incImpl(labels: B): F[Unit]
 
-  def inc(n: A, labels: B): F[Unit]
-  def inc(n: A)(implicit ev: Unit =:= B): F[Unit] = inc(n = n, labels = ev(()))
+  protected def incImpl(n: A, labels: B): F[Unit]
 
-  def dec(labels: B): F[Unit]
-  def dec(implicit ev: Unit =:= B): F[Unit] = dec(labels = ev(()))
+  protected def decImpl(labels: B): F[Unit]
 
-  def dec(n: A, labels: B): F[Unit]
-  def dec(n: A)(implicit ev: Unit =:= B): F[Unit] = dec(n = n, labels = ev(()))
+  protected def decImpl(n: A, labels: B): F[Unit]
 
-  def set(n: A, labels: B): F[Unit]
-  def set(n: A)(implicit ev: Unit =:= B): F[Unit] = set(n = n, labels = ev(()))
+  protected def setImpl(n: A, labels: B): F[Unit]
 
-  def reset(labels: B): F[Unit]
-  def reset(implicit ev: Unit =:= B): F[Unit] = reset(labels = ev(()))
+  protected def resetImpl(labels: B): F[Unit]
 
   def contramap[C](f: C => A): Gauge[F, C, B] = new Gauge[F, C, B] {
-    override def inc(labels: B): F[Unit] = self.inc(labels)
+    override def incImpl(labels: B): F[Unit] = self.incImpl(labels)
 
-    override def inc(n: C, labels: B): F[Unit] = self.inc(f(n), labels)
+    override def incImpl(n: C, labels: B): F[Unit] = self.incImpl(f(n), labels)
 
-    override def dec(labels: B): F[Unit] = self.dec(labels)
+    override def decImpl(labels: B): F[Unit] = self.decImpl(labels)
 
-    override def dec(n: C, labels: B): F[Unit] = self.dec(f(n), labels)
+    override def decImpl(n: C, labels: B): F[Unit] = self.decImpl(f(n), labels)
 
-    override def set(n: C, labels: B): F[Unit] = self.set(f(n), labels)
+    override def setImpl(n: C, labels: B): F[Unit] = self.setImpl(f(n), labels)
 
-    override def reset(labels: B): F[Unit] = self.reset(labels)
+    override def resetImpl(labels: B): F[Unit] = self.resetImpl(labels)
   }
 
   def contramapLabels[C](f: C => B): Gauge[F, A, C] = new Gauge[F, A, C] {
-    override def inc(labels: C): F[Unit] = self.inc(f(labels))
+    override def incImpl(labels: C): F[Unit] = self.incImpl(f(labels))
 
-    override def inc(n: A, labels: C): F[Unit] = self.inc(n, f(labels))
+    override def incImpl(n: A, labels: C): F[Unit] = self.incImpl(n, f(labels))
 
-    override def dec(labels: C): F[Unit] = self.dec(f(labels))
+    override def decImpl(labels: C): F[Unit] = self.decImpl(f(labels))
 
-    override def dec(n: A, labels: C): F[Unit] = self.dec(n, f(labels))
+    override def decImpl(n: A, labels: C): F[Unit] = self.decImpl(n, f(labels))
 
-    override def set(n: A, labels: C): F[Unit] = self.set(n, f(labels))
+    override def setImpl(n: A, labels: C): F[Unit] = self.setImpl(n, f(labels))
 
-    override def reset(labels: C): F[Unit] = self.reset(f(labels))
+    override def resetImpl(labels: C): F[Unit] = self.resetImpl(f(labels))
   }
 
   final def mapK[G[_]](fk: F ~> G): Gauge[G, A, B] =
     new Gauge[G, A, B] {
 
-      override def inc(labels: B): G[Unit] = fk(self.inc(labels))
+      override def incImpl(labels: B): G[Unit] = fk(self.incImpl(labels))
 
-      override def inc(n: A, labels: B): G[Unit] = fk(
-        self.inc(n, labels)
+      override def incImpl(n: A, labels: B): G[Unit] = fk(
+        self.incImpl(n, labels)
       )
 
-      override def dec(labels: B): G[Unit] = fk(self.dec(labels))
+      override def decImpl(labels: B): G[Unit] = fk(self.decImpl(labels))
 
-      override def dec(n: A, labels: B): G[Unit] = fk(
-        self.dec(n, labels)
+      override def decImpl(n: A, labels: B): G[Unit] = fk(
+        self.decImpl(n, labels)
       )
 
-      override def set(n: A, labels: B): G[Unit] = fk(
-        self.set(n, labels)
+      override def setImpl(n: A, labels: B): G[Unit] = fk(
+        self.setImpl(n, labels)
       )
 
-      override def reset(labels: B): G[Unit] = fk(self.reset(labels))
+      override def resetImpl(labels: B): G[Unit] = fk(self.resetImpl(labels))
     }
 
 }
 
 object Gauge {
+
+  implicit class GaugeSyntax[F[_], -A](gauge: Gauge[F, A, Unit]) {
+    def inc: F[Unit] = gauge.incImpl(())
+
+    def inc(n: A): F[Unit] = gauge.incImpl(n, ())
+
+    def dec: F[Unit] = gauge.decImpl(())
+
+    def dec(n: A): F[Unit] = gauge.decImpl(n, ())
+
+    def set(n: A): F[Unit] = gauge.setImpl(n, ())
+
+    def reset: F[Unit] = gauge.resetImpl(())
+  }
+
+  implicit class LabelledGaugeSyntax[F[_], -A, B](gauge: Gauge[F, A, B])(implicit ev: Unit =:!= B) {
+    def inc(labels: B): F[Unit] = gauge.incImpl(labels)
+
+    def inc(n: A, labels: B): F[Unit] = gauge.incImpl(n, labels)
+
+    def dec(labels: B): F[Unit] = gauge.decImpl(labels)
+
+    def dec(n: A, labels: B): F[Unit] = gauge.decImpl(n, labels)
+
+    def set(n: A, labels: B): F[Unit] = gauge.setImpl(n, labels)
+
+    def reset(labels: B): F[Unit] = gauge.resetImpl(labels)
+  }
 
   /** Refined value class for a gauge name that has been parsed from a string
     */
@@ -123,38 +145,38 @@ object Gauge {
       _set: (A, B) => F[Unit],
       _reset: B => F[Unit]
   ): Gauge[F, A, B] = new Gauge[F, A, B] {
-    override def inc(labels: B): F[Unit] = inc(default, labels)
+    override def incImpl(labels: B): F[Unit] = incImpl(default, labels)
 
-    override def inc(n: A, labels: B): F[Unit] = _inc(n, labels)
+    override def incImpl(n: A, labels: B): F[Unit] = _inc(n, labels)
 
-    override def dec(labels: B): F[Unit] = dec(default, labels)
+    override def decImpl(labels: B): F[Unit] = decImpl(default, labels)
 
-    override def dec(n: A, labels: B): F[Unit] = _dec(n, labels)
+    override def decImpl(n: A, labels: B): F[Unit] = _dec(n, labels)
 
-    override def set(n: A, labels: B): F[Unit] = _set(n, labels)
+    override def setImpl(n: A, labels: B): F[Unit] = _set(n, labels)
 
-    override def reset(labels: B): F[Unit] = _reset(labels)
+    override def resetImpl(labels: B): F[Unit] = _reset(labels)
   }
 
   def make[F[_], A, B](
-      _inc: (A, B) => F[Unit],
+      _incImpl: (A, B) => F[Unit],
       _dec: (A, B) => F[Unit],
       _set: (A, B) => F[Unit]
   )(implicit A: Numeric[A]): Gauge[F, A, B] =
-    make(A.one, _inc, _dec, _set, _set(A.zero, _))
+    make(A.one, _incImpl, _dec, _set, _set(A.zero, _))
 
   def noop[F[_]: Applicative, A, B]: Gauge[F, A, B] = new Gauge[F, A, B] {
-    override def inc(labels: B): F[Unit] = Applicative[F].unit
+    override def incImpl(labels: B): F[Unit] = Applicative[F].unit
 
-    override def inc(n: A, labels: B): F[Unit] = Applicative[F].unit
+    override def incImpl(n: A, labels: B): F[Unit] = Applicative[F].unit
 
-    override def dec(labels: B): F[Unit] = Applicative[F].unit
+    override def decImpl(labels: B): F[Unit] = Applicative[F].unit
 
-    override def dec(n: A, labels: B): F[Unit] = Applicative[F].unit
+    override def decImpl(n: A, labels: B): F[Unit] = Applicative[F].unit
 
-    override def set(n: A, labels: B): F[Unit] = Applicative[F].unit
+    override def setImpl(n: A, labels: B): F[Unit] = Applicative[F].unit
 
-    override def reset(labels: B): F[Unit] = Applicative[F].unit
+    override def resetImpl(labels: B): F[Unit] = Applicative[F].unit
   }
 
 }

--- a/core/src/main/scala/prometheus4cats/Info.scala
+++ b/core/src/main/scala/prometheus4cats/Info.scala
@@ -16,9 +16,10 @@
 
 package prometheus4cats
 
-import java.util.regex.Pattern
-
 import cats.{Applicative, Contravariant, ~>}
+
+import prometheus4cats.internal.Refined
+import prometheus4cats.internal.Refined.Regex
 
 sealed abstract class Info[F[_], -A] extends Metric[A] { self =>
 
@@ -37,14 +38,11 @@ object Info {
 
   /** Refined value class for a info name that has been parsed from a string
     */
-  final class Name private (val value: String) extends AnyVal with internal.Refined.Value[String] {
-    override def toString: String = s"""Info.Name("$value")"""
-  }
+  final class Name private (val value: String) extends AnyVal with Refined.Value[String]
 
-  object Name extends internal.Refined.StringRegexRefinement[Name] with internal.InfoNameFromStringLiteral {
-    override protected val regex: Pattern = "^[a-zA-Z_:][a-zA-Z0-9_:]*_info$".r.pattern
-    override protected def make(a: String): Name = new Name(a)
-  }
+  object Name
+      extends Regex[Name]("^[a-zA-Z_:][a-zA-Z0-9_:]*_info$".r.pattern, new Name(_))
+      with internal.InfoNameFromStringLiteral
 
   implicit def catsInstances[F[_]]: Contravariant[Info[F, *]] = new Contravariant[Info[F, *]] {
     override def contramap[A, B](fa: Info[F, A])(f: B => A): Info[F, B] = fa.contramap(f)

--- a/core/src/main/scala/prometheus4cats/MetricFactory.scala
+++ b/core/src/main/scala/prometheus4cats/MetricFactory.scala
@@ -60,7 +60,7 @@ sealed abstract class MetricFactory[F[_]](
             override def apply[B](
                 labels: IndexedSeq[Label.Name]
             )(f: B => IndexedSeq[String]): Resource[F, Gauge[F, Long, B]] =
-              metricRegistry.createAndRegisterLabelledLongGauge(prefix, name, help, commonLabels, labels)(f)
+              metricRegistry.createAndRegisterLongGauge(prefix, name, help, commonLabels, labels)(f)
           }
         )
       ),
@@ -70,7 +70,7 @@ sealed abstract class MetricFactory[F[_]](
             override def apply[B](
                 labels: IndexedSeq[Label.Name]
             )(f: B => IndexedSeq[String]): Resource[F, Gauge[F, Double, B]] =
-              metricRegistry.createAndRegisterLabelledDoubleGauge(prefix, name, help, commonLabels, labels)(f)
+              metricRegistry.createAndRegisterDoubleGauge(prefix, name, help, commonLabels, labels)(f)
           }
         )
       )
@@ -96,7 +96,7 @@ sealed abstract class MetricFactory[F[_]](
             override def apply[B](
                 labels: IndexedSeq[Label.Name]
             )(f: B => IndexedSeq[String]): Resource[F, Counter[F, Long, B]] =
-              metricRegistry.createAndRegisterLabelledLongCounter(prefix, name, help, commonLabels, labels)(f)
+              metricRegistry.createAndRegisterLongCounter(prefix, name, help, commonLabels, labels)(f)
           }
         )
       ),
@@ -106,7 +106,7 @@ sealed abstract class MetricFactory[F[_]](
             override def apply[B](
                 labels: IndexedSeq[Label.Name]
             )(f: B => IndexedSeq[String]): Resource[F, Counter[F, Double, B]] =
-              metricRegistry.createAndRegisterLabelledDoubleCounter(prefix, name, help, commonLabels, labels)(f)
+              metricRegistry.createAndRegisterDoubleCounter(prefix, name, help, commonLabels, labels)(f)
           }
         )
       )
@@ -134,7 +134,7 @@ sealed abstract class MetricFactory[F[_]](
                   labels: IndexedSeq[Label.Name]
               )(f: B => IndexedSeq[String]): Resource[F, Histogram[F, Long, B]] =
                 metricRegistry
-                  .createAndRegisterLabelledLongHistogram(prefix, name, help, commonLabels, labels, buckets)(f)
+                  .createAndRegisterLongHistogram(prefix, name, help, commonLabels, labels, buckets)(f)
             }
           )
         )
@@ -146,7 +146,7 @@ sealed abstract class MetricFactory[F[_]](
               override def apply[B](
                   labels: IndexedSeq[Label.Name]
               )(f: B => IndexedSeq[String]): Resource[F, Histogram[F, Double, B]] =
-                metricRegistry.createAndRegisterLabelledDoubleHistogram(
+                metricRegistry.createAndRegisterDoubleHistogram(
                   prefix,
                   name,
                   help,
@@ -171,7 +171,7 @@ sealed abstract class MetricFactory[F[_]](
               override def apply[B](
                   labels: IndexedSeq[Label.Name]
               )(f: B => IndexedSeq[String]): Resource[F, Summary[F, Long, B]] =
-                metricRegistry.createAndRegisterLabelledLongSummary(
+                metricRegistry.createAndRegisterLongSummary(
                   prefix,
                   name,
                   help,
@@ -191,7 +191,7 @@ sealed abstract class MetricFactory[F[_]](
               override def apply[B](
                   labels: IndexedSeq[Label.Name]
               )(f: B => IndexedSeq[String]): Resource[F, Summary[F, Double, B]] =
-                metricRegistry.createAndRegisterLabelledDoubleSummary(
+                metricRegistry.createAndRegisterDoubleSummary(
                   prefix,
                   name,
                   help,
@@ -278,15 +278,13 @@ object MetricFactory {
               override def apply[B](
                   labels: IndexedSeq[Label.Name]
               )(f: B => IndexedSeq[String]): Resource[F, Gauge[F, Long, B]] =
-                metricRegistry.createAndRegisterLabelledLongGauge(prefix, name, help, commonLabels, labels)(f)
+                metricRegistry.createAndRegisterLongGauge(prefix, name, help, commonLabels, labels)(f)
             },
             new LabelledCallbackPartiallyApplied[F, Long] {
               override def apply[B](labels: IndexedSeq[Label.Name], callback: F[NonEmptyList[(Long, B)]])(
                   f: B => IndexedSeq[String]
               ): Resource[F, Unit] =
-                callbackRegistry.registerLabelledLongGaugeCallback(prefix, name, help, commonLabels, labels, callback)(
-                  f
-                )
+                callbackRegistry.registerLongGaugeCallback(prefix, name, help, commonLabels, labels, callback)(f)
             }
           )
         ),
@@ -296,22 +294,20 @@ object MetricFactory {
               override def apply[B](
                   labels: IndexedSeq[Label.Name]
               )(f: B => IndexedSeq[String]): Resource[F, Gauge[F, Double, B]] =
-                metricRegistry.createAndRegisterLabelledDoubleGauge(prefix, name, help, commonLabels, labels)(f)
+                metricRegistry.createAndRegisterDoubleGauge(prefix, name, help, commonLabels, labels)(f)
             },
             new LabelledCallbackPartiallyApplied[F, Double] {
               override def apply[B](labels: IndexedSeq[Label.Name], callback: F[NonEmptyList[(Double, B)]])(
                   f: B => IndexedSeq[String]
               ): Resource[F, Unit] =
-                callbackRegistry.registerLabelledDoubleGaugeCallback(
+                callbackRegistry.registerDoubleGaugeCallback(
                   prefix,
                   name,
                   help,
                   commonLabels,
                   labels,
                   callback
-                )(
-                  f
-                )
+                )(f)
             }
           )
         )
@@ -327,14 +323,14 @@ object MetricFactory {
               override def apply[B](
                   labels: IndexedSeq[Label.Name]
               )(f: B => IndexedSeq[String]): Resource[F, Counter[F, Long, B]] =
-                metricRegistry.createAndRegisterLabelledLongCounter(prefix, name, help, commonLabels, labels)(f)
+                metricRegistry.createAndRegisterLongCounter(prefix, name, help, commonLabels, labels)(f)
             },
             new LabelledCallbackPartiallyApplied[F, Long] {
               override def apply[B](labels: IndexedSeq[Label.Name], callback: F[NonEmptyList[(Long, B)]])(
                   f: B => IndexedSeq[String]
               ): Resource[F, Unit] =
                 callbackRegistry
-                  .registerLabelledLongCounterCallback(prefix, name, help, commonLabels, labels, callback)(
+                  .registerLongCounterCallback(prefix, name, help, commonLabels, labels, callback)(
                     f
                   )
             }
@@ -346,22 +342,20 @@ object MetricFactory {
               override def apply[B](
                   labels: IndexedSeq[Label.Name]
               )(f: B => IndexedSeq[String]): Resource[F, Counter[F, Double, B]] =
-                metricRegistry.createAndRegisterLabelledDoubleCounter(prefix, name, help, commonLabels, labels)(f)
+                metricRegistry.createAndRegisterDoubleCounter(prefix, name, help, commonLabels, labels)(f)
             },
             new LabelledCallbackPartiallyApplied[F, Double] {
               override def apply[B](labels: IndexedSeq[Label.Name], callback: F[NonEmptyList[(Double, B)]])(
                   f: B => IndexedSeq[String]
               ): Resource[F, Unit] =
-                callbackRegistry.registerLabelledDoubleCounterCallback(
+                callbackRegistry.registerDoubleCounterCallback(
                   prefix,
                   name,
                   help,
                   commonLabels,
                   labels,
                   callback
-                )(
-                  f
-                )
+                )(f)
             }
           )
         )
@@ -382,7 +376,7 @@ object MetricFactory {
                     labels: IndexedSeq[Label.Name]
                 )(f: B => IndexedSeq[String]): Resource[F, Histogram[F, Long, B]] =
                   metricRegistry
-                    .createAndRegisterLabelledLongHistogram(prefix, name, help, commonLabels, labels, buckets)(f)
+                    .createAndRegisterLongHistogram(prefix, name, help, commonLabels, labels, buckets)(f)
               },
               new LabelledCallbackPartiallyApplied[F, Histogram.Value[Long]] {
                 override def apply[B](
@@ -392,7 +386,7 @@ object MetricFactory {
                     f: B => IndexedSeq[String]
                 ): Resource[F, Unit] =
                   callbackRegistry
-                    .registerLabelledLongHistogramCallback(
+                    .registerLongHistogramCallback(
                       prefix,
                       name,
                       help,
@@ -418,7 +412,7 @@ object MetricFactory {
                     labels: IndexedSeq[Label.Name]
                 )(f: B => IndexedSeq[String]): Resource[F, Histogram[F, Double, B]] =
                   metricRegistry
-                    .createAndRegisterLabelledDoubleHistogram(prefix, name, help, commonLabels, labels, buckets)(f)
+                    .createAndRegisterDoubleHistogram(prefix, name, help, commonLabels, labels, buckets)(f)
               },
               new LabelledCallbackPartiallyApplied[F, Histogram.Value[Double]] {
                 override def apply[B](
@@ -428,7 +422,7 @@ object MetricFactory {
                     f: B => IndexedSeq[String]
                 ): Resource[F, Unit] =
                   callbackRegistry
-                    .registerLabelledDoubleHistogramCallback(
+                    .registerDoubleHistogramCallback(
                       prefix,
                       name,
                       help,
@@ -457,7 +451,7 @@ object MetricFactory {
                 override def apply[B](
                     labels: IndexedSeq[Label.Name]
                 )(f: B => IndexedSeq[String]): Resource[F, Summary[F, Long, B]] =
-                  metricRegistry.createAndRegisterLabelledLongSummary(
+                  metricRegistry.createAndRegisterLongSummary(
                     prefix,
                     name,
                     help,
@@ -475,7 +469,7 @@ object MetricFactory {
               )(
                   f: B => IndexedSeq[String]
               ): Resource[F, Unit] =
-                callbackRegistry.registerLabelledLongSummaryCallback(
+                callbackRegistry.registerLongSummaryCallback(
                   prefix,
                   name,
                   help,
@@ -493,7 +487,7 @@ object MetricFactory {
                 override def apply[B](
                     labels: IndexedSeq[Label.Name]
                 )(f: B => IndexedSeq[String]): Resource[F, Summary[F, Double, B]] =
-                  metricRegistry.createAndRegisterLabelledDoubleSummary(
+                  metricRegistry.createAndRegisterDoubleSummary(
                     prefix,
                     name,
                     help,
@@ -511,7 +505,7 @@ object MetricFactory {
               )(
                   f: B => IndexedSeq[String]
               ): Resource[F, Unit] =
-                callbackRegistry.registerLabelledDoubleSummaryCallback(
+                callbackRegistry.registerDoubleSummaryCallback(
                   prefix,
                   name,
                   help,

--- a/core/src/main/scala/prometheus4cats/MetricFactory.scala
+++ b/core/src/main/scala/prometheus4cats/MetricFactory.scala
@@ -18,7 +18,7 @@ package prometheus4cats
 
 import cats.data.NonEmptyList
 import cats.effect.kernel.{MonadCancel, Resource}
-import cats.{Functor, Monad, ~>}
+import cats.{Applicative, Functor, ~>}
 import prometheus4cats.Metric.CommonLabels
 import prometheus4cats.internal._
 import prometheus4cats.internal.histogram.BucketDsl
@@ -543,7 +543,7 @@ object MetricFactory {
   }
 
   object WithCallbacks {
-    def noop[F[_]: Monad]: WithCallbacks[F] =
+    def noop[F[_]: Applicative]: WithCallbacks[F] =
       new WithCallbacks[F](
         MetricRegistry.noop,
         CallbackRegistry.noop,
@@ -554,7 +554,7 @@ object MetricFactory {
 
   /** Create an instance of [[MetricFactory]] that performs no operations
     */
-  def noop[F[_]: Monad]: MetricFactory[F] =
+  def noop[F[_]: Applicative]: MetricFactory[F] =
     new MetricFactory[F](
       MetricRegistry.noop,
       None,
@@ -642,7 +642,7 @@ object MetricFactory {
       * @return
       *   a new [[MetricFactory]] instance that performs no operations
       */
-    def noop[F[_]: Monad]: MetricFactory.WithCallbacks[F] =
+    def noop[F[_]: Applicative]: MetricFactory.WithCallbacks[F] =
       MetricFactory.WithCallbacks.noop[F]
   }
 

--- a/core/src/main/scala/prometheus4cats/MetricFactory.scala
+++ b/core/src/main/scala/prometheus4cats/MetricFactory.scala
@@ -40,7 +40,7 @@ sealed abstract class MetricFactory[F[_]](
       commonLabels
     ) {}
 
-  type GaugeDsl[MDsl[_[_], _, _[_[_], _], _[_[_], _, _]], A] = HelpStep[MDsl[F, A, Gauge, Gauge.Labelled]]
+  type GaugeDsl[MDsl[_[_], _, _[_[_], _, _]], A] = HelpStep[MDsl[F, A, Gauge]]
 
   /** Starts creating a "gauge" metric.
     *
@@ -57,10 +57,10 @@ sealed abstract class MetricFactory[F[_]](
       new HelpStep(help =>
         new MetricDsl(
           metricRegistry.createAndRegisterLongGauge(prefix, name, help, commonLabels),
-          new LabelledMetricPartiallyApplied[F, Long, Gauge.Labelled] {
+          new LabelledMetricPartiallyApplied[F, Long, Gauge] {
             override def apply[B](
                 labels: IndexedSeq[Label.Name]
-            )(f: B => IndexedSeq[String]): Resource[F, Gauge.Labelled[F, Long, B]] =
+            )(f: B => IndexedSeq[String]): Resource[F, Gauge[F, Long, B]] =
               metricRegistry.createAndRegisterLabelledLongGauge(prefix, name, help, commonLabels, labels)(f)
           }
         )
@@ -68,17 +68,17 @@ sealed abstract class MetricFactory[F[_]](
       new HelpStep(help =>
         new MetricDsl(
           metricRegistry.createAndRegisterDoubleGauge(prefix, name, help, commonLabels),
-          new LabelledMetricPartiallyApplied[F, Double, Gauge.Labelled] {
+          new LabelledMetricPartiallyApplied[F, Double, Gauge] {
             override def apply[B](
                 labels: IndexedSeq[Label.Name]
-            )(f: B => IndexedSeq[String]): Resource[F, Gauge.Labelled[F, Double, B]] =
+            )(f: B => IndexedSeq[String]): Resource[F, Gauge[F, Double, B]] =
               metricRegistry.createAndRegisterLabelledDoubleGauge(prefix, name, help, commonLabels, labels)(f)
           }
         )
       )
     )
 
-  type CounterDsl[MDsl[_[_], _, _[_[_], _], _[_[_], _, _]], A] = HelpStep[MDsl[F, A, Counter, Counter.Labelled]]
+  type CounterDsl[MDsl[_[_], _, _[_[_], _, _]], A] = HelpStep[MDsl[F, A, Counter]]
 
   /** Starts creating a "counter" metric.
     *
@@ -95,10 +95,10 @@ sealed abstract class MetricFactory[F[_]](
       new HelpStep(help =>
         new MetricDsl(
           metricRegistry.createAndRegisterLongCounter(prefix, name, help, commonLabels),
-          new LabelledMetricPartiallyApplied[F, Long, Counter.Labelled] {
+          new LabelledMetricPartiallyApplied[F, Long, Counter] {
             override def apply[B](
                 labels: IndexedSeq[Label.Name]
-            )(f: B => IndexedSeq[String]): Resource[F, Counter.Labelled[F, Long, B]] =
+            )(f: B => IndexedSeq[String]): Resource[F, Counter[F, Long, B]] =
               metricRegistry.createAndRegisterLabelledLongCounter(prefix, name, help, commonLabels, labels)(f)
           }
         )
@@ -106,18 +106,17 @@ sealed abstract class MetricFactory[F[_]](
       new HelpStep(help =>
         new MetricDsl(
           metricRegistry.createAndRegisterDoubleCounter(prefix, name, help, commonLabels),
-          new LabelledMetricPartiallyApplied[F, Double, Counter.Labelled] {
+          new LabelledMetricPartiallyApplied[F, Double, Counter] {
             override def apply[B](
                 labels: IndexedSeq[Label.Name]
-            )(f: B => IndexedSeq[String]): Resource[F, Counter.Labelled[F, Double, B]] =
+            )(f: B => IndexedSeq[String]): Resource[F, Counter[F, Double, B]] =
               metricRegistry.createAndRegisterLabelledDoubleCounter(prefix, name, help, commonLabels, labels)(f)
           }
         )
       )
     )
 
-  type HistogramDsl[MDsl[_[_], _, _[_[_], _], _[_[_], _, _]], A] =
-    HelpStep[BucketDsl[MDsl[F, A, Histogram, Histogram.Labelled], A]]
+  type HistogramDsl[MDsl[_[_], _, _[_[_], _, _]], A] = HelpStep[BucketDsl[MDsl[F, A, Histogram], A]]
 
   /** Starts creating a "histogram" metric.
     *
@@ -132,13 +131,13 @@ sealed abstract class MetricFactory[F[_]](
   def histogram(name: Histogram.Name): TypeStep[HistogramDsl[MetricDsl, *]] =
     new TypeStep[HistogramDsl[MetricDsl, *]](
       new HelpStep(help =>
-        new BucketDsl[MetricDsl[F, Long, Histogram, Histogram.Labelled], Long](buckets =>
+        new BucketDsl[MetricDsl[F, Long, Histogram], Long](buckets =>
           new MetricDsl(
             metricRegistry.createAndRegisterLongHistogram(prefix, name, help, commonLabels, buckets),
-            new LabelledMetricPartiallyApplied[F, Long, Histogram.Labelled] {
+            new LabelledMetricPartiallyApplied[F, Long, Histogram] {
               override def apply[B](
                   labels: IndexedSeq[Label.Name]
-              )(f: B => IndexedSeq[String]): Resource[F, Histogram.Labelled[F, Long, B]] =
+              )(f: B => IndexedSeq[String]): Resource[F, Histogram[F, Long, B]] =
                 metricRegistry
                   .createAndRegisterLabelledLongHistogram(prefix, name, help, commonLabels, labels, buckets)(f)
             }
@@ -146,13 +145,13 @@ sealed abstract class MetricFactory[F[_]](
         )
       ),
       new HelpStep(help =>
-        new BucketDsl[MetricDsl[F, Double, Histogram, Histogram.Labelled], Double](buckets =>
+        new BucketDsl[MetricDsl[F, Double, Histogram], Double](buckets =>
           new MetricDsl(
             metricRegistry.createAndRegisterDoubleHistogram(prefix, name, help, commonLabels, buckets),
-            new LabelledMetricPartiallyApplied[F, Double, Histogram.Labelled] {
+            new LabelledMetricPartiallyApplied[F, Double, Histogram] {
               override def apply[B](
                   labels: IndexedSeq[Label.Name]
-              )(f: B => IndexedSeq[String]): Resource[F, Histogram.Labelled[F, Double, B]] =
+              )(f: B => IndexedSeq[String]): Resource[F, Histogram[F, Double, B]] =
                 metricRegistry.createAndRegisterLabelledDoubleHistogram(
                   prefix,
                   name,
@@ -177,10 +176,10 @@ sealed abstract class MetricFactory[F[_]](
             metricRegistry
               .createAndRegisterLongSummary(prefix, name, help, commonLabels, quantiles, maxAge, ageBuckets),
           makeLabelledSummary = (quantiles, maxAge, ageBuckets) =>
-            new LabelledMetricPartiallyApplied[F, Long, Summary.Labelled] {
+            new LabelledMetricPartiallyApplied[F, Long, Summary] {
               override def apply[B](
                   labels: IndexedSeq[Label.Name]
-              )(f: B => IndexedSeq[String]): Resource[F, Summary.Labelled[F, Long, B]] =
+              )(f: B => IndexedSeq[String]): Resource[F, Summary[F, Long, B]] =
                 metricRegistry.createAndRegisterLabelledLongSummary(
                   prefix,
                   name,
@@ -200,10 +199,10 @@ sealed abstract class MetricFactory[F[_]](
             metricRegistry
               .createAndRegisterDoubleSummary(prefix, name, help, commonLabels, quantiles, maxAge, ageBuckets),
           makeLabelledSummary = (quantiles, maxAge, ageBuckets) =>
-            new LabelledMetricPartiallyApplied[F, Double, Summary.Labelled] {
+            new LabelledMetricPartiallyApplied[F, Double, Summary] {
               override def apply[B](
                   labels: IndexedSeq[Label.Name]
-              )(f: B => IndexedSeq[String]): Resource[F, Summary.Labelled[F, Double, B]] =
+              )(f: B => IndexedSeq[String]): Resource[F, Summary[F, Double, B]] =
                 metricRegistry.createAndRegisterLabelledDoubleSummary(
                   prefix,
                   name,
@@ -279,7 +278,7 @@ object MetricFactory {
       commonLabels
     ) {}
 
-    type SimpleCallbackDsl[G[_], A, M[_[_], _], L[_[_], _, _]] = MetricDsl.WithCallbacks[G, A, A, M, L]
+    type SimpleCallbackDsl[G[_], A, H[_[_], _, _]] = MetricDsl.WithCallbacks[G, A, A, H]
 
     /** @inheritdoc
       */
@@ -289,10 +288,10 @@ object MetricFactory {
           new MetricDsl.WithCallbacks(
             metricRegistry.createAndRegisterLongGauge(prefix, name, help, commonLabels),
             cb => callbackRegistry.registerLongGaugeCallback(prefix, name, help, commonLabels, cb),
-            new LabelledMetricPartiallyApplied[F, Long, Gauge.Labelled] {
+            new LabelledMetricPartiallyApplied[F, Long, Gauge] {
               override def apply[B](
                   labels: IndexedSeq[Label.Name]
-              )(f: B => IndexedSeq[String]): Resource[F, Gauge.Labelled[F, Long, B]] =
+              )(f: B => IndexedSeq[String]): Resource[F, Gauge[F, Long, B]] =
                 metricRegistry.createAndRegisterLabelledLongGauge(prefix, name, help, commonLabels, labels)(f)
             },
             new LabelledCallbackPartiallyApplied[F, Long] {
@@ -309,10 +308,10 @@ object MetricFactory {
           new MetricDsl.WithCallbacks(
             metricRegistry.createAndRegisterDoubleGauge(prefix, name, help, commonLabels),
             cb => callbackRegistry.registerDoubleGaugeCallback(prefix, name, help, commonLabels, cb),
-            new LabelledMetricPartiallyApplied[F, Double, Gauge.Labelled] {
+            new LabelledMetricPartiallyApplied[F, Double, Gauge] {
               override def apply[B](
                   labels: IndexedSeq[Label.Name]
-              )(f: B => IndexedSeq[String]): Resource[F, Gauge.Labelled[F, Double, B]] =
+              )(f: B => IndexedSeq[String]): Resource[F, Gauge[F, Double, B]] =
                 metricRegistry.createAndRegisterLabelledDoubleGauge(prefix, name, help, commonLabels, labels)(f)
             },
             new LabelledCallbackPartiallyApplied[F, Double] {
@@ -342,10 +341,10 @@ object MetricFactory {
           new MetricDsl.WithCallbacks(
             metricRegistry.createAndRegisterLongCounter(prefix, name, help, commonLabels),
             cb => callbackRegistry.registerLongCounterCallback(prefix, name, help, commonLabels, cb),
-            new LabelledMetricPartiallyApplied[F, Long, Counter.Labelled] {
+            new LabelledMetricPartiallyApplied[F, Long, Counter] {
               override def apply[B](
                   labels: IndexedSeq[Label.Name]
-              )(f: B => IndexedSeq[String]): Resource[F, Counter.Labelled[F, Long, B]] =
+              )(f: B => IndexedSeq[String]): Resource[F, Counter[F, Long, B]] =
                 metricRegistry.createAndRegisterLabelledLongCounter(prefix, name, help, commonLabels, labels)(f)
             },
             new LabelledCallbackPartiallyApplied[F, Long] {
@@ -363,10 +362,10 @@ object MetricFactory {
           new MetricDsl.WithCallbacks(
             metricRegistry.createAndRegisterDoubleCounter(prefix, name, help, commonLabels),
             cb => callbackRegistry.registerDoubleCounterCallback(prefix, name, help, commonLabels, cb),
-            new LabelledMetricPartiallyApplied[F, Double, Counter.Labelled] {
+            new LabelledMetricPartiallyApplied[F, Double, Counter] {
               override def apply[B](
                   labels: IndexedSeq[Label.Name]
-              )(f: B => IndexedSeq[String]): Resource[F, Counter.Labelled[F, Double, B]] =
+              )(f: B => IndexedSeq[String]): Resource[F, Counter[F, Double, B]] =
                 metricRegistry.createAndRegisterLabelledDoubleCounter(prefix, name, help, commonLabels, labels)(f)
             },
             new LabelledCallbackPartiallyApplied[F, Double] {
@@ -388,61 +387,60 @@ object MetricFactory {
         )
       )
 
-    type HistogramCallbackDsl[G[_], A, M[_[_], _], L[_[_], _, _]] =
-      MetricDsl.WithCallbacks[G, A, Histogram.Value[A], M, L]
+    type HistogramCallbackDsl[G[_], A, H[_[_], _, _]] =
+      MetricDsl.WithCallbacks[G, A, Histogram.Value[A], H]
 
     /** @inheritdoc
       */
     override def histogram(name: Histogram.Name): TypeStep[HistogramDsl[HistogramCallbackDsl, *]] =
       new TypeStep[HistogramDsl[HistogramCallbackDsl, *]](
         new HelpStep(help =>
-          new BucketDsl[MetricDsl.WithCallbacks[F, Long, Histogram.Value[Long], Histogram, Histogram.Labelled], Long](
-            buckets =>
-              new MetricDsl.WithCallbacks(
-                metricRegistry.createAndRegisterLongHistogram(prefix, name, help, commonLabels, buckets),
-                cb => callbackRegistry.registerLongHistogramCallback(prefix, name, help, commonLabels, buckets, cb),
-                new LabelledMetricPartiallyApplied[F, Long, Histogram.Labelled] {
-                  override def apply[B](
-                      labels: IndexedSeq[Label.Name]
-                  )(f: B => IndexedSeq[String]): Resource[F, Histogram.Labelled[F, Long, B]] =
-                    metricRegistry
-                      .createAndRegisterLabelledLongHistogram(prefix, name, help, commonLabels, labels, buckets)(f)
-                },
-                new LabelledCallbackPartiallyApplied[F, Histogram.Value[Long]] {
-                  override def apply[B](
-                      labels: IndexedSeq[Label.Name],
-                      callback: F[NonEmptyList[(Histogram.Value[Long], B)]]
-                  )(
-                      f: B => IndexedSeq[String]
-                  ): Resource[F, Unit] =
-                    callbackRegistry
-                      .registerLabelledLongHistogramCallback(
-                        prefix,
-                        name,
-                        help,
-                        commonLabels,
-                        labels,
-                        buckets,
-                        callback
-                      )(
-                        f
-                      )
-                }
-              )
+          new BucketDsl[MetricDsl.WithCallbacks[F, Long, Histogram.Value[Long], Histogram], Long](buckets =>
+            new MetricDsl.WithCallbacks(
+              metricRegistry.createAndRegisterLongHistogram(prefix, name, help, commonLabels, buckets),
+              cb => callbackRegistry.registerLongHistogramCallback(prefix, name, help, commonLabels, buckets, cb),
+              new LabelledMetricPartiallyApplied[F, Long, Histogram] {
+                override def apply[B](
+                    labels: IndexedSeq[Label.Name]
+                )(f: B => IndexedSeq[String]): Resource[F, Histogram[F, Long, B]] =
+                  metricRegistry
+                    .createAndRegisterLabelledLongHistogram(prefix, name, help, commonLabels, labels, buckets)(f)
+              },
+              new LabelledCallbackPartiallyApplied[F, Histogram.Value[Long]] {
+                override def apply[B](
+                    labels: IndexedSeq[Label.Name],
+                    callback: F[NonEmptyList[(Histogram.Value[Long], B)]]
+                )(
+                    f: B => IndexedSeq[String]
+                ): Resource[F, Unit] =
+                  callbackRegistry
+                    .registerLabelledLongHistogramCallback(
+                      prefix,
+                      name,
+                      help,
+                      commonLabels,
+                      labels,
+                      buckets,
+                      callback
+                    )(
+                      f
+                    )
+              }
+            )
           )
         ),
         new HelpStep(help =>
           new BucketDsl[
-            MetricDsl.WithCallbacks[F, Double, Histogram.Value[Double], Histogram, Histogram.Labelled],
+            MetricDsl.WithCallbacks[F, Double, Histogram.Value[Double], Histogram],
             Double
           ](buckets =>
             new MetricDsl.WithCallbacks(
               metricRegistry.createAndRegisterDoubleHistogram(prefix, name, help, commonLabels, buckets),
               cb => callbackRegistry.registerDoubleHistogramCallback(prefix, name, help, commonLabels, buckets, cb),
-              new LabelledMetricPartiallyApplied[F, Double, Histogram.Labelled] {
+              new LabelledMetricPartiallyApplied[F, Double, Histogram] {
                 override def apply[B](
                     labels: IndexedSeq[Label.Name]
-                )(f: B => IndexedSeq[String]): Resource[F, Histogram.Labelled[F, Double, B]] =
+                )(f: B => IndexedSeq[String]): Resource[F, Histogram[F, Double, B]] =
                   metricRegistry
                     .createAndRegisterLabelledDoubleHistogram(prefix, name, help, commonLabels, labels, buckets)(f)
               },
@@ -483,10 +481,10 @@ object MetricFactory {
                 .createAndRegisterLongSummary(prefix, name, help, commonLabels, quantiles, maxAge, ageBuckets),
             makeSummaryCallback = callbackRegistry.registerLongSummaryCallback(prefix, name, help, commonLabels, _),
             makeLabelledSummary = (quantiles, maxAge, ageBuckets) =>
-              new LabelledMetricPartiallyApplied[F, Long, Summary.Labelled] {
+              new LabelledMetricPartiallyApplied[F, Long, Summary] {
                 override def apply[B](
                     labels: IndexedSeq[Label.Name]
-                )(f: B => IndexedSeq[String]): Resource[F, Summary.Labelled[F, Long, B]] =
+                )(f: B => IndexedSeq[String]): Resource[F, Summary[F, Long, B]] =
                   metricRegistry.createAndRegisterLabelledLongSummary(
                     prefix,
                     name,
@@ -523,10 +521,10 @@ object MetricFactory {
                 .createAndRegisterDoubleSummary(prefix, name, help, commonLabels, quantiles, maxAge, ageBuckets),
             makeSummaryCallback = callbackRegistry.registerDoubleSummaryCallback(prefix, name, help, commonLabels, _),
             makeLabelledSummary = (quantiles, maxAge, ageBuckets) =>
-              new LabelledMetricPartiallyApplied[F, Double, Summary.Labelled] {
+              new LabelledMetricPartiallyApplied[F, Double, Summary] {
                 override def apply[B](
                     labels: IndexedSeq[Label.Name]
-                )(f: B => IndexedSeq[String]): Resource[F, Summary.Labelled[F, Double, B]] =
+                )(f: B => IndexedSeq[String]): Resource[F, Summary[F, Double, B]] =
                   metricRegistry.createAndRegisterLabelledDoubleSummary(
                     prefix,
                     name,

--- a/core/src/main/scala/prometheus4cats/MetricFactory.scala
+++ b/core/src/main/scala/prometheus4cats/MetricFactory.scala
@@ -166,7 +166,7 @@ sealed abstract class MetricFactory[F[_]](
     new TypeStep[SummaryDslLambda](
       new HelpStep(help =>
         new SummaryDsl[F, Long](
-          makeLabelledSummary = (quantiles, maxAge, ageBuckets) =>
+          makeSummary = (quantiles, maxAge, ageBuckets) =>
             new LabelledMetricPartiallyApplied[F, Long, Summary] {
               override def apply[B](
                   labels: IndexedSeq[Label.Name]
@@ -186,7 +186,7 @@ sealed abstract class MetricFactory[F[_]](
       ),
       new HelpStep(help =>
         new SummaryDsl[F, Double](
-          makeLabelledSummary = (quantiles, maxAge, ageBuckets) =>
+          makeSummary = (quantiles, maxAge, ageBuckets) =>
             new LabelledMetricPartiallyApplied[F, Double, Summary] {
               override def apply[B](
                   labels: IndexedSeq[Label.Name]
@@ -452,7 +452,7 @@ object MetricFactory {
       new TypeStep[SummaryCallbackDsl](
         new HelpStep(help =>
           new SummaryDsl.WithCallbacks[F, Long, Summary.Value[Long]](
-            makeLabelledSummary = (quantiles, maxAge, ageBuckets) =>
+            makeSummary = (quantiles, maxAge, ageBuckets) =>
               new LabelledMetricPartiallyApplied[F, Long, Summary] {
                 override def apply[B](
                     labels: IndexedSeq[Label.Name]
@@ -468,7 +468,7 @@ object MetricFactory {
                     ageBuckets
                   )(f)
               },
-            makeLabelledSummaryCallback = new LabelledCallbackPartiallyApplied[F, Summary.Value[Long]] {
+            makeSummaryCallback = new LabelledCallbackPartiallyApplied[F, Summary.Value[Long]] {
               override def apply[B](
                   labels: IndexedSeq[Label.Name],
                   callback: F[NonEmptyList[(Summary.Value[Long], B)]]
@@ -488,7 +488,7 @@ object MetricFactory {
         ),
         new HelpStep(help =>
           new SummaryDsl.WithCallbacks[F, Double, Summary.Value[Double]](
-            makeLabelledSummary = (quantiles, maxAge, ageBuckets) =>
+            makeSummary = (quantiles, maxAge, ageBuckets) =>
               new LabelledMetricPartiallyApplied[F, Double, Summary] {
                 override def apply[B](
                     labels: IndexedSeq[Label.Name]
@@ -504,7 +504,7 @@ object MetricFactory {
                     ageBuckets
                   )(f)
               },
-            makeLabelledSummaryCallback = new LabelledCallbackPartiallyApplied[F, Summary.Value[Double]] {
+            makeSummaryCallback = new LabelledCallbackPartiallyApplied[F, Summary.Value[Double]] {
               override def apply[B](
                   labels: IndexedSeq[Label.Name],
                   callback: F[NonEmptyList[(Summary.Value[Double], B)]]

--- a/core/src/main/scala/prometheus4cats/MetricRegistry.scala
+++ b/core/src/main/scala/prometheus4cats/MetricRegistry.scala
@@ -18,7 +18,7 @@ package prometheus4cats
 
 import cats.data.NonEmptySeq
 import cats.effect.kernel.{MonadCancel, Resource}
-import cats.{Monad, ~>}
+import cats.{Applicative, ~>}
 import prometheus4cats.Metric.CommonLabels
 import prometheus4cats.Summary.QuantileDefinition
 import prometheus4cats.util.DoubleMetricRegistry
@@ -293,7 +293,7 @@ trait MetricRegistry[F[_]] {
 
 object MetricRegistry {
 
-  def noop[F[_]](implicit F: Monad[F]): MetricRegistry[F] =
+  def noop[F[_]](implicit F: Applicative[F]): MetricRegistry[F] =
     new DoubleMetricRegistry[F] {
 
       def createAndRegisterDoubleCounter[A](

--- a/core/src/main/scala/prometheus4cats/MetricRegistry.scala
+++ b/core/src/main/scala/prometheus4cats/MetricRegistry.scala
@@ -30,46 +30,6 @@ import scala.concurrent.duration.FiniteDuration
   */
 trait MetricRegistry[F[_]] {
 
-  /** Create and register a counter that records [[scala.Double]] values against a metrics registry
-    *
-    * @param prefix
-    *   optional [[Metric.Prefix]] to be prepended to the metric name
-    * @param name
-    *   [[Counter.Name]] metric name
-    * @param help
-    *   [[Metric.Help]] string to describe the metric
-    * @param commonLabels
-    *   [[Metric.CommonLabels]] map of common labels to be added to the metric
-    * @return
-    *   a [[Counter]] wrapped in whatever side effect that was performed in registering it
-    */
-  def createAndRegisterDoubleCounter(
-      prefix: Option[Metric.Prefix],
-      name: Counter.Name,
-      help: Metric.Help,
-      commonLabels: Metric.CommonLabels
-  ): Resource[F, Counter[F, Double, Unit]]
-
-  /** Create and register a counter that records [[scala.Long]] values against a metrics registry
-    *
-    * @param prefix
-    *   optional [[Metric.Prefix]] to be prepended to the metric name
-    * @param name
-    *   [[Counter.Name]] metric name
-    * @param help
-    *   [[Metric.Help]] string to describe the metric
-    * @param commonLabels
-    *   [[Metric.CommonLabels]] map of common labels to be added to the metric
-    * @return
-    *   a [[Counter]] wrapped in whatever side effect that was performed in registering it
-    */
-  def createAndRegisterLongCounter(
-      prefix: Option[Metric.Prefix],
-      name: Counter.Name,
-      help: Metric.Help,
-      commonLabels: Metric.CommonLabels
-  ): Resource[F, Counter[F, Long, Unit]]
-
   /** Create and register a labelled counter that records [[scala.Double]] values against a metrics registry
     *
     * @param prefix
@@ -88,7 +48,7 @@ trait MetricRegistry[F[_]] {
     * @return
     *   a [[Counter]] wrapped in whatever side effect that was performed in registering it
     */
-  def createAndRegisterLabelledDoubleCounter[A](
+  def createAndRegisterDoubleCounter[A](
       prefix: Option[Metric.Prefix],
       name: Counter.Name,
       help: Metric.Help,
@@ -114,53 +74,13 @@ trait MetricRegistry[F[_]] {
     * @return
     *   a [[Counter]] wrapped in whatever side effect that was performed in registering it
     */
-  def createAndRegisterLabelledLongCounter[A](
+  def createAndRegisterLongCounter[A](
       prefix: Option[Metric.Prefix],
       name: Counter.Name,
       help: Metric.Help,
       commonLabels: Metric.CommonLabels,
       labelNames: IndexedSeq[Label.Name]
   )(f: A => IndexedSeq[String]): Resource[F, Counter[F, Long, A]]
-
-  /** Create and register a gauge that records [[scala.Double]] values against a metrics registry
-    *
-    * @param prefix
-    *   optional [[Metric.Prefix]] to be prepended to the metric name
-    * @param name
-    *   [[Gauge.Name]] metric name
-    * @param help
-    *   [[Metric.Help]] string to describe the metric
-    * @param commonLabels
-    *   [[Metric.CommonLabels]] map of common labels to be added to the metric
-    * @return
-    *   a [[Gauge]] wrapped in whatever side effect that was performed in registering it
-    */
-  def createAndRegisterDoubleGauge(
-      prefix: Option[Metric.Prefix],
-      name: Gauge.Name,
-      help: Metric.Help,
-      commonLabels: Metric.CommonLabels
-  ): Resource[F, Gauge[F, Double, Unit]]
-
-  /** Create and register a gauge that records [[scala.Long]] values against a metrics registry
-    *
-    * @param prefix
-    *   optional [[Metric.Prefix]] to be prepended to the metric name
-    * @param name
-    *   [[Gauge.Name]] metric name
-    * @param help
-    *   [[Metric.Help]] string to describe the metric
-    * @param commonLabels
-    *   [[Metric.CommonLabels]] map of common labels to be added to the metric
-    * @return
-    *   a [[Gauge]] wrapped in whatever side effect that was performed in registering it
-    */
-  def createAndRegisterLongGauge(
-      prefix: Option[Metric.Prefix],
-      name: Gauge.Name,
-      help: Metric.Help,
-      commonLabels: Metric.CommonLabels
-  ): Resource[F, Gauge[F, Long, Unit]]
 
   /** Create and register a labelled gauge that records [[scala.Double]] values against a metrics registry
     *
@@ -180,7 +100,7 @@ trait MetricRegistry[F[_]] {
     * @return
     *   a [[Gauge]] wrapped in whatever side effect that was performed in registering it
     */
-  def createAndRegisterLabelledDoubleGauge[A](
+  def createAndRegisterDoubleGauge[A](
       prefix: Option[Metric.Prefix],
       name: Gauge.Name,
       help: Metric.Help,
@@ -206,59 +126,13 @@ trait MetricRegistry[F[_]] {
     * @return
     *   a [[Gauge]] wrapped in whatever side effect that was performed in registering it
     */
-  def createAndRegisterLabelledLongGauge[A](
+  def createAndRegisterLongGauge[A](
       prefix: Option[Metric.Prefix],
       name: Gauge.Name,
       help: Metric.Help,
       commonLabels: Metric.CommonLabels,
       labelNames: IndexedSeq[Label.Name]
   )(f: A => IndexedSeq[String]): Resource[F, Gauge[F, Long, A]]
-
-  /** Create and register a histogram that records [[scala.Double]] values against a metrics registry
-    *
-    * @param prefix
-    *   optional [[Metric.Prefix]] to be prepended to the metric name
-    * @param name
-    *   [[Histogram.Name]] metric name
-    * @param help
-    *   [[Metric.Help]] string to describe the metric
-    * @param commonLabels
-    *   [[Metric.CommonLabels]] map of common labels to be added to the metric
-    * @param buckets
-    *   a [[cats.data.NonEmptySeq]] of [[scala.Double]]s representing bucket values for the histogram
-    * @return
-    *   a [[Histogram]] wrapped in whatever side effect that was performed in registering it
-    */
-  def createAndRegisterDoubleHistogram(
-      prefix: Option[Metric.Prefix],
-      name: Histogram.Name,
-      help: Metric.Help,
-      commonLabels: Metric.CommonLabels,
-      buckets: NonEmptySeq[Double]
-  ): Resource[F, Histogram[F, Double, Unit]]
-
-  /** Create and register a histogram that records [[scala.Long]] values against a metrics registry
-    *
-    * @param prefix
-    *   optional [[Metric.Prefix]] to be prepended to the metric name
-    * @param name
-    *   [[Histogram.Name]] metric name
-    * @param help
-    *   [[Metric.Help]] string to describe the metric
-    * @param commonLabels
-    *   [[Metric.CommonLabels]] map of common labels to be added to the metric
-    * @param buckets
-    *   a [[cats.data.NonEmptySeq]] of [[scala.Double]]s representing bucket values for the histogram
-    * @return
-    *   a [[Histogram]] wrapped in whatever side effect that was performed in registering it
-    */
-  def createAndRegisterLongHistogram(
-      prefix: Option[Metric.Prefix],
-      name: Histogram.Name,
-      help: Metric.Help,
-      commonLabels: Metric.CommonLabels,
-      buckets: NonEmptySeq[Long]
-  ): Resource[F, Histogram[F, Long, Unit]]
 
   /** Create and register a labelled histogram against a metrics registry
     *
@@ -280,7 +154,7 @@ trait MetricRegistry[F[_]] {
     * @return
     *   a [[Histogram]] wrapped in whatever side effect that was performed in registering it
     */
-  def createAndRegisterLabelledDoubleHistogram[A](
+  def createAndRegisterDoubleHistogram[A](
       prefix: Option[Metric.Prefix],
       name: Histogram.Name,
       help: Metric.Help,
@@ -309,7 +183,7 @@ trait MetricRegistry[F[_]] {
     * @return
     *   a [[Histogram]] wrapped in whatever side effect that was performed in registering it
     */
-  def createAndRegisterLabelledLongHistogram[A](
+  def createAndRegisterLongHistogram[A](
       prefix: Option[Metric.Prefix],
       name: Histogram.Name,
       help: Metric.Help,
@@ -317,72 +191,6 @@ trait MetricRegistry[F[_]] {
       labelNames: IndexedSeq[Label.Name],
       buckets: NonEmptySeq[Long]
   )(f: A => IndexedSeq[String]): Resource[F, Histogram[F, Long, A]]
-
-  /** Create and register a summary that records [[scala.Double]] values against a metrics registry
-    *
-    * @param prefix
-    *   optional [[Metric.Prefix]] to be prepended to the metric name
-    * @param name
-    *   [[Summary.Name]] metric name
-    * @param help
-    *   [[Metric.Help]] string to describe the metric
-    * @param commonLabels
-    *   [[Metric.CommonLabels]] map of common labels to be added to the metric
-    * @param quantiles
-    *   a [[scala.Seq]] of [[Summary.QuantileDefinition]]s representing bucket values for the summary. Quantiles are
-    *   expensive to calculate, so this may be empty.
-    * @param maxAge
-    *   a [[scala.concurrent.duration.FiniteDuration]] indicating a window over which the summary should be calculate.
-    *   Typically, you don't want to have a [[Summary]] representing the entire runtime of the application, but you want
-    *   to look at a reasonable time interval. [[Summary]] metrics should implement a configurable sliding time window.
-    * @param ageBuckets
-    *   how many intervals there should be in a given time window defined by `maxAge`. For example, if a time window of
-    *   10 minutes and 5 age buckets, i.e. the time window is 10 minutes wide, and we slide it forward every 2 minutes.
-    * @return
-    *   a [[Summary]] wrapped in whatever side effect that was performed in registering it
-    */
-  def createAndRegisterDoubleSummary(
-      prefix: Option[Metric.Prefix],
-      name: Summary.Name,
-      help: Metric.Help,
-      commonLabels: Metric.CommonLabels,
-      quantiles: Seq[QuantileDefinition],
-      maxAge: FiniteDuration,
-      ageBuckets: Summary.AgeBuckets
-  ): Resource[F, Summary[F, Double, Unit]]
-
-  /** Create and register a summary that records [[scala.Long]] values against a metrics registry
-    *
-    * @param prefix
-    *   optional [[Metric.Prefix]] to be prepended to the metric name
-    * @param name
-    *   [[Summary.Name]] metric name
-    * @param help
-    *   [[Metric.Help]] string to describe the metric
-    * @param commonLabels
-    *   [[Metric.CommonLabels]] map of common labels to be added to the metric
-    * @param quantiles
-    *   a [[scala.Seq]] of [[Summary.QuantileDefinition]]s representing bucket values for the summary. Quantiles are
-    *   expensive to calculate, so this may be empty.
-    * @param maxAge
-    *   a [[scala.concurrent.duration.FiniteDuration]] indicating a window over which the summary should be calculate.
-    *   Typically, you don't want to have a [[Summary]] representing the entire runtime of the application, but you want
-    *   to look at a reasonable time interval. [[Summary]] metrics should implement a configurable sliding time window.
-    * @param ageBuckets
-    *   how many intervals there should be in a given time window defined by `maxAge`. For example, if a time window of
-    *   10 minutes and 5 age buckets, i.e. the time window is 10 minutes wide, and we slide it forward every 2 minutes.
-    * @return
-    *   a [[Summary]] wrapped in whatever side effect that was performed in registering it
-    */
-  def createAndRegisterLongSummary(
-      prefix: Option[Metric.Prefix],
-      name: Summary.Name,
-      help: Metric.Help,
-      commonLabels: Metric.CommonLabels,
-      quantiles: Seq[QuantileDefinition],
-      maxAge: FiniteDuration,
-      ageBuckets: Summary.AgeBuckets
-  ): Resource[F, Summary[F, Long, Unit]]
 
   /** Create and register a summary that records [[scala.Double]] values against a metrics registry
     *
@@ -412,7 +220,7 @@ trait MetricRegistry[F[_]] {
     * @return
     *   a [[Summary]] wrapped in whatever side effect that was performed in registering it
     */
-  def createAndRegisterLabelledDoubleSummary[A](
+  def createAndRegisterDoubleSummary[A](
       prefix: Option[Metric.Prefix],
       name: Summary.Name,
       help: Metric.Help,
@@ -451,7 +259,7 @@ trait MetricRegistry[F[_]] {
     * @return
     *   a [[Summary]] wrapped in whatever side effect that was performed in registering it
     */
-  def createAndRegisterLabelledLongSummary[A](
+  def createAndRegisterLongSummary[A](
       prefix: Option[Metric.Prefix],
       name: Summary.Name,
       help: Metric.Help,
@@ -488,14 +296,7 @@ object MetricRegistry {
   def noop[F[_]](implicit F: Monad[F]): MetricRegistry[F] =
     new DoubleMetricRegistry[F] {
 
-      override def createAndRegisterDoubleCounter(
-          prefix: Option[Metric.Prefix],
-          name: Counter.Name,
-          help: Metric.Help,
-          commonLabels: CommonLabels
-      ): Resource[F, Counter[F, Double, Unit]] = Resource.pure(Counter.noop)
-
-      override def createAndRegisterLabelledDoubleCounter[A](
+      def createAndRegisterDoubleCounter[A](
           prefix: Option[Metric.Prefix],
           name: Counter.Name,
           help: Metric.Help,
@@ -504,15 +305,7 @@ object MetricRegistry {
       )(f: A => IndexedSeq[String]): Resource[F, Counter[F, Double, A]] =
         Resource.pure(Counter.noop)
 
-      override def createAndRegisterDoubleGauge(
-          prefix: Option[Metric.Prefix],
-          name: Gauge.Name,
-          help: Metric.Help,
-          commonLabels: CommonLabels
-      ): Resource[F, Gauge[F, Double, Unit]] =
-        Resource.pure(Gauge.noop)
-
-      override def createAndRegisterLabelledDoubleGauge[A](
+      override def createAndRegisterDoubleGauge[A](
           prefix: Option[Metric.Prefix],
           name: Gauge.Name,
           help: Metric.Help,
@@ -521,15 +314,7 @@ object MetricRegistry {
       )(f: A => IndexedSeq[String]): Resource[F, Gauge[F, Double, A]] =
         Resource.pure(Gauge.noop)
 
-      override def createAndRegisterDoubleHistogram(
-          prefix: Option[Metric.Prefix],
-          name: Histogram.Name,
-          help: Metric.Help,
-          commonLabels: CommonLabels,
-          buckets: NonEmptySeq[Double]
-      ): Resource[F, Histogram[F, Double, Unit]] = Resource.pure(Histogram.noop)
-
-      override def createAndRegisterLabelledDoubleHistogram[A](
+      override def createAndRegisterDoubleHistogram[A](
           prefix: Option[Metric.Prefix],
           name: Histogram.Name,
           help: Metric.Help,
@@ -539,17 +324,7 @@ object MetricRegistry {
       )(f: A => IndexedSeq[String]): Resource[F, Histogram[F, Double, A]] =
         Resource.pure(Histogram.noop)
 
-      override def createAndRegisterDoubleSummary(
-          prefix: Option[Metric.Prefix],
-          name: Summary.Name,
-          help: Metric.Help,
-          commonLabels: CommonLabels,
-          quantiles: Seq[QuantileDefinition],
-          maxAge: FiniteDuration,
-          ageBuckets: Summary.AgeBuckets
-      ): Resource[F, Summary[F, Double, Unit]] = Resource.pure(Summary.noop)
-
-      override def createAndRegisterLabelledDoubleSummary[A](
+      override def createAndRegisterDoubleSummary[A](
           prefix: Option[Metric.Prefix],
           name: Summary.Name,
           help: Metric.Help,
@@ -573,15 +348,8 @@ object MetricRegistry {
       fk: F ~> G
   )(implicit F: MonadCancel[F, _], G: MonadCancel[G, _]): MetricRegistry[G] =
     new MetricRegistry[G] {
-      override def createAndRegisterDoubleCounter(
-          prefix: Option[Metric.Prefix],
-          name: Counter.Name,
-          help: Metric.Help,
-          commonLabels: CommonLabels
-      ): Resource[G, Counter[G, Double, Unit]] =
-        self.createAndRegisterDoubleCounter(prefix, name, help, commonLabels).mapK(fk).map(_.mapK(fk))
 
-      override def createAndRegisterLabelledDoubleCounter[A](
+      override def createAndRegisterDoubleCounter[A](
           prefix: Option[Metric.Prefix],
           name: Counter.Name,
           help: Metric.Help,
@@ -589,7 +357,7 @@ object MetricRegistry {
           labelNames: IndexedSeq[Label.Name]
       )(f: A => IndexedSeq[String]): Resource[G, Counter[G, Double, A]] =
         self
-          .createAndRegisterLabelledDoubleCounter(
+          .createAndRegisterDoubleCounter(
             prefix,
             name,
             help,
@@ -599,29 +367,7 @@ object MetricRegistry {
           .mapK(fk)
           .map(_.mapK(fk))
 
-      override def createAndRegisterDoubleGauge(
-          prefix: Option[Metric.Prefix],
-          name: Gauge.Name,
-          help: Metric.Help,
-          commonLabels: CommonLabels
-      ): Resource[G, Gauge[G, Double, Unit]] =
-        self
-          .createAndRegisterDoubleGauge(prefix, name, help, commonLabels)
-          .mapK(fk)
-          .map(_.mapK(fk))
-
-      override def createAndRegisterLongGauge(
-          prefix: Option[Metric.Prefix],
-          name: Gauge.Name,
-          help: Metric.Help,
-          commonLabels: CommonLabels
-      ): Resource[G, Gauge[G, Long, Unit]] =
-        self
-          .createAndRegisterLongGauge(prefix, name, help, commonLabels)
-          .mapK(fk)
-          .map(_.mapK(fk))
-
-      override def createAndRegisterLabelledDoubleGauge[A](
+      override def createAndRegisterDoubleGauge[A](
           prefix: Option[Metric.Prefix],
           name: Gauge.Name,
           help: Metric.Help,
@@ -629,7 +375,7 @@ object MetricRegistry {
           labelNames: IndexedSeq[Label.Name]
       )(f: A => IndexedSeq[String]): Resource[G, Gauge[G, Double, A]] =
         self
-          .createAndRegisterLabelledDoubleGauge(
+          .createAndRegisterDoubleGauge(
             prefix,
             name,
             help,
@@ -639,25 +385,7 @@ object MetricRegistry {
           .mapK(fk)
           .map(_.mapK(fk))
 
-      override def createAndRegisterDoubleHistogram(
-          prefix: Option[Metric.Prefix],
-          name: Histogram.Name,
-          help: Metric.Help,
-          commonLabels: CommonLabels,
-          buckets: NonEmptySeq[Double]
-      ): Resource[G, Histogram[G, Double, Unit]] =
-        self
-          .createAndRegisterDoubleHistogram(
-            prefix,
-            name,
-            help,
-            commonLabels,
-            buckets
-          )
-          .mapK(fk)
-          .map(_.mapK(fk))
-
-      override def createAndRegisterLabelledDoubleHistogram[A](
+      override def createAndRegisterDoubleHistogram[A](
           prefix: Option[Metric.Prefix],
           name: Histogram.Name,
           help: Metric.Help,
@@ -666,7 +394,7 @@ object MetricRegistry {
           buckets: NonEmptySeq[Double]
       )(f: A => IndexedSeq[String]): Resource[G, Histogram[G, Double, A]] =
         self
-          .createAndRegisterLabelledDoubleHistogram(
+          .createAndRegisterDoubleHistogram(
             prefix,
             name,
             help,
@@ -677,15 +405,7 @@ object MetricRegistry {
           .mapK(fk)
           .map(_.mapK(fk))
 
-      override def createAndRegisterLongCounter(
-          prefix: Option[Metric.Prefix],
-          name: Counter.Name,
-          help: Metric.Help,
-          commonLabels: CommonLabels
-      ): Resource[G, Counter[G, Long, Unit]] =
-        self.createAndRegisterLongCounter(prefix, name, help, commonLabels).mapK(fk).map(_.mapK(fk))
-
-      override def createAndRegisterLabelledLongCounter[A](
+      override def createAndRegisterLongCounter[A](
           prefix: Option[Metric.Prefix],
           name: Counter.Name,
           help: Metric.Help,
@@ -693,11 +413,11 @@ object MetricRegistry {
           labelNames: IndexedSeq[Label.Name]
       )(f: A => IndexedSeq[String]): Resource[G, Counter[G, Long, A]] =
         self
-          .createAndRegisterLabelledLongCounter(prefix, name, help, commonLabels, labelNames)(f)
+          .createAndRegisterLongCounter(prefix, name, help, commonLabels, labelNames)(f)
           .mapK(fk)
           .map(_.mapK(fk))
 
-      override def createAndRegisterLabelledLongGauge[A](
+      override def createAndRegisterLongGauge[A](
           prefix: Option[Metric.Prefix],
           name: Gauge.Name,
           help: Metric.Help,
@@ -705,20 +425,11 @@ object MetricRegistry {
           labelNames: IndexedSeq[Label.Name]
       )(f: A => IndexedSeq[String]): Resource[G, Gauge[G, Long, A]] =
         self
-          .createAndRegisterLabelledLongGauge(prefix, name, help, commonLabels, labelNames)(f)
+          .createAndRegisterLongGauge(prefix, name, help, commonLabels, labelNames)(f)
           .mapK(fk)
           .map(_.mapK(fk))
 
-      override def createAndRegisterLongHistogram(
-          prefix: Option[Metric.Prefix],
-          name: Histogram.Name,
-          help: Metric.Help,
-          commonLabels: CommonLabels,
-          buckets: NonEmptySeq[Long]
-      ): Resource[G, Histogram[G, Long, Unit]] =
-        self.createAndRegisterLongHistogram(prefix, name, help, commonLabels, buckets).mapK(fk).map(_.mapK(fk))
-
-      override def createAndRegisterLabelledLongHistogram[A](
+      override def createAndRegisterLongHistogram[A](
           prefix: Option[Metric.Prefix],
           name: Histogram.Name,
           help: Metric.Help,
@@ -727,39 +438,11 @@ object MetricRegistry {
           buckets: NonEmptySeq[Long]
       )(f: A => IndexedSeq[String]): Resource[G, Histogram[G, Long, A]] =
         self
-          .createAndRegisterLabelledLongHistogram(prefix, name, help, commonLabels, labelNames, buckets)(f)
+          .createAndRegisterLongHistogram(prefix, name, help, commonLabels, labelNames, buckets)(f)
           .mapK(fk)
           .map(_.mapK(fk))
 
-      override def createAndRegisterDoubleSummary(
-          prefix: Option[Metric.Prefix],
-          name: Summary.Name,
-          help: Metric.Help,
-          commonLabels: CommonLabels,
-          quantiles: Seq[QuantileDefinition],
-          maxAge: FiniteDuration,
-          ageBuckets: Summary.AgeBuckets
-      ): Resource[G, Summary[G, Double, Unit]] =
-        self
-          .createAndRegisterDoubleSummary(prefix, name, help, commonLabels, quantiles, maxAge, ageBuckets)
-          .mapK(fk)
-          .map(_.mapK(fk))
-
-      override def createAndRegisterLongSummary(
-          prefix: Option[Metric.Prefix],
-          name: Summary.Name,
-          help: Metric.Help,
-          commonLabels: CommonLabels,
-          quantiles: Seq[QuantileDefinition],
-          maxAge: FiniteDuration,
-          ageBuckets: Summary.AgeBuckets
-      ): Resource[G, Summary[G, Long, Unit]] =
-        self
-          .createAndRegisterLongSummary(prefix, name, help, commonLabels, quantiles, maxAge, ageBuckets)
-          .mapK(fk)
-          .map(_.mapK(fk))
-
-      override def createAndRegisterLabelledDoubleSummary[A](
+      override def createAndRegisterDoubleSummary[A](
           prefix: Option[Metric.Prefix],
           name: Summary.Name,
           help: Metric.Help,
@@ -770,7 +453,7 @@ object MetricRegistry {
           ageBuckets: Summary.AgeBuckets
       )(f: A => IndexedSeq[String]): Resource[G, Summary[G, Double, A]] =
         self
-          .createAndRegisterLabelledDoubleSummary(
+          .createAndRegisterDoubleSummary(
             prefix,
             name,
             help,
@@ -783,7 +466,7 @@ object MetricRegistry {
           .mapK(fk)
           .map(_.mapK(fk))
 
-      override def createAndRegisterLabelledLongSummary[A](
+      override def createAndRegisterLongSummary[A](
           prefix: Option[Metric.Prefix],
           name: Summary.Name,
           help: Metric.Help,
@@ -794,7 +477,7 @@ object MetricRegistry {
           ageBuckets: Summary.AgeBuckets
       )(f: A => IndexedSeq[String]): Resource[G, Summary[G, Long, A]] =
         self
-          .createAndRegisterLabelledLongSummary(
+          .createAndRegisterLongSummary(
             prefix,
             name,
             help,

--- a/core/src/main/scala/prometheus4cats/MetricRegistry.scala
+++ b/core/src/main/scala/prometheus4cats/MetricRegistry.scala
@@ -48,7 +48,7 @@ trait MetricRegistry[F[_]] {
       name: Counter.Name,
       help: Metric.Help,
       commonLabels: Metric.CommonLabels
-  ): Resource[F, Counter[F, Double]]
+  ): Resource[F, Counter[F, Double, Unit]]
 
   /** Create and register a counter that records [[scala.Long]] values against a metrics registry
     *
@@ -68,7 +68,7 @@ trait MetricRegistry[F[_]] {
       name: Counter.Name,
       help: Metric.Help,
       commonLabels: Metric.CommonLabels
-  ): Resource[F, Counter[F, Long]]
+  ): Resource[F, Counter[F, Long, Unit]]
 
   /** Create and register a labelled counter that records [[scala.Double]] values against a metrics registry
     *
@@ -86,7 +86,7 @@ trait MetricRegistry[F[_]] {
     *   a function from `A` to an [[scala.IndexedSeq]] of [[java.lang.String]] that provides label values, which must be
     *   paired with their corresponding name in the [[scala.IndexedSeq]] of [[Label.Name]]s
     * @return
-    *   a [[Counter.Labelled]] wrapped in whatever side effect that was performed in registering it
+    *   a [[Counter]] wrapped in whatever side effect that was performed in registering it
     */
   def createAndRegisterLabelledDoubleCounter[A](
       prefix: Option[Metric.Prefix],
@@ -94,7 +94,7 @@ trait MetricRegistry[F[_]] {
       help: Metric.Help,
       commonLabels: Metric.CommonLabels,
       labelNames: IndexedSeq[Label.Name]
-  )(f: A => IndexedSeq[String]): Resource[F, Counter.Labelled[F, Double, A]]
+  )(f: A => IndexedSeq[String]): Resource[F, Counter[F, Double, A]]
 
   /** Create and register a labelled counter that records [[scala.Long]] values against a metrics registry
     *
@@ -112,7 +112,7 @@ trait MetricRegistry[F[_]] {
     *   a function from `A` to an [[scala.IndexedSeq]] of [[java.lang.String]] that provides label values, which must be
     *   paired with their corresponding name in the [[scala.IndexedSeq]] of [[Label.Name]]s
     * @return
-    *   a [[Counter.Labelled]] wrapped in whatever side effect that was performed in registering it
+    *   a [[Counter]] wrapped in whatever side effect that was performed in registering it
     */
   def createAndRegisterLabelledLongCounter[A](
       prefix: Option[Metric.Prefix],
@@ -120,7 +120,7 @@ trait MetricRegistry[F[_]] {
       help: Metric.Help,
       commonLabels: Metric.CommonLabels,
       labelNames: IndexedSeq[Label.Name]
-  )(f: A => IndexedSeq[String]): Resource[F, Counter.Labelled[F, Long, A]]
+  )(f: A => IndexedSeq[String]): Resource[F, Counter[F, Long, A]]
 
   /** Create and register a gauge that records [[scala.Double]] values against a metrics registry
     *
@@ -140,7 +140,7 @@ trait MetricRegistry[F[_]] {
       name: Gauge.Name,
       help: Metric.Help,
       commonLabels: Metric.CommonLabels
-  ): Resource[F, Gauge[F, Double]]
+  ): Resource[F, Gauge[F, Double, Unit]]
 
   /** Create and register a gauge that records [[scala.Long]] values against a metrics registry
     *
@@ -160,7 +160,7 @@ trait MetricRegistry[F[_]] {
       name: Gauge.Name,
       help: Metric.Help,
       commonLabels: Metric.CommonLabels
-  ): Resource[F, Gauge[F, Long]]
+  ): Resource[F, Gauge[F, Long, Unit]]
 
   /** Create and register a labelled gauge that records [[scala.Double]] values against a metrics registry
     *
@@ -178,7 +178,7 @@ trait MetricRegistry[F[_]] {
     *   a function from `A` to an [[scala.IndexedSeq]] of [[java.lang.String]] that provides label values, which must be
     *   paired with their corresponding name in the [[scala.IndexedSeq]] of [[Label.Name]]s
     * @return
-    *   a [[Gauge.Labelled]] wrapped in whatever side effect that was performed in registering it
+    *   a [[Gauge]] wrapped in whatever side effect that was performed in registering it
     */
   def createAndRegisterLabelledDoubleGauge[A](
       prefix: Option[Metric.Prefix],
@@ -186,7 +186,7 @@ trait MetricRegistry[F[_]] {
       help: Metric.Help,
       commonLabels: Metric.CommonLabels,
       labelNames: IndexedSeq[Label.Name]
-  )(f: A => IndexedSeq[String]): Resource[F, Gauge.Labelled[F, Double, A]]
+  )(f: A => IndexedSeq[String]): Resource[F, Gauge[F, Double, A]]
 
   /** Create and register a labelled gauge that records [[scala.Long]] values against a metrics registry
     *
@@ -204,7 +204,7 @@ trait MetricRegistry[F[_]] {
     *   a function from `A` to an [[scala.IndexedSeq]] of [[java.lang.String]] that provides label values, which must be
     *   paired with their corresponding name in the [[scala.IndexedSeq]] of [[Label.Name]]s
     * @return
-    *   a [[Gauge.Labelled]] wrapped in whatever side effect that was performed in registering it
+    *   a [[Gauge]] wrapped in whatever side effect that was performed in registering it
     */
   def createAndRegisterLabelledLongGauge[A](
       prefix: Option[Metric.Prefix],
@@ -212,7 +212,7 @@ trait MetricRegistry[F[_]] {
       help: Metric.Help,
       commonLabels: Metric.CommonLabels,
       labelNames: IndexedSeq[Label.Name]
-  )(f: A => IndexedSeq[String]): Resource[F, Gauge.Labelled[F, Long, A]]
+  )(f: A => IndexedSeq[String]): Resource[F, Gauge[F, Long, A]]
 
   /** Create and register a histogram that records [[scala.Double]] values against a metrics registry
     *
@@ -235,7 +235,7 @@ trait MetricRegistry[F[_]] {
       help: Metric.Help,
       commonLabels: Metric.CommonLabels,
       buckets: NonEmptySeq[Double]
-  ): Resource[F, Histogram[F, Double]]
+  ): Resource[F, Histogram[F, Double, Unit]]
 
   /** Create and register a histogram that records [[scala.Long]] values against a metrics registry
     *
@@ -258,7 +258,7 @@ trait MetricRegistry[F[_]] {
       help: Metric.Help,
       commonLabels: Metric.CommonLabels,
       buckets: NonEmptySeq[Long]
-  ): Resource[F, Histogram[F, Long]]
+  ): Resource[F, Histogram[F, Long, Unit]]
 
   /** Create and register a labelled histogram against a metrics registry
     *
@@ -278,7 +278,7 @@ trait MetricRegistry[F[_]] {
     *   a function from `A` to an [[scala.IndexedSeq]] of [[java.lang.String]] that provides label values, which must be
     *   paired with their corresponding name in the [[scala.IndexedSeq]] of [[Label.Name]]s
     * @return
-    *   a [[Histogram.Labelled]] wrapped in whatever side effect that was performed in registering it
+    *   a [[Histogram]] wrapped in whatever side effect that was performed in registering it
     */
   def createAndRegisterLabelledDoubleHistogram[A](
       prefix: Option[Metric.Prefix],
@@ -287,7 +287,7 @@ trait MetricRegistry[F[_]] {
       commonLabels: Metric.CommonLabels,
       labelNames: IndexedSeq[Label.Name],
       buckets: NonEmptySeq[Double]
-  )(f: A => IndexedSeq[String]): Resource[F, Histogram.Labelled[F, Double, A]]
+  )(f: A => IndexedSeq[String]): Resource[F, Histogram[F, Double, A]]
 
   /** Create and register a labelled histogram against a metrics registry
     *
@@ -307,7 +307,7 @@ trait MetricRegistry[F[_]] {
     *   a function from `A` to an [[scala.IndexedSeq]] of [[java.lang.String]] that provides label values, which must be
     *   paired with their corresponding name in the [[scala.IndexedSeq]] of [[Label.Name]]s
     * @return
-    *   a [[Histogram.Labelled]] wrapped in whatever side effect that was performed in registering it
+    *   a [[Histogram]] wrapped in whatever side effect that was performed in registering it
     */
   def createAndRegisterLabelledLongHistogram[A](
       prefix: Option[Metric.Prefix],
@@ -316,7 +316,7 @@ trait MetricRegistry[F[_]] {
       commonLabels: Metric.CommonLabels,
       labelNames: IndexedSeq[Label.Name],
       buckets: NonEmptySeq[Long]
-  )(f: A => IndexedSeq[String]): Resource[F, Histogram.Labelled[F, Long, A]]
+  )(f: A => IndexedSeq[String]): Resource[F, Histogram[F, Long, A]]
 
   /** Create and register a summary that records [[scala.Double]] values against a metrics registry
     *
@@ -349,7 +349,7 @@ trait MetricRegistry[F[_]] {
       quantiles: Seq[QuantileDefinition],
       maxAge: FiniteDuration,
       ageBuckets: Summary.AgeBuckets
-  ): Resource[F, Summary[F, Double]]
+  ): Resource[F, Summary[F, Double, Unit]]
 
   /** Create and register a summary that records [[scala.Long]] values against a metrics registry
     *
@@ -382,7 +382,7 @@ trait MetricRegistry[F[_]] {
       quantiles: Seq[QuantileDefinition],
       maxAge: FiniteDuration,
       ageBuckets: Summary.AgeBuckets
-  ): Resource[F, Summary[F, Long]]
+  ): Resource[F, Summary[F, Long, Unit]]
 
   /** Create and register a summary that records [[scala.Double]] values against a metrics registry
     *
@@ -410,7 +410,7 @@ trait MetricRegistry[F[_]] {
     *   a function from `A` to an [[scala.IndexedSeq]] of [[java.lang.String]] that provides label values, which must be
     *   paired with their corresponding name in the [[scala.IndexedSeq]] of [[Label.Name]]s
     * @return
-    *   a [[Summary.Labelled]] wrapped in whatever side effect that was performed in registering it
+    *   a [[Summary]] wrapped in whatever side effect that was performed in registering it
     */
   def createAndRegisterLabelledDoubleSummary[A](
       prefix: Option[Metric.Prefix],
@@ -421,7 +421,7 @@ trait MetricRegistry[F[_]] {
       quantiles: Seq[QuantileDefinition],
       maxAge: FiniteDuration,
       ageBuckets: Summary.AgeBuckets
-  )(f: A => IndexedSeq[String]): Resource[F, Summary.Labelled[F, Double, A]]
+  )(f: A => IndexedSeq[String]): Resource[F, Summary[F, Double, A]]
 
   /** Create and register a summary that records [[scala.Long]] values against a metrics registry
     *
@@ -449,7 +449,7 @@ trait MetricRegistry[F[_]] {
     *   a function from `A` to an [[scala.IndexedSeq]] of [[java.lang.String]] that provides label values, which must be
     *   paired with their corresponding name in the [[scala.IndexedSeq]] of [[Label.Name]]s
     * @return
-    *   a [[Summary.Labelled]] wrapped in whatever side effect that was performed in registering it
+    *   a [[Summary]] wrapped in whatever side effect that was performed in registering it
     */
   def createAndRegisterLabelledLongSummary[A](
       prefix: Option[Metric.Prefix],
@@ -460,7 +460,7 @@ trait MetricRegistry[F[_]] {
       quantiles: Seq[QuantileDefinition],
       maxAge: FiniteDuration,
       ageBuckets: Summary.AgeBuckets
-  )(f: A => IndexedSeq[String]): Resource[F, Summary.Labelled[F, Long, A]]
+  )(f: A => IndexedSeq[String]): Resource[F, Summary[F, Long, A]]
 
   /** Create and register an info metric against a metrics registry
     *
@@ -493,7 +493,7 @@ object MetricRegistry {
           name: Counter.Name,
           help: Metric.Help,
           commonLabels: CommonLabels
-      ): Resource[F, Counter[F, Double]] = Resource.pure(Counter.noop)
+      ): Resource[F, Counter[F, Double, Unit]] = Resource.pure(Counter.noop)
 
       override def createAndRegisterLabelledDoubleCounter[A](
           prefix: Option[Metric.Prefix],
@@ -501,15 +501,15 @@ object MetricRegistry {
           help: Metric.Help,
           commonLabels: CommonLabels,
           labelNames: IndexedSeq[Label.Name]
-      )(f: A => IndexedSeq[String]): Resource[F, Counter.Labelled[F, Double, A]] =
-        Resource.pure(Counter.Labelled.noop)
+      )(f: A => IndexedSeq[String]): Resource[F, Counter[F, Double, A]] =
+        Resource.pure(Counter.noop)
 
       override def createAndRegisterDoubleGauge(
           prefix: Option[Metric.Prefix],
           name: Gauge.Name,
           help: Metric.Help,
           commonLabels: CommonLabels
-      ): Resource[F, Gauge[F, Double]] =
+      ): Resource[F, Gauge[F, Double, Unit]] =
         Resource.pure(Gauge.noop)
 
       override def createAndRegisterLabelledDoubleGauge[A](
@@ -518,8 +518,8 @@ object MetricRegistry {
           help: Metric.Help,
           commonLabels: CommonLabels,
           labelNames: IndexedSeq[Label.Name]
-      )(f: A => IndexedSeq[String]): Resource[F, Gauge.Labelled[F, Double, A]] =
-        Resource.pure(Gauge.Labelled.noop)
+      )(f: A => IndexedSeq[String]): Resource[F, Gauge[F, Double, A]] =
+        Resource.pure(Gauge.noop)
 
       override def createAndRegisterDoubleHistogram(
           prefix: Option[Metric.Prefix],
@@ -527,7 +527,7 @@ object MetricRegistry {
           help: Metric.Help,
           commonLabels: CommonLabels,
           buckets: NonEmptySeq[Double]
-      ): Resource[F, Histogram[F, Double]] = Resource.pure(Histogram.noop)
+      ): Resource[F, Histogram[F, Double, Unit]] = Resource.pure(Histogram.noop)
 
       override def createAndRegisterLabelledDoubleHistogram[A](
           prefix: Option[Metric.Prefix],
@@ -536,8 +536,8 @@ object MetricRegistry {
           commonLabels: CommonLabels,
           labelNames: IndexedSeq[Label.Name],
           buckets: NonEmptySeq[Double]
-      )(f: A => IndexedSeq[String]): Resource[F, Histogram.Labelled[F, Double, A]] =
-        Resource.pure(Histogram.Labelled.noop)
+      )(f: A => IndexedSeq[String]): Resource[F, Histogram[F, Double, A]] =
+        Resource.pure(Histogram.noop)
 
       override def createAndRegisterDoubleSummary(
           prefix: Option[Metric.Prefix],
@@ -547,7 +547,7 @@ object MetricRegistry {
           quantiles: Seq[QuantileDefinition],
           maxAge: FiniteDuration,
           ageBuckets: Summary.AgeBuckets
-      ): Resource[F, Summary[F, Double]] = Resource.pure(Summary.noop)
+      ): Resource[F, Summary[F, Double, Unit]] = Resource.pure(Summary.noop)
 
       override def createAndRegisterLabelledDoubleSummary[A](
           prefix: Option[Metric.Prefix],
@@ -558,8 +558,8 @@ object MetricRegistry {
           quantiles: Seq[QuantileDefinition],
           maxAge: FiniteDuration,
           ageBuckets: Summary.AgeBuckets
-      )(f: A => IndexedSeq[String]): Resource[F, Summary.Labelled[F, Double, A]] =
-        Resource.pure(Summary.Labelled.noop)
+      )(f: A => IndexedSeq[String]): Resource[F, Summary[F, Double, A]] =
+        Resource.pure(Summary.noop)
 
       override def createAndRegisterInfo(
           prefix: Option[Metric.Prefix],
@@ -578,7 +578,7 @@ object MetricRegistry {
           name: Counter.Name,
           help: Metric.Help,
           commonLabels: CommonLabels
-      ): Resource[G, Counter[G, Double]] =
+      ): Resource[G, Counter[G, Double, Unit]] =
         self.createAndRegisterDoubleCounter(prefix, name, help, commonLabels).mapK(fk).map(_.mapK(fk))
 
       override def createAndRegisterLabelledDoubleCounter[A](
@@ -587,7 +587,7 @@ object MetricRegistry {
           help: Metric.Help,
           commonLabels: CommonLabels,
           labelNames: IndexedSeq[Label.Name]
-      )(f: A => IndexedSeq[String]): Resource[G, Counter.Labelled[G, Double, A]] =
+      )(f: A => IndexedSeq[String]): Resource[G, Counter[G, Double, A]] =
         self
           .createAndRegisterLabelledDoubleCounter(
             prefix,
@@ -604,7 +604,7 @@ object MetricRegistry {
           name: Gauge.Name,
           help: Metric.Help,
           commonLabels: CommonLabels
-      ): Resource[G, Gauge[G, Double]] =
+      ): Resource[G, Gauge[G, Double, Unit]] =
         self
           .createAndRegisterDoubleGauge(prefix, name, help, commonLabels)
           .mapK(fk)
@@ -615,7 +615,7 @@ object MetricRegistry {
           name: Gauge.Name,
           help: Metric.Help,
           commonLabels: CommonLabels
-      ): Resource[G, Gauge[G, Long]] =
+      ): Resource[G, Gauge[G, Long, Unit]] =
         self
           .createAndRegisterLongGauge(prefix, name, help, commonLabels)
           .mapK(fk)
@@ -627,7 +627,7 @@ object MetricRegistry {
           help: Metric.Help,
           commonLabels: CommonLabels,
           labelNames: IndexedSeq[Label.Name]
-      )(f: A => IndexedSeq[String]): Resource[G, Gauge.Labelled[G, Double, A]] =
+      )(f: A => IndexedSeq[String]): Resource[G, Gauge[G, Double, A]] =
         self
           .createAndRegisterLabelledDoubleGauge(
             prefix,
@@ -645,7 +645,7 @@ object MetricRegistry {
           help: Metric.Help,
           commonLabels: CommonLabels,
           buckets: NonEmptySeq[Double]
-      ): Resource[G, Histogram[G, Double]] =
+      ): Resource[G, Histogram[G, Double, Unit]] =
         self
           .createAndRegisterDoubleHistogram(
             prefix,
@@ -664,7 +664,7 @@ object MetricRegistry {
           commonLabels: CommonLabels,
           labelNames: IndexedSeq[Label.Name],
           buckets: NonEmptySeq[Double]
-      )(f: A => IndexedSeq[String]): Resource[G, Histogram.Labelled[G, Double, A]] =
+      )(f: A => IndexedSeq[String]): Resource[G, Histogram[G, Double, A]] =
         self
           .createAndRegisterLabelledDoubleHistogram(
             prefix,
@@ -682,7 +682,7 @@ object MetricRegistry {
           name: Counter.Name,
           help: Metric.Help,
           commonLabels: CommonLabels
-      ): Resource[G, Counter[G, Long]] =
+      ): Resource[G, Counter[G, Long, Unit]] =
         self.createAndRegisterLongCounter(prefix, name, help, commonLabels).mapK(fk).map(_.mapK(fk))
 
       override def createAndRegisterLabelledLongCounter[A](
@@ -691,7 +691,7 @@ object MetricRegistry {
           help: Metric.Help,
           commonLabels: CommonLabels,
           labelNames: IndexedSeq[Label.Name]
-      )(f: A => IndexedSeq[String]): Resource[G, Counter.Labelled[G, Long, A]] =
+      )(f: A => IndexedSeq[String]): Resource[G, Counter[G, Long, A]] =
         self
           .createAndRegisterLabelledLongCounter(prefix, name, help, commonLabels, labelNames)(f)
           .mapK(fk)
@@ -703,7 +703,7 @@ object MetricRegistry {
           help: Metric.Help,
           commonLabels: CommonLabels,
           labelNames: IndexedSeq[Label.Name]
-      )(f: A => IndexedSeq[String]): Resource[G, Gauge.Labelled[G, Long, A]] =
+      )(f: A => IndexedSeq[String]): Resource[G, Gauge[G, Long, A]] =
         self
           .createAndRegisterLabelledLongGauge(prefix, name, help, commonLabels, labelNames)(f)
           .mapK(fk)
@@ -715,7 +715,7 @@ object MetricRegistry {
           help: Metric.Help,
           commonLabels: CommonLabels,
           buckets: NonEmptySeq[Long]
-      ): Resource[G, Histogram[G, Long]] =
+      ): Resource[G, Histogram[G, Long, Unit]] =
         self.createAndRegisterLongHistogram(prefix, name, help, commonLabels, buckets).mapK(fk).map(_.mapK(fk))
 
       override def createAndRegisterLabelledLongHistogram[A](
@@ -725,7 +725,7 @@ object MetricRegistry {
           commonLabels: CommonLabels,
           labelNames: IndexedSeq[Label.Name],
           buckets: NonEmptySeq[Long]
-      )(f: A => IndexedSeq[String]): Resource[G, Histogram.Labelled[G, Long, A]] =
+      )(f: A => IndexedSeq[String]): Resource[G, Histogram[G, Long, A]] =
         self
           .createAndRegisterLabelledLongHistogram(prefix, name, help, commonLabels, labelNames, buckets)(f)
           .mapK(fk)
@@ -739,7 +739,7 @@ object MetricRegistry {
           quantiles: Seq[QuantileDefinition],
           maxAge: FiniteDuration,
           ageBuckets: Summary.AgeBuckets
-      ): Resource[G, Summary[G, Double]] =
+      ): Resource[G, Summary[G, Double, Unit]] =
         self
           .createAndRegisterDoubleSummary(prefix, name, help, commonLabels, quantiles, maxAge, ageBuckets)
           .mapK(fk)
@@ -753,7 +753,7 @@ object MetricRegistry {
           quantiles: Seq[QuantileDefinition],
           maxAge: FiniteDuration,
           ageBuckets: Summary.AgeBuckets
-      ): Resource[G, Summary[G, Long]] =
+      ): Resource[G, Summary[G, Long, Unit]] =
         self
           .createAndRegisterLongSummary(prefix, name, help, commonLabels, quantiles, maxAge, ageBuckets)
           .mapK(fk)
@@ -768,7 +768,7 @@ object MetricRegistry {
           quantiles: Seq[QuantileDefinition],
           maxAge: FiniteDuration,
           ageBuckets: Summary.AgeBuckets
-      )(f: A => IndexedSeq[String]): Resource[G, Summary.Labelled[G, Double, A]] =
+      )(f: A => IndexedSeq[String]): Resource[G, Summary[G, Double, A]] =
         self
           .createAndRegisterLabelledDoubleSummary(
             prefix,
@@ -792,7 +792,7 @@ object MetricRegistry {
           quantiles: Seq[QuantileDefinition],
           maxAge: FiniteDuration,
           ageBuckets: Summary.AgeBuckets
-      )(f: A => IndexedSeq[String]): Resource[G, Summary.Labelled[G, Long, A]] =
+      )(f: A => IndexedSeq[String]): Resource[G, Summary[G, Long, A]] =
         self
           .createAndRegisterLabelledLongSummary(
             prefix,

--- a/core/src/main/scala/prometheus4cats/OutcomeRecorder.scala
+++ b/core/src/main/scala/prometheus4cats/OutcomeRecorder.scala
@@ -19,87 +19,13 @@ package prometheus4cats
 import cats.effect.kernel.syntax.monadCancel._
 import cats.effect.kernel.{MonadCancelThrow, Outcome}
 import cats.syntax.flatMap._
-import cats.{Show, ~>}
+import cats.{FlatMap, Show, ~>}
 
 /** A derived metric type that records the outcome of an operation. See [[OutcomeRecorder.fromCounter]] and
   * [[OutcomeRecorder.fromGauge]] for more information.
   */
-sealed abstract class OutcomeRecorder[F[_]: MonadCancelThrow, -A] extends Metric.Labelled[A] { self =>
+sealed abstract class OutcomeRecorder[F[_], -A] extends Metric.Labelled[A] { self =>
   type Metric
-
-  /** Surround an operation and evaluate its outcome using an instance of [[cats.effect.kernel.MonadCancel]].
-    *
-    * The resulting metrics depend on the underlying implementation. See [[OutcomeRecorder.fromCounter]] and
-    * [[OutcomeRecorder.fromGauge]] for more details.
-    *
-    * @param fb
-    *   operation to be evaluated
-    * @param labels
-    *   labels to add to the underlying metric
-    */
-  final def surround[B](fb: F[B], labels: A): F[B] = fb.guaranteeCase(recordOutcome(_, labels))
-
-  /** Record the result of provided [[cats.effect.kernel.Outcome]]
-    *
-    * The resulting metrics depend on the underlying implementation. See [[OutcomeRecorder.fromCounter]] and
-    * [[OutcomeRecorder.fromGauge]] for more details.
-    *
-    * @param outcome
-    *   the [[cats.effect.kernel.Outcome]] to be recorded
-    * @param labels
-    *   labels to add to the underlying metric
-    */
-  final def recordOutcome[B, E](outcome: Outcome[F, E, B], labels: A): F[Unit] =
-    outcome match {
-      case Outcome.Succeeded(_) => onSucceeded(labels)
-      case Outcome.Errored(_) => onErrored(labels)
-      case Outcome.Canceled() => onCanceled(labels)
-    }
-
-  /** Surround an operation and evaluate its outcome using an instance of [[cats.effect.kernel.MonadCancel]], computing
-    * additional labels from the result.
-    *
-    * The resulting metrics depend on the underlying implementation. See [[OutcomeRecorder.fromCounter]] and
-    * [[OutcomeRecorder.fromGauge]] for more details.
-    *
-    * @param fb
-    *   operation to be evaluated
-    * @param labelsCanceled
-    *   labels to add when the operation is canceled
-    * @param labelsSuccess
-    *   function to compute labels from the result of `fb` when the operation is successful
-    * @param labelsError
-    *   function to compute labels from the exception that was raised if the operation is unsuccessful
-    */
-  final def surroundWithComputedLabels[B](
-      fb: F[B],
-      labelsCanceled: A
-  )(labelsSuccess: B => A, labelsError: Throwable => A): F[B] =
-    fb.guaranteeCase(recordOutcomeWithComputedLabels(_, labelsCanceled)(labelsSuccess, labelsError))
-
-  /** Record the result of provided [[cats.effect.kernel.Outcome]] computing additional labels from the result.
-    *
-    * The resulting metrics depend on the underlying implementation. See [[OutcomeRecorder.fromCounter]] and
-    * [[OutcomeRecorder.fromGauge]] for more details.
-    *
-    * @param outcome
-    *   the [[cats.effect.kernel.Outcome]] to be recorded
-    * @param labelsCanceled
-    *   labels to add when the operation is canceled
-    * @param labelsSuccess
-    *   function to compute labels from the result of `fb` when the operation is successful
-    * @param labelsError
-    *   function to compute labels from the exception that was raised if the operation is unsuccessful
-    */
-  final def recordOutcomeWithComputedLabels[B, E](
-      outcome: Outcome[F, E, B],
-      labelsCanceled: A
-  )(labelsSuccess: B => A, labelsError: E => A): F[Unit] =
-    outcome match {
-      case Outcome.Succeeded(fb) => fb.flatMap(b => onSucceeded(labelsSuccess(b)))
-      case Outcome.Errored(th) => onErrored(labelsError(th))
-      case Outcome.Canceled() => onCanceled(labelsCanceled)
-    }
 
   protected def onCanceled(labels: A): F[Unit]
 
@@ -117,7 +43,7 @@ sealed abstract class OutcomeRecorder[F[_]: MonadCancelThrow, -A] extends Metric
     override protected def onSucceeded(labels: B): F[Unit] = self.onSucceeded(f(labels))
   }
 
-  def mapK[G[_]: MonadCancelThrow](fk: F ~> G): OutcomeRecorder[G, A] = new OutcomeRecorder[G, A] {
+  def mapK[G[_]](fk: F ~> G): OutcomeRecorder[G, A] = new OutcomeRecorder[G, A] {
     override type Metric = self.Metric
 
     override protected def onCanceled(labels: A): G[Unit] = fk(self.onCanceled(labels))
@@ -150,6 +76,113 @@ object OutcomeRecorder {
     type Metric = M[F, A, (B, Status)]
   }
 
+  implicit class OutcomeRecorderSyntax[F[_]](recorder: OutcomeRecorder[F, Unit]) {
+
+    /** Surround an operation and evaluate its outcome using an instance of [[cats.effect.kernel.MonadCancel]].
+      *
+      * The resulting metrics depend on the underlying implementation. See [[OutcomeRecorder.fromCounter]] and
+      * [[OutcomeRecorder.fromGauge]] for more details.
+      *
+      * @param fb
+      *   operation to be evaluated
+      */
+    final def surround[B](fb: F[B])(implicit F: MonadCancelThrow[F]): F[B] = fb.guaranteeCase(recordOutcome)
+
+    /** Record the result of provided [[cats.effect.kernel.Outcome]]
+      *
+      * The resulting metrics depend on the underlying implementation. See [[OutcomeRecorder.fromCounter]] and
+      * [[OutcomeRecorder.fromGauge]] for more details.
+      *
+      * @param outcome
+      *   the [[cats.effect.kernel.Outcome]] to be recorded
+      */
+    final def recordOutcome[B, E](outcome: Outcome[F, E, B]): F[Unit] =
+      outcome match {
+        case Outcome.Succeeded(_) => recorder.onSucceeded(())
+        case Outcome.Errored(_) => recorder.onErrored(())
+        case Outcome.Canceled() => recorder.onCanceled(())
+      }
+  }
+
+  implicit class LabelledOutcomeRecorder[F[_], -A](recorder: OutcomeRecorder[F, A]) {
+
+    /** Surround an operation and evaluate its outcome using an instance of [[cats.effect.kernel.MonadCancel]].
+      *
+      * The resulting metrics depend on the underlying implementation. See [[OutcomeRecorder.fromCounter]] and
+      * [[OutcomeRecorder.fromGauge]] for more details.
+      *
+      * @param fb
+      *   operation to be evaluated
+      * @param labels
+      *   labels to add to the underlying metric
+      */
+    final def surround[B](fb: F[B], labels: A)(implicit F: MonadCancelThrow[F]): F[B] =
+      fb.guaranteeCase(recordOutcome(_, labels))
+
+    /** Record the result of provided [[cats.effect.kernel.Outcome]]
+      *
+      * The resulting metrics depend on the underlying implementation. See [[OutcomeRecorder.fromCounter]] and
+      * [[OutcomeRecorder.fromGauge]] for more details.
+      *
+      * @param outcome
+      *   the [[cats.effect.kernel.Outcome]] to be recorded
+      * @param labels
+      *   labels to add to the underlying metric
+      */
+    final def recordOutcome[B, E](outcome: Outcome[F, E, B], labels: A): F[Unit] =
+      outcome match {
+        case Outcome.Succeeded(_) => recorder.onSucceeded(labels)
+        case Outcome.Errored(_) => recorder.onErrored(labels)
+        case Outcome.Canceled() => recorder.onCanceled(labels)
+      }
+
+    /** Surround an operation and evaluate its outcome using an instance of [[cats.effect.kernel.MonadCancel]],
+      * computing additional labels from the result.
+      *
+      * The resulting metrics depend on the underlying implementation. See [[OutcomeRecorder.fromCounter]] and
+      * [[OutcomeRecorder.fromGauge]] for more details.
+      *
+      * @param fb
+      *   operation to be evaluated
+      * @param labelsCanceled
+      *   labels to add when the operation is canceled
+      * @param labelsSuccess
+      *   function to compute labels from the result of `fb` when the operation is successful
+      * @param labelsError
+      *   function to compute labels from the exception that was raised if the operation is unsuccessful
+      */
+    final def surroundWithComputedLabels[B](
+        fb: F[B],
+        labelsCanceled: A
+    )(labelsSuccess: B => A, labelsError: Throwable => A)(implicit F: MonadCancelThrow[F]): F[B] =
+      fb.guaranteeCase(recordOutcomeWithComputedLabels(_, labelsCanceled)(labelsSuccess, labelsError))
+
+    /** Record the result of provided [[cats.effect.kernel.Outcome]] computing additional labels from the result.
+      *
+      * The resulting metrics depend on the underlying implementation. See [[OutcomeRecorder.fromCounter]] and
+      * [[OutcomeRecorder.fromGauge]] for more details.
+      *
+      * @param outcome
+      *   the [[cats.effect.kernel.Outcome]] to be recorded
+      * @param labelsCanceled
+      *   labels to add when the operation is canceled
+      * @param labelsSuccess
+      *   function to compute labels from the result of `fb` when the operation is successful
+      * @param labelsError
+      *   function to compute labels from the exception that was raised if the operation is unsuccessful
+      */
+    final def recordOutcomeWithComputedLabels[B, E](
+        outcome: Outcome[F, E, B],
+        labelsCanceled: A
+    )(labelsSuccess: B => A, labelsError: E => A)(implicit F: FlatMap[F]): F[Unit] =
+      outcome match {
+        case Outcome.Succeeded(fb) => fb.flatMap(b => recorder.onSucceeded(labelsSuccess(b)))
+        case Outcome.Errored(th) => recorder.onErrored(labelsError(th))
+        case Outcome.Canceled() => recorder.onCanceled(labelsCanceled)
+      }
+
+  }
+
   implicit def labelsContravariant[F[_]]: LabelsContravariant[OutcomeRecorder[F, *]] =
     new LabelsContravariant[OutcomeRecorder[F, *]] {
       override def contramapLabels[A, B](fa: OutcomeRecorder[F, A])(f: B => A): OutcomeRecorder[F, B] =
@@ -168,7 +201,7 @@ object OutcomeRecorder {
     * @return
     *   an [[OutcomeRecorder.Aux]] that is annotated with the type of underlying metric, in this case [[Counter]]
     */
-  def fromCounter[F[_]: MonadCancelThrow, A, B](
+  def fromCounter[F[_], A, B](
       counter: Counter[F, A, (B, Status)]
   ): OutcomeRecorder.Aux[F, A, B, Counter] = new OutcomeRecorder[F, B] {
     override type Metric = Counter[F, A, (B, Status)]
@@ -214,125 +247,9 @@ object OutcomeRecorder {
   /** A derived metric type that records the outcome of an operation. See [[OutcomeRecorder.fromCounter]] and
     * [[OutcomeRecorder.fromGauge]] for more information.
     */
-  sealed abstract class Exemplar[F[_]: MonadCancelThrow, -A] extends Metric.Labelled[A] {
+  sealed abstract class Exemplar[F[_], -A] extends Metric.Labelled[A] {
     self =>
     type Metric
-
-    /** Surround an operation and evaluate its outcome using an instance of [[cats.effect.kernel.MonadCancel]].
-      *
-      * The resulting metrics depend on the underlying implementation. See [[OutcomeRecorder.fromCounter]] and
-      * [[OutcomeRecorder.fromGauge]] for more details.
-      *
-      * @param fb
-      *   operation to be evaluated
-      * @param labels
-      *   labels to add to the underlying metric
-      */
-    final def surround[B](
-        fb: F[B],
-        labels: A,
-        recordExemplarOnSucceeded: Boolean = false,
-        recordExemplarOnErrored: Boolean = false,
-        recordExemplarOnCanceled: Boolean = false
-    )(implicit exemplar: prometheus4cats.Exemplar[F]): F[B] = fb.guaranteeCase(
-      recordOutcome(_, labels, recordExemplarOnSucceeded, recordExemplarOnErrored, recordExemplarOnCanceled)
-    )
-
-    /** Record the result of provided [[cats.effect.kernel.Outcome]]
-      *
-      * The resulting metrics depend on the underlying implementation. See [[OutcomeRecorder.fromCounter]] and
-      * [[OutcomeRecorder.fromGauge]] for more details.
-      *
-      * @param outcome
-      *   the [[cats.effect.kernel.Outcome]] to be recorded
-      * @param labels
-      *   labels to add to the underlying metric
-      */
-    final def recordOutcome[B, E](
-        outcome: Outcome[F, E, B],
-        labels: A,
-        recordExemplarOnSucceeded: Boolean = false,
-        recordExemplarOnErrored: Boolean = false,
-        recordExemplarOnCanceled: Boolean = false
-    )(implicit exemplar: prometheus4cats.Exemplar[F]): F[Unit] =
-      outcome match {
-        case Outcome.Succeeded(_) =>
-          if (recordExemplarOnSucceeded) exemplar.get.flatMap(onSucceeded(labels, _))
-          else onSucceeded(labels, None)
-        case Outcome.Errored(_) =>
-          if (recordExemplarOnErrored) exemplar.get.flatMap(onErrored(labels, _))
-          else onErrored(labels, None)
-        case Outcome.Canceled() =>
-          if (recordExemplarOnCanceled) exemplar.get.flatMap(onCanceled(labels, _))
-          else onCanceled(labels, None)
-      }
-
-    /** Surround an operation and evaluate its outcome using an instance of [[cats.effect.kernel.MonadCancel]],
-      * computing additional labels from the result.
-      *
-      * The resulting metrics depend on the underlying implementation. See [[OutcomeRecorder.fromCounter]] and
-      * [[OutcomeRecorder.fromGauge]] for more details.
-      *
-      * @param fb
-      *   operation to be evaluated
-      * @param labelsCanceled
-      *   labels to add when the operation is canceled
-      * @param labelsSuccess
-      *   function to compute labels from the result of `fb` when the operation is successful
-      * @param labelsError
-      *   function to compute labels from the exception that was raised if the operation is unsuccessful
-      */
-    final def surroundWithComputedLabels[B](
-        fb: F[B],
-        labelsCanceled: A,
-        recordExemplarOnSucceeded: Boolean = false,
-        recordExemplarOnErrored: Boolean = false,
-        recordExemplarOnCanceled: Boolean = false
-    )(labelsSuccess: B => A, labelsError: Throwable => A)(implicit exemplar: prometheus4cats.Exemplar[F]): F[B] =
-      fb.guaranteeCase(
-        recordOutcomeWithComputedLabels(
-          _,
-          labelsCanceled,
-          recordExemplarOnSucceeded,
-          recordExemplarOnErrored,
-          recordExemplarOnCanceled
-        )(labelsSuccess, labelsError)
-      )
-
-    /** Record the result of provided [[cats.effect.kernel.Outcome]] computing additional labels from the result.
-      *
-      * The resulting metrics depend on the underlying implementation. See [[OutcomeRecorder.fromCounter]] and
-      * [[OutcomeRecorder.fromGauge]] for more details.
-      *
-      * @param outcome
-      *   the [[cats.effect.kernel.Outcome]] to be recorded
-      * @param labelsCanceled
-      *   labels to add when the operation is canceled
-      * @param labelsSuccess
-      *   function to compute labels from the result of `fb` when the operation is successful
-      * @param labelsError
-      *   function to compute labels from the exception that was raised if the operation is unsuccessful
-      */
-    final def recordOutcomeWithComputedLabels[B, E](
-        outcome: Outcome[F, E, B],
-        labelsCanceled: A,
-        recordExemplarOnSucceeded: Boolean = false,
-        recordExemplarOnErrored: Boolean = false,
-        recordExemplarOnCanceled: Boolean = false
-    )(labelsSuccess: B => A, labelsError: E => A)(implicit exemplar: prometheus4cats.Exemplar[F]): F[Unit] =
-      outcome match {
-        case Outcome.Succeeded(fb) =>
-          fb.flatMap(b =>
-            if (recordExemplarOnSucceeded) exemplar.get.flatMap(onSucceeded(labelsSuccess(b), _))
-            else onSucceeded(labelsSuccess(b), None)
-          )
-        case Outcome.Errored(th) =>
-          if (recordExemplarOnErrored) exemplar.get.flatMap(onErrored(labelsError(th), _))
-          else onErrored(labelsError(th), None)
-        case Outcome.Canceled() =>
-          if (recordExemplarOnCanceled) exemplar.get.flatMap(onCanceled(labelsCanceled, _))
-          else onCanceled(labelsCanceled, None)
-      }
 
     protected def onCanceled(labels: A, exemplar: Option[prometheus4cats.Exemplar.Labels]): F[Unit]
 
@@ -353,7 +270,7 @@ object OutcomeRecorder {
         self.onSucceeded(f(labels), exemplar)
     }
 
-    def mapK[G[_]: MonadCancelThrow](fk: F ~> G): Exemplar[G, A] = new Exemplar[G, A] {
+    def mapK[G[_]](fk: F ~> G): Exemplar[G, A] = new Exemplar[G, A] {
       override type Metric = self.Metric
 
       override protected def onCanceled(labels: A, exemplar: Option[prometheus4cats.Exemplar.Labels]): G[Unit] = fk(
@@ -367,6 +284,221 @@ object OutcomeRecorder {
       override protected def onSucceeded(labels: A, exemplar: Option[prometheus4cats.Exemplar.Labels]): G[Unit] = fk(
         self.onSucceeded(labels, exemplar)
       )
+    }
+  }
+
+  object Exemplar {
+    type Aux[F[_], A, B, M[_[_], _, _]] = OutcomeRecorder.Exemplar[F, B] {
+      type Metric = M[F, A, (B, Status)]
+    }
+
+    implicit class OutcomeRecorderExemplarSyntax[F[_]](recorder: OutcomeRecorder.Exemplar[F, Unit]) {
+
+      /** Surround an operation and evaluate its outcome using an instance of [[cats.effect.kernel.MonadCancel]].
+        *
+        * The resulting metrics depend on the underlying implementation. See [[OutcomeRecorder.fromCounter]] and
+        * [[OutcomeRecorder.fromGauge]] for more details.
+        *
+        * @param fb
+        *   operation to be evaluated
+        */
+      final def surround[B](
+          fb: F[B],
+          recordExemplarOnSucceeded: Boolean = false,
+          recordExemplarOnErrored: Boolean = false,
+          recordExemplarOnCanceled: Boolean = false
+      )(implicit F: MonadCancelThrow[F], exemplar: prometheus4cats.Exemplar[F]): F[B] = fb.guaranteeCase(
+        recordOutcome(_, recordExemplarOnSucceeded, recordExemplarOnErrored, recordExemplarOnCanceled)
+      )
+
+      /** Record the result of provided [[cats.effect.kernel.Outcome]]
+        *
+        * The resulting metrics depend on the underlying implementation. See [[OutcomeRecorder.fromCounter]] and
+        * [[OutcomeRecorder.fromGauge]] for more details.
+        *
+        * @param outcome
+        *   the [[cats.effect.kernel.Outcome]] to be recorded
+        */
+      final def recordOutcome[B, E](
+          outcome: Outcome[F, E, B],
+          recordExemplarOnSucceeded: Boolean = false,
+          recordExemplarOnErrored: Boolean = false,
+          recordExemplarOnCanceled: Boolean = false
+      )(implicit F: FlatMap[F], exemplar: prometheus4cats.Exemplar[F]): F[Unit] =
+        outcome match {
+          case Outcome.Succeeded(_) =>
+            if (recordExemplarOnSucceeded) exemplar.get.flatMap(recorder.onSucceeded((), _))
+            else recorder.onSucceeded((), None)
+          case Outcome.Errored(_) =>
+            if (recordExemplarOnErrored) exemplar.get.flatMap(recorder.onErrored((), _))
+            else recorder.onErrored((), None)
+          case Outcome.Canceled() =>
+            if (recordExemplarOnCanceled) exemplar.get.flatMap(recorder.onCanceled((), _))
+            else recorder.onCanceled((), None)
+        }
+    }
+
+    implicit class LabelledOutcomeRecorderExemplarSyntax[F[_], A](recorder: OutcomeRecorder.Exemplar[F, A])(implicit
+        ev: Unit =:!= A
+    ) {
+
+      /** Surround an operation and evaluate its outcome using an instance of [[cats.effect.kernel.MonadCancel]].
+        *
+        * The resulting metrics depend on the underlying implementation. See [[OutcomeRecorder.fromCounter]] and
+        * [[OutcomeRecorder.fromGauge]] for more details.
+        *
+        * @param fb
+        *   operation to be evaluated
+        * @param labels
+        *   labels to add to the underlying metric
+        */
+      final def surround[B](
+          fb: F[B],
+          labels: A,
+          recordExemplarOnSucceeded: Boolean = false,
+          recordExemplarOnErrored: Boolean = false,
+          recordExemplarOnCanceled: Boolean = false
+      )(implicit F: MonadCancelThrow[F], exemplar: prometheus4cats.Exemplar[F]): F[B] = fb.guaranteeCase(
+        recordOutcome(_, labels, recordExemplarOnSucceeded, recordExemplarOnErrored, recordExemplarOnCanceled)
+      )
+
+      /** Record the result of provided [[cats.effect.kernel.Outcome]]
+        *
+        * The resulting metrics depend on the underlying implementation. See [[OutcomeRecorder.fromCounter]] and
+        * [[OutcomeRecorder.fromGauge]] for more details.
+        *
+        * @param outcome
+        *   the [[cats.effect.kernel.Outcome]] to be recorded
+        * @param labels
+        *   labels to add to the underlying metric
+        */
+      final def recordOutcome[B, E](
+          outcome: Outcome[F, E, B],
+          labels: A,
+          recordExemplarOnSucceeded: Boolean = false,
+          recordExemplarOnErrored: Boolean = false,
+          recordExemplarOnCanceled: Boolean = false
+      )(implicit F: FlatMap[F], exemplar: prometheus4cats.Exemplar[F]): F[Unit] =
+        outcome match {
+          case Outcome.Succeeded(_) =>
+            if (recordExemplarOnSucceeded) exemplar.get.flatMap(recorder.onSucceeded(labels, _))
+            else recorder.onSucceeded(labels, None)
+          case Outcome.Errored(_) =>
+            if (recordExemplarOnErrored) exemplar.get.flatMap(recorder.onErrored(labels, _))
+            else recorder.onErrored(labels, None)
+          case Outcome.Canceled() =>
+            if (recordExemplarOnCanceled) exemplar.get.flatMap(recorder.onCanceled(labels, _))
+            else recorder.onCanceled(labels, None)
+        }
+
+      /** Surround an operation and evaluate its outcome using an instance of [[cats.effect.kernel.MonadCancel]],
+        * computing additional labels from the result.
+        *
+        * The resulting metrics depend on the underlying implementation. See [[OutcomeRecorder.fromCounter]] and
+        * [[OutcomeRecorder.fromGauge]] for more details.
+        *
+        * @param fb
+        *   operation to be evaluated
+        * @param labelsCanceled
+        *   labels to add when the operation is canceled
+        * @param labelsSuccess
+        *   function to compute labels from the result of `fb` when the operation is successful
+        * @param labelsError
+        *   function to compute labels from the exception that was raised if the operation is unsuccessful
+        */
+      final def surroundWithComputedLabels[B](
+          fb: F[B],
+          labelsCanceled: A,
+          recordExemplarOnSucceeded: Boolean = false,
+          recordExemplarOnErrored: Boolean = false,
+          recordExemplarOnCanceled: Boolean = false
+      )(labelsSuccess: B => A, labelsError: Throwable => A)(implicit
+          F: MonadCancelThrow[F],
+          exemplar: prometheus4cats.Exemplar[F]
+      ): F[B] =
+        fb.guaranteeCase(
+          recordOutcomeWithComputedLabels(
+            _,
+            labelsCanceled,
+            recordExemplarOnSucceeded,
+            recordExemplarOnErrored,
+            recordExemplarOnCanceled
+          )(labelsSuccess, labelsError)
+        )
+
+      /** Record the result of provided [[cats.effect.kernel.Outcome]] computing additional labels from the result.
+        *
+        * The resulting metrics depend on the underlying implementation. See [[OutcomeRecorder.fromCounter]] and
+        * [[OutcomeRecorder.fromGauge]] for more details.
+        *
+        * @param outcome
+        *   the [[cats.effect.kernel.Outcome]] to be recorded
+        * @param labelsCanceled
+        *   labels to add when the operation is canceled
+        * @param labelsSuccess
+        *   function to compute labels from the result of `fb` when the operation is successful
+        * @param labelsError
+        *   function to compute labels from the exception that was raised if the operation is unsuccessful
+        */
+      final def recordOutcomeWithComputedLabels[B, E](
+          outcome: Outcome[F, E, B],
+          labelsCanceled: A,
+          recordExemplarOnSucceeded: Boolean = false,
+          recordExemplarOnErrored: Boolean = false,
+          recordExemplarOnCanceled: Boolean = false
+      )(labelsSuccess: B => A, labelsError: E => A)(implicit
+          F: FlatMap[F],
+          exemplar: prometheus4cats.Exemplar[F]
+      ): F[Unit] =
+        outcome match {
+          case Outcome.Succeeded(fb) =>
+            fb.flatMap(b =>
+              if (recordExemplarOnSucceeded) exemplar.get.flatMap(recorder.onSucceeded(labelsSuccess(b), _))
+              else recorder.onSucceeded(labelsSuccess(b), None)
+            )
+          case Outcome.Errored(th) =>
+            if (recordExemplarOnErrored) exemplar.get.flatMap(recorder.onErrored(labelsError(th), _))
+            else recorder.onErrored(labelsError(th), None)
+          case Outcome.Canceled() =>
+            if (recordExemplarOnCanceled) exemplar.get.flatMap(recorder.onCanceled(labelsCanceled, _))
+            else recorder.onCanceled(labelsCanceled, None)
+        }
+
+    }
+
+    implicit def labelsContravariant[F[_]]: LabelsContravariant[OutcomeRecorder.Exemplar[F, *]] =
+      new LabelsContravariant[OutcomeRecorder.Exemplar[F, *]] {
+        override def contramapLabels[A, B](fa: OutcomeRecorder.Exemplar[F, A])(
+            f: B => A
+        ): OutcomeRecorder.Exemplar[F, B] =
+          fa.contramapLabels(f)
+      }
+
+    /** Create an [[OutcomeRecorder]] from a [[Counter]] instance, where its labels type is a tuple of the original
+      * labels of the counter and [[Status]].
+      *
+      * This works by incrementing a counter with a label value that corresponds to the value [[Status]] on each
+      * invocation.
+      *
+      * The best way to construct a counter based [[OutcomeRecorder]] is to use the `.asOutcomeRecorder` on the counter
+      * DSL provided by [[MetricFactory]].
+      *
+      * @return
+      *   an [[OutcomeRecorder.Aux]] that is annotated with the type of underlying metric, in this case [[Counter]]
+      */
+    def fromCounter[F[_], A, B](
+        counter: Counter[F, A, (B, Status)]
+    ): OutcomeRecorder.Exemplar.Aux[F, A, B, Counter] = new OutcomeRecorder.Exemplar[F, B] {
+      override type Metric = Counter[F, A, (B, Status)]
+
+      override protected def onCanceled(labels: B, exemplar: Option[prometheus4cats.Exemplar.Labels]): F[Unit] =
+        counter.incWithExemplar((labels, Status.Canceled), exemplar)
+
+      override protected def onErrored(labels: B, exemplar: Option[prometheus4cats.Exemplar.Labels]): F[Unit] =
+        counter.incWithExemplar((labels, Status.Errored), exemplar)
+
+      override protected def onSucceeded(labels: B, exemplar: Option[prometheus4cats.Exemplar.Labels]): F[Unit] =
+        counter.incWithExemplar((labels, Status.Succeeded), exemplar)
     }
   }
 

--- a/core/src/main/scala/prometheus4cats/OutcomeRecorder.scala
+++ b/core/src/main/scala/prometheus4cats/OutcomeRecorder.scala
@@ -24,7 +24,7 @@ import cats.{Show, ~>}
 /** A derived metric type that records the outcome of an operation. See [[OutcomeRecorder.fromCounter]] and
   * [[OutcomeRecorder.fromGauge]] for more information.
   */
-sealed abstract class OutcomeRecorder[F[_]: MonadCancelThrow] { self =>
+sealed abstract class OutcomeRecorder[F[_]: MonadCancelThrow, -A] extends Metric.Labelled[A] { self =>
   type Metric
 
   /** Surround an operation and evaluate its outcome using an instance of [[cats.effect.kernel.MonadCancel]].
@@ -32,10 +32,12 @@ sealed abstract class OutcomeRecorder[F[_]: MonadCancelThrow] { self =>
     * The resulting metrics depend on the underlying implementation. See [[OutcomeRecorder.fromCounter]] and
     * [[OutcomeRecorder.fromGauge]] for more details.
     *
-    * @param fa
+    * @param fb
     *   operation to be evaluated
+    * @param labels
+    *   labels to add to the underlying metric
     */
-  final def surround[A](fa: F[A]): F[A] = fa.guaranteeCase(recordOutcome[A, Throwable])
+  final def surround[B](fb: F[B], labels: A): F[B] = fb.guaranteeCase(recordOutcome(_, labels))
 
   /** Record the result of provided [[cats.effect.kernel.Outcome]]
     *
@@ -44,35 +46,89 @@ sealed abstract class OutcomeRecorder[F[_]: MonadCancelThrow] { self =>
     *
     * @param outcome
     *   the [[cats.effect.kernel.Outcome]] to be recorded
+    * @param labels
+    *   labels to add to the underlying metric
     */
-  final def recordOutcome[A, E](outcome: Outcome[F, E, A]): F[Unit] = outcome match {
-    case Outcome.Succeeded(_) => onSucceeded
-    case Outcome.Errored(_) => onErrored
-    case Outcome.Canceled() => onCanceled
-  }
+  final def recordOutcome[B, E](outcome: Outcome[F, E, B], labels: A): F[Unit] =
+    outcome match {
+      case Outcome.Succeeded(_) => onSucceeded(labels)
+      case Outcome.Errored(_) => onErrored(labels)
+      case Outcome.Canceled() => onCanceled(labels)
+    }
 
-  protected def onCanceled: F[Unit]
+  /** Surround an operation and evaluate its outcome using an instance of [[cats.effect.kernel.MonadCancel]], computing
+    * additional labels from the result.
+    *
+    * The resulting metrics depend on the underlying implementation. See [[OutcomeRecorder.fromCounter]] and
+    * [[OutcomeRecorder.fromGauge]] for more details.
+    *
+    * @param fb
+    *   operation to be evaluated
+    * @param labelsCanceled
+    *   labels to add when the operation is canceled
+    * @param labelsSuccess
+    *   function to compute labels from the result of `fb` when the operation is successful
+    * @param labelsError
+    *   function to compute labels from the exception that was raised if the operation is unsuccessful
+    */
+  final def surroundWithComputedLabels[B](
+      fb: F[B],
+      labelsCanceled: A
+  )(labelsSuccess: B => A, labelsError: Throwable => A): F[B] =
+    fb.guaranteeCase(recordOutcomeWithComputedLabels(_, labelsCanceled)(labelsSuccess, labelsError))
 
-  protected def onErrored: F[Unit]
+  /** Record the result of provided [[cats.effect.kernel.Outcome]] computing additional labels from the result.
+    *
+    * The resulting metrics depend on the underlying implementation. See [[OutcomeRecorder.fromCounter]] and
+    * [[OutcomeRecorder.fromGauge]] for more details.
+    *
+    * @param outcome
+    *   the [[cats.effect.kernel.Outcome]] to be recorded
+    * @param labelsCanceled
+    *   labels to add when the operation is canceled
+    * @param labelsSuccess
+    *   function to compute labels from the result of `fb` when the operation is successful
+    * @param labelsError
+    *   function to compute labels from the exception that was raised if the operation is unsuccessful
+    */
+  final def recordOutcomeWithComputedLabels[B, E](
+      outcome: Outcome[F, E, B],
+      labelsCanceled: A
+  )(labelsSuccess: B => A, labelsError: E => A): F[Unit] =
+    outcome match {
+      case Outcome.Succeeded(fb) => fb.flatMap(b => onSucceeded(labelsSuccess(b)))
+      case Outcome.Errored(th) => onErrored(labelsError(th))
+      case Outcome.Canceled() => onCanceled(labelsCanceled)
+    }
 
-  protected def onSucceeded: F[Unit]
+  protected def onCanceled(labels: A): F[Unit]
 
-  def mapK[G[_]: MonadCancelThrow](fk: F ~> G): OutcomeRecorder[G] = new OutcomeRecorder[G] {
+  protected def onErrored(labels: A): F[Unit]
+
+  protected def onSucceeded(labels: A): F[Unit]
+
+  def contramapLabels[B](f: B => A): OutcomeRecorder[F, B] = new OutcomeRecorder[F, B] {
     override type Metric = self.Metric
 
-    override protected def onCanceled: G[Unit] = fk(self.onCanceled)
+    override protected def onCanceled(labels: B): F[Unit] = self.onCanceled(f(labels))
 
-    override protected def onErrored: G[Unit] = fk(self.onErrored)
+    override protected def onErrored(labels: B): F[Unit] = self.onErrored(f(labels))
 
-    override protected def onSucceeded: G[Unit] = fk(self.onSucceeded)
+    override protected def onSucceeded(labels: B): F[Unit] = self.onSucceeded(f(labels))
+  }
+
+  def mapK[G[_]: MonadCancelThrow](fk: F ~> G): OutcomeRecorder[G, A] = new OutcomeRecorder[G, A] {
+    override type Metric = self.Metric
+
+    override protected def onCanceled(labels: A): G[Unit] = fk(self.onCanceled(labels))
+
+    override protected def onErrored(labels: A): G[Unit] = fk(self.onErrored(labels))
+
+    override protected def onSucceeded(labels: A): G[Unit] = fk(self.onSucceeded(labels))
   }
 }
 
 object OutcomeRecorder {
-
-  type Aux[F[_], A, M[_[_], _, _]] = OutcomeRecorder[F] {
-    type Metric = M[F, A, Status]
-  }
 
   sealed trait Status
 
@@ -90,7 +146,18 @@ object OutcomeRecorder {
     }
   }
 
-  /** Create an [[OutcomeRecorder]] from a [[Counter]] instance, where its only label type is [[Status]].
+  type Aux[F[_], A, B, M[_[_], _, _]] = OutcomeRecorder[F, B] {
+    type Metric = M[F, A, (B, Status)]
+  }
+
+  implicit def labelsContravariant[F[_]]: LabelsContravariant[OutcomeRecorder[F, *]] =
+    new LabelsContravariant[OutcomeRecorder[F, *]] {
+      override def contramapLabels[A, B](fa: OutcomeRecorder[F, A])(f: B => A): OutcomeRecorder[F, B] =
+        fa.contramapLabels(f)
+    }
+
+  /** Create an [[OutcomeRecorder]] from a [[Counter]] instance, where its labels type is a tuple of the original labels
+    * of the counter and [[Status]].
     *
     * This works by incrementing a counter with a label value that corresponds to the value [[Status]] on each
     * invocation.
@@ -101,19 +168,20 @@ object OutcomeRecorder {
     * @return
     *   an [[OutcomeRecorder.Aux]] that is annotated with the type of underlying metric, in this case [[Counter]]
     */
-  def fromCounter[F[_]: MonadCancelThrow, A](
-      counter: Counter[F, A, Status]
-  ): OutcomeRecorder.Aux[F, A, Counter] = new OutcomeRecorder[F] {
-    override type Metric = Counter[F, A, Status]
+  def fromCounter[F[_]: MonadCancelThrow, A, B](
+      counter: Counter[F, A, (B, Status)]
+  ): OutcomeRecorder.Aux[F, A, B, Counter] = new OutcomeRecorder[F, B] {
+    override type Metric = Counter[F, A, (B, Status)]
 
-    override protected val onCanceled: F[Unit] = counter.inc(Status.Canceled)
+    override protected def onCanceled(labels: B): F[Unit] = counter.inc((labels, Status.Canceled))
 
-    override protected val onErrored: F[Unit] = counter.inc(Status.Errored)
+    override protected def onErrored(labels: B): F[Unit] = counter.inc((labels, Status.Errored))
 
-    override protected val onSucceeded: F[Unit] = counter.inc(Status.Succeeded)
+    override protected def onSucceeded(labels: B): F[Unit] = counter.inc((labels, Status.Succeeded))
   }
 
-  /** Create an [[OutcomeRecorder]] from a [[Gauge]] instance, where its only label type is [[Status]].
+  /** Create an [[OutcomeRecorder]] from a [[Gauge]] instance, where its only label type is a tuple of the original
+    * labels of the counter and [[Status]].
     *
     * This works by setting gauge with a label value that corresponds to the value of [[Status]] to `1` on each
     * invocation, while the other statuses are set to `0`.
@@ -124,55 +192,51 @@ object OutcomeRecorder {
     * @return
     *   an [[OutcomeRecorder.Aux]] that is annotated with the type of underlying metric, in this case [[Gauge]]
     */
-  def fromGauge[F[_]: MonadCancelThrow, A](
-      gauge: Gauge[F, A, Status]
-  ): OutcomeRecorder.Aux[F, A, Gauge] =
-    new OutcomeRecorder[F] {
-      override type Metric = Gauge[F, A, Status]
+  def fromGauge[F[_]: MonadCancelThrow, A, B](
+      gauge: Gauge[F, A, (B, Status)]
+  ): OutcomeRecorder.Aux[F, A, B, Gauge] =
+    new OutcomeRecorder[F, B] {
+      override type Metric = Gauge[F, A, (B, Status)]
 
-      private def setOutcome(status: Status): F[Unit] =
+      private def setOutcome(labels: B, status: Status): F[Unit] =
         (
-          gauge.reset(Status.Succeeded) >> gauge.reset(Status.Canceled) >> gauge.reset(Status.Errored) >>
-            gauge.inc(status)
+          gauge.reset(labels -> Status.Succeeded) >> gauge.reset(labels -> Status.Canceled) >>
+            gauge.reset(labels -> Status.Errored) >> gauge.inc(labels -> status)
         ).uncancelable
 
-      override protected val onCanceled: F[Unit] = setOutcome(Status.Canceled)
+      override protected def onCanceled(labels: B): F[Unit] = setOutcome(labels, Status.Canceled)
 
-      override protected val onErrored: F[Unit] = setOutcome(Status.Errored)
+      override protected def onErrored(labels: B): F[Unit] = setOutcome(labels, Status.Errored)
 
-      override protected val onSucceeded: F[Unit] = setOutcome(Status.Succeeded)
+      override protected def onSucceeded(labels: B): F[Unit] = setOutcome(labels, Status.Succeeded)
     }
 
-  sealed abstract class Exemplar[F[_]: MonadCancelThrow] {
+  /** A derived metric type that records the outcome of an operation. See [[OutcomeRecorder.fromCounter]] and
+    * [[OutcomeRecorder.fromGauge]] for more information.
+    */
+  sealed abstract class Exemplar[F[_]: MonadCancelThrow, -A] extends Metric.Labelled[A] {
     self =>
     type Metric
 
     /** Surround an operation and evaluate its outcome using an instance of [[cats.effect.kernel.MonadCancel]].
       *
-      * The resulting metrics depend on the underlying implementation. See [[OutcomeRecorder.Exemplar.fromCounter]] and
+      * The resulting metrics depend on the underlying implementation. See [[OutcomeRecorder.fromCounter]] and
+      * [[OutcomeRecorder.fromGauge]] for more details.
       *
-      * @param fa
+      * @param fb
       *   operation to be evaluated
+      * @param labels
+      *   labels to add to the underlying metric
       */
-    final def surround[A](
-        fa: F[A],
+    final def surround[B](
+        fb: F[B],
+        labels: A,
         recordExemplarOnSucceeded: Boolean = false,
         recordExemplarOnErrored: Boolean = false,
         recordExemplarOnCanceled: Boolean = false
-    )(implicit exemplar: prometheus4cats.Exemplar[F]): F[A] =
-      fa.guaranteeCase(
-        recordOutcome[A, Throwable](_, recordExemplarOnSucceeded, recordExemplarOnErrored, recordExemplarOnCanceled)
-      )
-
-    final def surroundWithExemplar[A](
-        fa: F[A],
-        exemplarOnSucceeded: Option[prometheus4cats.Exemplar.Labels] = None,
-        exemplarOnErrored: Option[prometheus4cats.Exemplar.Labels] = None,
-        exemplarOnCanceled: Option[prometheus4cats.Exemplar.Labels] = None
-    ): F[A] =
-      fa.guaranteeCase(
-        recordOutcomeWithExemplar[A, Throwable](_, exemplarOnSucceeded, exemplarOnErrored, exemplarOnCanceled)
-      )
+    )(implicit exemplar: prometheus4cats.Exemplar[F]): F[B] = fb.guaranteeCase(
+      recordOutcome(_, labels, recordExemplarOnSucceeded, recordExemplarOnErrored, recordExemplarOnCanceled)
+    )
 
     /** Record the result of provided [[cats.effect.kernel.Outcome]]
       *
@@ -181,129 +245,33 @@ object OutcomeRecorder {
       *
       * @param outcome
       *   the [[cats.effect.kernel.Outcome]] to be recorded
+      * @param labels
+      *   labels to add to the underlying metric
       */
-    final def recordOutcome[A, E](
-        outcome: Outcome[F, E, A],
+    final def recordOutcome[B, E](
+        outcome: Outcome[F, E, B],
+        labels: A,
         recordExemplarOnSucceeded: Boolean = false,
         recordExemplarOnErrored: Boolean = false,
         recordExemplarOnCanceled: Boolean = false
-    )(implicit exemplar: prometheus4cats.Exemplar[F]): F[Unit] = outcome match {
-      case Outcome.Succeeded(_) =>
-        if (recordExemplarOnSucceeded) exemplar.get.flatMap(onSucceeded) else onSucceeded(None)
-      case Outcome.Errored(_) =>
-        if (recordExemplarOnErrored) exemplar.get.flatMap(onErrored) else onErrored(None)
-      case Outcome.Canceled() =>
-        if (recordExemplarOnCanceled) exemplar.get.flatMap(onCanceled) else onCanceled(None)
-    }
-
-    final def recordOutcomeWithExemplar[A, E](
-        outcome: Outcome[F, E, A],
-        exemplarOnSucceeded: Option[prometheus4cats.Exemplar.Labels] = None,
-        exemplarOnErrored: Option[prometheus4cats.Exemplar.Labels] = None,
-        exemplarOnCanceled: Option[prometheus4cats.Exemplar.Labels] = None
-    ): F[Unit] = outcome match {
-      case Outcome.Succeeded(_) =>
-        onSucceeded(exemplarOnSucceeded)
-      case Outcome.Errored(_) =>
-        onErrored(exemplarOnErrored)
-      case Outcome.Canceled() =>
-        onCanceled(exemplarOnCanceled)
-    }
-
-    protected def onCanceled(exemplar: Option[prometheus4cats.Exemplar.Labels]): F[Unit]
-
-    protected def onErrored(exemplar: Option[prometheus4cats.Exemplar.Labels]): F[Unit]
-
-    protected def onSucceeded(exemplar: Option[prometheus4cats.Exemplar.Labels]): F[Unit]
-
-    def mapK[G[_]: MonadCancelThrow](fk: F ~> G): OutcomeRecorder.Exemplar[G] = new OutcomeRecorder.Exemplar[G] {
-      override type Metric = self.Metric
-
-      override protected def onCanceled(exemplar: Option[prometheus4cats.Exemplar.Labels]): G[Unit] = fk(
-        self.onCanceled(exemplar)
-      )
-
-      override protected def onErrored(exemplar: Option[prometheus4cats.Exemplar.Labels]): G[Unit] = fk(
-        self.onErrored(exemplar)
-      )
-
-      override protected def onSucceeded(exemplar: Option[prometheus4cats.Exemplar.Labels]): G[Unit] = fk(
-        self.onSucceeded(exemplar)
-      )
-    }
-  }
-  object Exemplar {
-    type Aux[F[_], A, M[_[_], _, _]] = OutcomeRecorder.Exemplar[F] {
-      type Metric = M[F, A, Status]
-    }
-
-    /** Create an [[OutcomeRecorder]] from a [[Counter]] instance, where its only label type is [[Status]].
-      *
-      * This works by incrementing a counter with a label value that corresponds to the value [[Status]] on each
-      * invocation.
-      *
-      * The best way to construct a counter based [[OutcomeRecorder]] is to use the `.asOutcomeRecorder` on the counter
-      * DSL provided by [[MetricFactory]].
-      *
-      * @return
-      *   an [[OutcomeRecorder.Aux]] that is annotated with the type of underlying metric, in this case [[Counter]]
-      */
-    def fromCounter[F[_]: MonadCancelThrow, A](
-        counter: Counter[F, A, Status]
-    ): OutcomeRecorder.Exemplar.Aux[F, A, Counter] = new OutcomeRecorder.Exemplar[F] {
-      override type Metric = Counter[F, A, Status]
-
-      override protected def onCanceled(exemplar: Option[prometheus4cats.Exemplar.Labels]): F[Unit] =
-        counter.incWithExemplar(Status.Canceled, exemplar)
-
-      override protected def onErrored(exemplar: Option[prometheus4cats.Exemplar.Labels]): F[Unit] =
-        counter.incWithExemplar(Status.Errored, exemplar)
-
-      override protected def onSucceeded(exemplar: Option[prometheus4cats.Exemplar.Labels]): F[Unit] =
-        counter.incWithExemplar(Status.Succeeded, exemplar)
-    }
-  }
-
-  /** A derived metric type that records the outcome of an operation. See [[OutcomeRecorder.Labelled.fromCounter]] and
-    * [[OutcomeRecorder.Labelled.fromGauge]] for more information.
-    */
-  sealed abstract class Labelled[F[_]: MonadCancelThrow, -A] extends Metric.Labelled[A] { self =>
-    type Metric
-
-    /** Surround an operation and evaluate its outcome using an instance of [[cats.effect.kernel.MonadCancel]].
-      *
-      * The resulting metrics depend on the underlying implementation. See [[OutcomeRecorder.Labelled.fromCounter]] and
-      * [[OutcomeRecorder.Labelled.fromGauge]] for more details.
-      *
-      * @param fb
-      *   operation to be evaluated
-      * @param labels
-      *   labels to add to the underlying metric
-      */
-    final def surround[B](fb: F[B], labels: A): F[B] = fb.guaranteeCase(recordOutcome(_, labels))
-
-    /** Record the result of provided [[cats.effect.kernel.Outcome]]
-      *
-      * The resulting metrics depend on the underlying implementation. See [[OutcomeRecorder.Labelled.fromCounter]] and
-      * [[OutcomeRecorder.Labelled.fromGauge]] for more details.
-      *
-      * @param outcome
-      *   the [[cats.effect.kernel.Outcome]] to be recorded
-      * @param labels
-      *   labels to add to the underlying metric
-      */
-    final def recordOutcome[B, E](outcome: Outcome[F, E, B], labels: A): F[Unit] =
+    )(implicit exemplar: prometheus4cats.Exemplar[F]): F[Unit] =
       outcome match {
-        case Outcome.Succeeded(_) => onSucceeded(labels)
-        case Outcome.Errored(_) => onErrored(labels)
-        case Outcome.Canceled() => onCanceled(labels)
+        case Outcome.Succeeded(_) =>
+          if (recordExemplarOnSucceeded) exemplar.get.flatMap(onSucceeded(labels, _))
+          else onSucceeded(labels, None)
+        case Outcome.Errored(_) =>
+          if (recordExemplarOnErrored) exemplar.get.flatMap(onErrored(labels, _))
+          else onErrored(labels, None)
+        case Outcome.Canceled() =>
+          if (recordExemplarOnCanceled) exemplar.get.flatMap(onCanceled(labels, _))
+          else onCanceled(labels, None)
       }
 
     /** Surround an operation and evaluate its outcome using an instance of [[cats.effect.kernel.MonadCancel]],
       * computing additional labels from the result.
       *
-      * The resulting metrics depend on the underlying implementation. See [[OutcomeRecorder.Labelled.fromCounter]] and
-      * [[OutcomeRecorder.Labelled.fromGauge]] for more details.
+      * The resulting metrics depend on the underlying implementation. See [[OutcomeRecorder.fromCounter]] and
+      * [[OutcomeRecorder.fromGauge]] for more details.
       *
       * @param fb
       *   operation to be evaluated
@@ -316,14 +284,25 @@ object OutcomeRecorder {
       */
     final def surroundWithComputedLabels[B](
         fb: F[B],
-        labelsCanceled: A
-    )(labelsSuccess: B => A, labelsError: Throwable => A): F[B] =
-      fb.guaranteeCase(recordOutcomeWithComputedLabels(_, labelsCanceled)(labelsSuccess, labelsError))
+        labelsCanceled: A,
+        recordExemplarOnSucceeded: Boolean = false,
+        recordExemplarOnErrored: Boolean = false,
+        recordExemplarOnCanceled: Boolean = false
+    )(labelsSuccess: B => A, labelsError: Throwable => A)(implicit exemplar: prometheus4cats.Exemplar[F]): F[B] =
+      fb.guaranteeCase(
+        recordOutcomeWithComputedLabels(
+          _,
+          labelsCanceled,
+          recordExemplarOnSucceeded,
+          recordExemplarOnErrored,
+          recordExemplarOnCanceled
+        )(labelsSuccess, labelsError)
+      )
 
     /** Record the result of provided [[cats.effect.kernel.Outcome]] computing additional labels from the result.
       *
-      * The resulting metrics depend on the underlying implementation. See [[OutcomeRecorder.Labelled.fromCounter]] and
-      * [[OutcomeRecorder.Labelled.fromGauge]] for more details.
+      * The resulting metrics depend on the underlying implementation. See [[OutcomeRecorder.fromCounter]] and
+      * [[OutcomeRecorder.fromGauge]] for more details.
       *
       * @param outcome
       *   the [[cats.effect.kernel.Outcome]] to be recorded
@@ -336,265 +315,59 @@ object OutcomeRecorder {
       */
     final def recordOutcomeWithComputedLabels[B, E](
         outcome: Outcome[F, E, B],
-        labelsCanceled: A
-    )(labelsSuccess: B => A, labelsError: E => A): F[Unit] =
+        labelsCanceled: A,
+        recordExemplarOnSucceeded: Boolean = false,
+        recordExemplarOnErrored: Boolean = false,
+        recordExemplarOnCanceled: Boolean = false
+    )(labelsSuccess: B => A, labelsError: E => A)(implicit exemplar: prometheus4cats.Exemplar[F]): F[Unit] =
       outcome match {
-        case Outcome.Succeeded(fb) => fb.flatMap(b => onSucceeded(labelsSuccess(b)))
-        case Outcome.Errored(th) => onErrored(labelsError(th))
-        case Outcome.Canceled() => onCanceled(labelsCanceled)
+        case Outcome.Succeeded(fb) =>
+          fb.flatMap(b =>
+            if (recordExemplarOnSucceeded) exemplar.get.flatMap(onSucceeded(labelsSuccess(b), _))
+            else onSucceeded(labelsSuccess(b), None)
+          )
+        case Outcome.Errored(th) =>
+          if (recordExemplarOnErrored) exemplar.get.flatMap(onErrored(labelsError(th), _))
+          else onErrored(labelsError(th), None)
+        case Outcome.Canceled() =>
+          if (recordExemplarOnCanceled) exemplar.get.flatMap(onCanceled(labelsCanceled, _))
+          else onCanceled(labelsCanceled, None)
       }
 
-    protected def onCanceled(labels: A): F[Unit]
+    protected def onCanceled(labels: A, exemplar: Option[prometheus4cats.Exemplar.Labels]): F[Unit]
 
-    protected def onErrored(labels: A): F[Unit]
+    protected def onErrored(labels: A, exemplar: Option[prometheus4cats.Exemplar.Labels]): F[Unit]
 
-    protected def onSucceeded(labels: A): F[Unit]
+    protected def onSucceeded(labels: A, exemplar: Option[prometheus4cats.Exemplar.Labels]): F[Unit]
 
-    def contramapLabels[B](f: B => A): Labelled[F, B] = new Labelled[F, B] {
+    def contramapLabels[B](f: B => A): Exemplar[F, B] = new Exemplar[F, B] {
       override type Metric = self.Metric
 
-      override protected def onCanceled(labels: B): F[Unit] = self.onCanceled(f(labels))
+      override protected def onCanceled(labels: B, exemplar: Option[prometheus4cats.Exemplar.Labels]): F[Unit] =
+        self.onCanceled(f(labels), exemplar)
 
-      override protected def onErrored(labels: B): F[Unit] = self.onErrored(f(labels))
+      override protected def onErrored(labels: B, exemplar: Option[prometheus4cats.Exemplar.Labels]): F[Unit] =
+        self.onErrored(f(labels), exemplar)
 
-      override protected def onSucceeded(labels: B): F[Unit] = self.onSucceeded(f(labels))
+      override protected def onSucceeded(labels: B, exemplar: Option[prometheus4cats.Exemplar.Labels]): F[Unit] =
+        self.onSucceeded(f(labels), exemplar)
     }
 
-    def mapK[G[_]: MonadCancelThrow](fk: F ~> G): Labelled[G, A] = new Labelled[G, A] {
+    def mapK[G[_]: MonadCancelThrow](fk: F ~> G): Exemplar[G, A] = new Exemplar[G, A] {
       override type Metric = self.Metric
 
-      override protected def onCanceled(labels: A): G[Unit] = fk(self.onCanceled(labels))
-
-      override protected def onErrored(labels: A): G[Unit] = fk(self.onErrored(labels))
-
-      override protected def onSucceeded(labels: A): G[Unit] = fk(self.onSucceeded(labels))
-    }
-  }
-
-  object Labelled {
-    type Aux[F[_], A, B, M[_[_], _, _]] = OutcomeRecorder.Labelled[F, B] {
-      type Metric = M[F, A, (B, Status)]
-    }
-
-    implicit def labelsContravariant[F[_]]: LabelsContravariant[Labelled[F, *]] =
-      new LabelsContravariant[Labelled[F, *]] {
-        override def contramapLabels[A, B](fa: Labelled[F, A])(f: B => A): Labelled[F, B] = fa.contramapLabels(f)
-      }
-
-    /** Create an [[OutcomeRecorder]] from a [[Counter]] instance, where its labels type is a tuple of the original
-      * labels of the counter and [[Status]].
-      *
-      * This works by incrementing a counter with a label value that corresponds to the value [[Status]] on each
-      * invocation.
-      *
-      * The best way to construct a counter based [[OutcomeRecorder]] is to use the `.asOutcomeRecorder` on the counter
-      * DSL provided by [[MetricFactory]].
-      *
-      * @return
-      *   an [[OutcomeRecorder.Labelled.Aux]] that is annotated with the type of underlying metric, in this case
-      *   [[Counter]]
-      */
-    def fromCounter[F[_]: MonadCancelThrow, A, B](
-        counter: Counter[F, A, (B, Status)]
-    ): OutcomeRecorder.Labelled.Aux[F, A, B, Counter] = new OutcomeRecorder.Labelled[F, B] {
-      override type Metric = Counter[F, A, (B, Status)]
-
-      override protected def onCanceled(labels: B): F[Unit] = counter.inc((labels, Status.Canceled))
-
-      override protected def onErrored(labels: B): F[Unit] = counter.inc((labels, Status.Errored))
-
-      override protected def onSucceeded(labels: B): F[Unit] = counter.inc((labels, Status.Succeeded))
-    }
-
-    /** Create an [[OutcomeRecorder]] from a [[Gauge]] instance, where its only label type is a tuple of the original
-      * labels of the counter and [[Status]].
-      *
-      * This works by setting gauge with a label value that corresponds to the value of [[Status]] to `1` on each
-      * invocation, while the other statuses are set to `0`.
-      *
-      * The best way to construct a gauge based [[OutcomeRecorder]] is to use the `.asOutcomeRecorder` on the gauge DSL
-      * provided by [[MetricFactory]].
-      *
-      * @return
-      *   an [[OutcomeRecorder.Labelled.Aux]] that is annotated with the type of underlying metric, in this case
-      *   [[Gauge]]
-      */
-    def fromGauge[F[_]: MonadCancelThrow, A, B](
-        gauge: Gauge[F, A, (B, Status)]
-    ): OutcomeRecorder.Labelled.Aux[F, A, B, Gauge] =
-      new OutcomeRecorder.Labelled[F, B] {
-        override type Metric = Gauge[F, A, (B, Status)]
-
-        private def setOutcome(labels: B, status: Status): F[Unit] =
-          (
-            gauge.reset(labels -> Status.Succeeded) >> gauge.reset(labels -> Status.Canceled) >>
-              gauge.reset(labels -> Status.Errored) >> gauge.inc(labels -> status)
-          ).uncancelable
-
-        override protected def onCanceled(labels: B): F[Unit] = setOutcome(labels, Status.Canceled)
-
-        override protected def onErrored(labels: B): F[Unit] = setOutcome(labels, Status.Errored)
-
-        override protected def onSucceeded(labels: B): F[Unit] = setOutcome(labels, Status.Succeeded)
-      }
-
-    /** A derived metric type that records the outcome of an operation. See [[OutcomeRecorder.Labelled.fromCounter]] and
-      * [[OutcomeRecorder.Labelled.fromGauge]] for more information.
-      */
-    sealed abstract class Exemplar[F[_]: MonadCancelThrow, -A] extends Metric.Labelled[A] {
-      self =>
-      type Metric
-
-      /** Surround an operation and evaluate its outcome using an instance of [[cats.effect.kernel.MonadCancel]].
-        *
-        * The resulting metrics depend on the underlying implementation. See [[OutcomeRecorder.Labelled.fromCounter]]
-        * and [[OutcomeRecorder.Labelled.fromGauge]] for more details.
-        *
-        * @param fb
-        *   operation to be evaluated
-        * @param labels
-        *   labels to add to the underlying metric
-        */
-      final def surround[B](
-          fb: F[B],
-          labels: A,
-          recordExemplarOnSucceeded: Boolean = false,
-          recordExemplarOnErrored: Boolean = false,
-          recordExemplarOnCanceled: Boolean = false
-      )(implicit exemplar: prometheus4cats.Exemplar[F]): F[B] = fb.guaranteeCase(
-        recordOutcome(_, labels, recordExemplarOnSucceeded, recordExemplarOnErrored, recordExemplarOnCanceled)
+      override protected def onCanceled(labels: A, exemplar: Option[prometheus4cats.Exemplar.Labels]): G[Unit] = fk(
+        self.onCanceled(labels, exemplar)
       )
 
-      /** Record the result of provided [[cats.effect.kernel.Outcome]]
-        *
-        * The resulting metrics depend on the underlying implementation. See [[OutcomeRecorder.Labelled.fromCounter]]
-        * and [[OutcomeRecorder.Labelled.fromGauge]] for more details.
-        *
-        * @param outcome
-        *   the [[cats.effect.kernel.Outcome]] to be recorded
-        * @param labels
-        *   labels to add to the underlying metric
-        */
-      final def recordOutcome[B, E](
-          outcome: Outcome[F, E, B],
-          labels: A,
-          recordExemplarOnSucceeded: Boolean = false,
-          recordExemplarOnErrored: Boolean = false,
-          recordExemplarOnCanceled: Boolean = false
-      )(implicit exemplar: prometheus4cats.Exemplar[F]): F[Unit] =
-        outcome match {
-          case Outcome.Succeeded(_) =>
-            if (recordExemplarOnSucceeded) exemplar.get.flatMap(onSucceeded(labels, _))
-            else onSucceeded(labels, None)
-          case Outcome.Errored(_) =>
-            if (recordExemplarOnErrored) exemplar.get.flatMap(onErrored(labels, _))
-            else onErrored(labels, None)
-          case Outcome.Canceled() =>
-            if (recordExemplarOnCanceled) exemplar.get.flatMap(onCanceled(labels, _))
-            else onCanceled(labels, None)
-        }
+      override protected def onErrored(labels: A, exemplar: Option[prometheus4cats.Exemplar.Labels]): G[Unit] = fk(
+        self.onErrored(labels, exemplar)
+      )
 
-      /** Surround an operation and evaluate its outcome using an instance of [[cats.effect.kernel.MonadCancel]],
-        * computing additional labels from the result.
-        *
-        * The resulting metrics depend on the underlying implementation. See [[OutcomeRecorder.Labelled.fromCounter]]
-        * and [[OutcomeRecorder.Labelled.fromGauge]] for more details.
-        *
-        * @param fb
-        *   operation to be evaluated
-        * @param labelsCanceled
-        *   labels to add when the operation is canceled
-        * @param labelsSuccess
-        *   function to compute labels from the result of `fb` when the operation is successful
-        * @param labelsError
-        *   function to compute labels from the exception that was raised if the operation is unsuccessful
-        */
-      final def surroundWithComputedLabels[B](
-          fb: F[B],
-          labelsCanceled: A,
-          recordExemplarOnSucceeded: Boolean = false,
-          recordExemplarOnErrored: Boolean = false,
-          recordExemplarOnCanceled: Boolean = false
-      )(labelsSuccess: B => A, labelsError: Throwable => A)(implicit exemplar: prometheus4cats.Exemplar[F]): F[B] =
-        fb.guaranteeCase(
-          recordOutcomeWithComputedLabels(
-            _,
-            labelsCanceled,
-            recordExemplarOnSucceeded,
-            recordExemplarOnErrored,
-            recordExemplarOnCanceled
-          )(labelsSuccess, labelsError)
-        )
-
-      /** Record the result of provided [[cats.effect.kernel.Outcome]] computing additional labels from the result.
-        *
-        * The resulting metrics depend on the underlying implementation. See [[OutcomeRecorder.Labelled.fromCounter]]
-        * and [[OutcomeRecorder.Labelled.fromGauge]] for more details.
-        *
-        * @param outcome
-        *   the [[cats.effect.kernel.Outcome]] to be recorded
-        * @param labelsCanceled
-        *   labels to add when the operation is canceled
-        * @param labelsSuccess
-        *   function to compute labels from the result of `fb` when the operation is successful
-        * @param labelsError
-        *   function to compute labels from the exception that was raised if the operation is unsuccessful
-        */
-      final def recordOutcomeWithComputedLabels[B, E](
-          outcome: Outcome[F, E, B],
-          labelsCanceled: A,
-          recordExemplarOnSucceeded: Boolean = false,
-          recordExemplarOnErrored: Boolean = false,
-          recordExemplarOnCanceled: Boolean = false
-      )(labelsSuccess: B => A, labelsError: E => A)(implicit exemplar: prometheus4cats.Exemplar[F]): F[Unit] =
-        outcome match {
-          case Outcome.Succeeded(fb) =>
-            fb.flatMap(b =>
-              if (recordExemplarOnSucceeded) exemplar.get.flatMap(onSucceeded(labelsSuccess(b), _))
-              else onSucceeded(labelsSuccess(b), None)
-            )
-          case Outcome.Errored(th) =>
-            if (recordExemplarOnErrored) exemplar.get.flatMap(onErrored(labelsError(th), _))
-            else onErrored(labelsError(th), None)
-          case Outcome.Canceled() =>
-            if (recordExemplarOnCanceled) exemplar.get.flatMap(onCanceled(labelsCanceled, _))
-            else onCanceled(labelsCanceled, None)
-        }
-
-      protected def onCanceled(labels: A, exemplar: Option[prometheus4cats.Exemplar.Labels]): F[Unit]
-
-      protected def onErrored(labels: A, exemplar: Option[prometheus4cats.Exemplar.Labels]): F[Unit]
-
-      protected def onSucceeded(labels: A, exemplar: Option[prometheus4cats.Exemplar.Labels]): F[Unit]
-
-      def contramapLabels[B](f: B => A): Labelled.Exemplar[F, B] = new Labelled.Exemplar[F, B] {
-        override type Metric = self.Metric
-
-        override protected def onCanceled(labels: B, exemplar: Option[prometheus4cats.Exemplar.Labels]): F[Unit] =
-          self.onCanceled(f(labels), exemplar)
-
-        override protected def onErrored(labels: B, exemplar: Option[prometheus4cats.Exemplar.Labels]): F[Unit] =
-          self.onErrored(f(labels), exemplar)
-
-        override protected def onSucceeded(labels: B, exemplar: Option[prometheus4cats.Exemplar.Labels]): F[Unit] =
-          self.onSucceeded(f(labels), exemplar)
-      }
-
-      def mapK[G[_]: MonadCancelThrow](fk: F ~> G): Labelled.Exemplar[G, A] = new Labelled.Exemplar[G, A] {
-        override type Metric = self.Metric
-
-        override protected def onCanceled(labels: A, exemplar: Option[prometheus4cats.Exemplar.Labels]): G[Unit] = fk(
-          self.onCanceled(labels, exemplar)
-        )
-
-        override protected def onErrored(labels: A, exemplar: Option[prometheus4cats.Exemplar.Labels]): G[Unit] = fk(
-          self.onErrored(labels, exemplar)
-        )
-
-        override protected def onSucceeded(labels: A, exemplar: Option[prometheus4cats.Exemplar.Labels]): G[Unit] = fk(
-          self.onSucceeded(labels, exemplar)
-        )
-      }
+      override protected def onSucceeded(labels: A, exemplar: Option[prometheus4cats.Exemplar.Labels]): G[Unit] = fk(
+        self.onSucceeded(labels, exemplar)
+      )
     }
   }
+
 }

--- a/core/src/main/scala/prometheus4cats/OutcomeRecorder.scala
+++ b/core/src/main/scala/prometheus4cats/OutcomeRecorder.scala
@@ -90,7 +90,7 @@ object OutcomeRecorder {
     }
   }
 
-  /** Create an [[OutcomeRecorder]] from a [[Counter.Labelled]] instance, where its only label type is [[Status]].
+  /** Create an [[OutcomeRecorder]] from a [[Counter]] instance, where its only label type is [[Status]].
     *
     * This works by incrementing a counter with a label value that corresponds to the value [[Status]] on each
     * invocation.
@@ -99,13 +99,12 @@ object OutcomeRecorder {
     * DSL provided by [[MetricFactory]].
     *
     * @return
-    *   an [[OutcomeRecorder.Aux]] that is annotated with the type of underlying metric, in this case
-    *   [[Counter.Labelled]]
+    *   an [[OutcomeRecorder.Aux]] that is annotated with the type of underlying metric, in this case [[Counter]]
     */
   def fromCounter[F[_]: MonadCancelThrow, A](
-      counter: Counter.Labelled[F, A, Status]
-  ): OutcomeRecorder.Aux[F, A, Counter.Labelled] = new OutcomeRecorder[F] {
-    override type Metric = Counter.Labelled[F, A, Status]
+      counter: Counter[F, A, Status]
+  ): OutcomeRecorder.Aux[F, A, Counter] = new OutcomeRecorder[F] {
+    override type Metric = Counter[F, A, Status]
 
     override protected val onCanceled: F[Unit] = counter.inc(Status.Canceled)
 
@@ -114,7 +113,7 @@ object OutcomeRecorder {
     override protected val onSucceeded: F[Unit] = counter.inc(Status.Succeeded)
   }
 
-  /** Create an [[OutcomeRecorder]] from a [[Gauge.Labelled]] instance, where its only label type is [[Status]].
+  /** Create an [[OutcomeRecorder]] from a [[Gauge]] instance, where its only label type is [[Status]].
     *
     * This works by setting gauge with a label value that corresponds to the value of [[Status]] to `1` on each
     * invocation, while the other statuses are set to `0`.
@@ -123,13 +122,13 @@ object OutcomeRecorder {
     * provided by [[MetricFactory]].
     *
     * @return
-    *   an [[OutcomeRecorder.Aux]] that is annotated with the type of underlying metric, in this case [[Gauge.Labelled]]
+    *   an [[OutcomeRecorder.Aux]] that is annotated with the type of underlying metric, in this case [[Gauge]]
     */
   def fromGauge[F[_]: MonadCancelThrow, A](
-      gauge: Gauge.Labelled[F, A, Status]
-  ): OutcomeRecorder.Aux[F, A, Gauge.Labelled] =
+      gauge: Gauge[F, A, Status]
+  ): OutcomeRecorder.Aux[F, A, Gauge] =
     new OutcomeRecorder[F] {
-      override type Metric = Gauge.Labelled[F, A, Status]
+      override type Metric = Gauge[F, A, Status]
 
       private def setOutcome(status: Status): F[Unit] =
         (
@@ -238,7 +237,7 @@ object OutcomeRecorder {
       type Metric = M[F, A, Status]
     }
 
-    /** Create an [[OutcomeRecorder]] from a [[Counter.Labelled]] instance, where its only label type is [[Status]].
+    /** Create an [[OutcomeRecorder]] from a [[Counter]] instance, where its only label type is [[Status]].
       *
       * This works by incrementing a counter with a label value that corresponds to the value [[Status]] on each
       * invocation.
@@ -247,13 +246,12 @@ object OutcomeRecorder {
       * DSL provided by [[MetricFactory]].
       *
       * @return
-      *   an [[OutcomeRecorder.Aux]] that is annotated with the type of underlying metric, in this case
-      *   [[Counter.Labelled]]
+      *   an [[OutcomeRecorder.Aux]] that is annotated with the type of underlying metric, in this case [[Counter]]
       */
     def fromCounter[F[_]: MonadCancelThrow, A](
-        counter: Counter.Labelled[F, A, Status]
-    ): OutcomeRecorder.Exemplar.Aux[F, A, Counter.Labelled] = new OutcomeRecorder.Exemplar[F] {
-      override type Metric = Counter.Labelled[F, A, Status]
+        counter: Counter[F, A, Status]
+    ): OutcomeRecorder.Exemplar.Aux[F, A, Counter] = new OutcomeRecorder.Exemplar[F] {
+      override type Metric = Counter[F, A, Status]
 
       override protected def onCanceled(exemplar: Option[prometheus4cats.Exemplar.Labels]): F[Unit] =
         counter.incWithExemplar(Status.Canceled, exemplar)
@@ -383,8 +381,8 @@ object OutcomeRecorder {
         override def contramapLabels[A, B](fa: Labelled[F, A])(f: B => A): Labelled[F, B] = fa.contramapLabels(f)
       }
 
-    /** Create an [[OutcomeRecorder]] from a [[Counter.Labelled]] instance, where its labels type is a tuple of the
-      * original labels of the counter and [[Status]].
+    /** Create an [[OutcomeRecorder]] from a [[Counter]] instance, where its labels type is a tuple of the original
+      * labels of the counter and [[Status]].
       *
       * This works by incrementing a counter with a label value that corresponds to the value [[Status]] on each
       * invocation.
@@ -394,12 +392,12 @@ object OutcomeRecorder {
       *
       * @return
       *   an [[OutcomeRecorder.Labelled.Aux]] that is annotated with the type of underlying metric, in this case
-      *   [[Counter.Labelled]]
+      *   [[Counter]]
       */
     def fromCounter[F[_]: MonadCancelThrow, A, B](
-        counter: Counter.Labelled[F, A, (B, Status)]
-    ): OutcomeRecorder.Labelled.Aux[F, A, B, Counter.Labelled] = new OutcomeRecorder.Labelled[F, B] {
-      override type Metric = Counter.Labelled[F, A, (B, Status)]
+        counter: Counter[F, A, (B, Status)]
+    ): OutcomeRecorder.Labelled.Aux[F, A, B, Counter] = new OutcomeRecorder.Labelled[F, B] {
+      override type Metric = Counter[F, A, (B, Status)]
 
       override protected def onCanceled(labels: B): F[Unit] = counter.inc((labels, Status.Canceled))
 
@@ -408,8 +406,8 @@ object OutcomeRecorder {
       override protected def onSucceeded(labels: B): F[Unit] = counter.inc((labels, Status.Succeeded))
     }
 
-    /** Create an [[OutcomeRecorder]] from a [[Gauge.Labelled]] instance, where its only label type is a tuple of the
-      * original labels of the counter and [[Status]].
+    /** Create an [[OutcomeRecorder]] from a [[Gauge]] instance, where its only label type is a tuple of the original
+      * labels of the counter and [[Status]].
       *
       * This works by setting gauge with a label value that corresponds to the value of [[Status]] to `1` on each
       * invocation, while the other statuses are set to `0`.
@@ -419,13 +417,13 @@ object OutcomeRecorder {
       *
       * @return
       *   an [[OutcomeRecorder.Labelled.Aux]] that is annotated with the type of underlying metric, in this case
-      *   [[Gauge.Labelled]]
+      *   [[Gauge]]
       */
     def fromGauge[F[_]: MonadCancelThrow, A, B](
-        gauge: Gauge.Labelled[F, A, (B, Status)]
-    ): OutcomeRecorder.Labelled.Aux[F, A, B, Gauge.Labelled] =
+        gauge: Gauge[F, A, (B, Status)]
+    ): OutcomeRecorder.Labelled.Aux[F, A, B, Gauge] =
       new OutcomeRecorder.Labelled[F, B] {
-        override type Metric = Gauge.Labelled[F, A, (B, Status)]
+        override type Metric = Gauge[F, A, (B, Status)]
 
         private def setOutcome(labels: B, status: Status): F[Unit] =
           (

--- a/core/src/main/scala/prometheus4cats/Summary.scala
+++ b/core/src/main/scala/prometheus4cats/Summary.scala
@@ -16,9 +16,10 @@
 
 package prometheus4cats
 
-import java.util.regex.Pattern
-
 import cats.{Applicative, Contravariant, ~>}
+
+import prometheus4cats.internal.Refined
+import prometheus4cats.internal.Refined.Regex
 
 sealed abstract class Summary[F[_], -A, B] extends Metric[A] with Metric.Labelled[B] {
   self =>
@@ -49,65 +50,55 @@ object Summary {
     def observe(n: A, labels: B): F[Unit] = summary.observeImpl(n, labels)
   }
 
-  final class AgeBuckets(val value: Int) extends AnyVal with internal.Refined.Value[Int] {
-    override def toString: String = s"""Summary.AgeBuckets(value: "$value")"""
-  }
+  final class AgeBuckets(val value: Int) extends AnyVal with Refined.Value[Int]
 
-  object AgeBuckets extends internal.Refined[Int, AgeBuckets] with internal.SummaryAgeBucketsFromIntLiteral {
+  object AgeBuckets
+      extends Refined[Int, AgeBuckets](
+        make = new AgeBuckets(_),
+        test = _ > 0,
+        nonMatchMessage = a => s"AgeBuckets value $a must be greater than 0"
+      )
+      with internal.SummaryAgeBucketsFromIntLiteral {
 
     val Default: AgeBuckets = new AgeBuckets(5)
 
-    override protected def make(a: Int): AgeBuckets = new AgeBuckets(a)
-
-    override protected def test(a: Int): Boolean = a > 0
-
-    override protected def nonMatchMessage(a: Int): String = s"AgeBuckets value $a must be greater than 0"
   }
 
-  final class Quantile(val value: Double) extends AnyVal with internal.Refined.Value[Double] {
-    override def toString: String = s"""Summary.Quantile(value: "$value")"""
-  }
+  final class Quantile(val value: Double) extends AnyVal with Refined.Value[Double]
 
-  object Quantile extends internal.Refined[Double, Quantile] with internal.SummaryQuantileFromDoubleLiteral {
-    override protected def make(a: Double): Quantile = new Quantile(a)
+  object Quantile
+      extends Refined[Double, Quantile](
+        make = new Quantile(_),
+        test = a => a >= 0.0 && a <= 1.0,
+        nonMatchMessage = a => s"Quantile value $a must be between 0.0 and 1.0"
+      )
+      with internal.SummaryQuantileFromDoubleLiteral
 
-    override protected def test(a: Double): Boolean = a >= 0.0 && a <= 1.0
-
-    override protected def nonMatchMessage(a: Double): String = s"Quantile value $a must be between 0.0 and 1.0"
-  }
-
-  final class AllowedError(val value: Double) extends AnyVal with internal.Refined.Value[Double] {
-    override def toString: String = s"""Summary.ErrorRate(value: "$value")"""
-  }
+  final class AllowedError(val value: Double) extends AnyVal with Refined.Value[Double]
 
   object AllowedError
-      extends internal.Refined[Double, AllowedError]
-      with internal.SummaryAllowedErrorFromDoubleLiteral {
-    override protected def make(a: Double): AllowedError = new AllowedError(a)
+      extends Refined[Double, AllowedError](
+        make = new AllowedError(_),
+        test = a => a >= 0.0 && a <= 1.0,
+        nonMatchMessage = a => s"AllowedError value $a must be between 0.0 and 1.0"
+      )
+      with internal.SummaryAllowedErrorFromDoubleLiteral
 
-    override protected def test(a: Double): Boolean = a >= 0.0 && a <= 1.0
-
-    override protected def nonMatchMessage(a: Double): String = s"AllowedError value $a must be between 0.0 and 1.0"
-  }
-
-  final case class QuantileDefinition(value: Quantile, error: AllowedError) {
-    override def toString: String = s"""Summary.QuantileDefinition(value: "${value.value}", error: "${error.value}")"""
-  }
+  final case class QuantileDefinition(value: Quantile, error: AllowedError)
 
   case class Value[A](count: A, sum: A, quantiles: Map[Double, A] = Map.empty) {
+
     def map[B](f: A => B): Value[B] = Value(f(count), f(sum), quantiles.map { case (q, v) => q -> f(v) })
+
   }
 
   /** Refined value class for a gauge name that has been parsed from a string
     */
-  final class Name private (val value: String) extends AnyVal with internal.Refined.Value[String] {
-    override def toString: String = s"""Summary.Name("$value")"""
-  }
+  final class Name private (val value: String) extends AnyVal with Refined.Value[String]
 
-  object Name extends internal.Refined.StringRegexRefinement[Name] with internal.SummaryNameFromStringLiteral {
-    final override protected val regex: Pattern = "^[a-zA-Z_:][a-zA-Z0-9_:]*$".r.pattern
-    final override protected def make(a: String): Name = new Name(a)
-  }
+  object Name
+      extends Regex[Name]("^[a-zA-Z_:][a-zA-Z0-9_:]*$".r.pattern, new Name(_))
+      with internal.SummaryNameFromStringLiteral
 
   implicit def catsInstances[F[_], C]: Contravariant[Summary[F, *, C]] =
     new Contravariant[Summary[F, *, C]] {

--- a/core/src/main/scala/prometheus4cats/Timer.scala
+++ b/core/src/main/scala/prometheus4cats/Timer.scala
@@ -21,7 +21,7 @@ import cats.syntax.applicativeError._
 import cats.syntax.either._
 import cats.syntax.flatMap._
 import cats.syntax.functor._
-import cats.{Applicative, FlatMap, Monad, MonadThrow, ~>}
+import cats.{Applicative, MonadThrow, ~>}
 
 import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.FiniteDuration
@@ -29,37 +29,96 @@ import scala.concurrent.duration.FiniteDuration
 /** A derived metric type that can time a given operation. See [[Timer.fromHistogram]] and [[Timer.fromGauge]] for more
   * information.
   */
-sealed abstract class Timer[F[_]: FlatMap: Clock] { self =>
+sealed abstract class Timer[F[_]: MonadThrow: Clock, A] extends Metric.Labelled[A] { self =>
   type Metric
+
+  def recordTime(duration: FiniteDuration, labels: A): F[Unit]
+  def recordTime(duration: FiniteDuration)(implicit ev: Unit =:= A): F[Unit] =
+    recordTime(duration = duration, labels = ev(()))
 
   /** Time an operation using an instance of [[cats.effect.kernel.Clock]].
     *
     * The resulting metrics depend on the underlying implementation. See [[Timer.fromHistogram]] and [[Timer.fromGauge]]
     * for more details.
     *
-    * @param fa
+    * @param fb
+    *   operation to be timed
+    * @param labels
+    *   labels to add to the underlying metric
+    */
+  final def time[B](fb: F[B], labels: A): F[B] =
+    timeWithComputedLabels(fb)(_ => labels)
+
+  /** Time an operation using an instance of [[cats.effect.kernel.Clock]].
+    *
+    * The resulting metrics depend on the underlying implementation. See [[Timer.fromHistogram]] and [[Timer.fromGauge]]
+    * for more details.
+    *
+    * @param fb
     *   operation to be timed
     */
-  final def time[B](fa: F[B]): F[B] = Clock[F].timed(fa).flatMap { case (t, a) => recordTime(t).as(a) }
+  final def time[B](fb: F[B])(implicit ev: A =:= Unit): F[B] = time(fb = fb, labels = ev.flip(()))
 
-  def recordTime(duration: FiniteDuration): F[Unit]
+  /** Time an operation using an instance of [[cats.effect.kernel.Clock]], computing labels from the result.
+    *
+    * @param fb
+    *   operation to be timed
+    * @param labels
+    *   function to convert the result of `fb` to labels
+    */
+  final def timeWithComputedLabels[B](fb: F[B])(labels: B => A): F[B] =
+    Clock[F].timed(fb).flatMap { case (t, a) => recordTime(t, labels(a)).as(a) }
 
-  def mapK[G[_]: FlatMap: Clock](fk: F ~> G): Timer[G] = new Timer[G] {
+  /** Time an operation using an instance of [[cats.effect.kernel.Clock]], handling failures and computing labels from
+    * the result.
+    *
+    * @param fb
+    *   operation to be timed
+    * @param labelsSuccess
+    *   function to convert the successful result of `fb` to labels
+    * @param labelsError
+    *   partial function to convert an exception raised on unsuccessful operation of `fb`. If the exception does not
+    *   match the provided [[scala.PartialFunction]] then no value will be recorded.
+    */
+  final def timeAttempt[B](fb: F[B])(
+      labelsSuccess: B => A,
+      labelsError: PartialFunction[Throwable, A]
+  ): F[B] =
+    for {
+      x <- Clock[F].timed(fb.attempt)
+      _ <- x._2.fold(
+        e =>
+          labelsError
+            .lift(e)
+            .fold(Applicative[F].unit)(b => recordTime(x._1, b)),
+        a => recordTime(x._1, labelsSuccess(a))
+      )
+      res <- x._2.liftTo[F]
+    } yield res
+
+  def contramapLabels[B](f: B => A): Timer[F, B] = new Timer[F, B] {
     override type Metric = self.Metric
 
-    override def recordTime(duration: FiniteDuration): G[Unit] = fk(self.recordTime(duration))
+    override def recordTime(duration: FiniteDuration, labels: B): F[Unit] = self.recordTime(duration, f(labels))
+  }
+
+  def mapK[G[_]: MonadThrow: Clock](fk: F ~> G): Timer[G, A] = new Timer[G, A] {
+    override type Metric = self.Metric
+
+    override def recordTime(duration: FiniteDuration, labels: A): G[Unit] = fk(self.recordTime(duration, labels))
   }
 }
 
 object Timer {
-  type Aux[F[_], M[_[_], _]] = Timer[F] {
-    type Metric = M[F, Double]
+
+  type Aux[F[_], A, M[_[_], _, _]] = Timer[F, A] {
+    type Metric = M[F, Double, A]
   }
 
-  /** Create a [[Timer]] from a [[Histogram]] instance.
+  /** Create a [[Timer]] from a [[Histogram.Timer]] instance.
     *
-    * This delegates to the underlying [[Histogram]] instance and assumes you have already set up sensible buckets for
-    * the distribution of values.
+    * This delegates to the underlying [[Histogram.Timer]] instance and assumes you have already set up sensible buckets
+    * for the distribution of values.
     *
     * Values are recorded in [[scala.Double]]s by converting a [[scala.concurrent.duration.FiniteDuration]] to seconds.
     *
@@ -67,12 +126,16 @@ object Timer {
     * [[MetricFactory]].
     *
     * @return
-    *   a [[Timer.Aux]] that is annotated with the type of underlying metrics, in this case [[Histogram]]
+    *   a [[Timer.Aux]] that is annotated with the type of underlying metrics, in this case [[Histogram.Timer]]
     */
-  def fromHistogram[F[_]: FlatMap: Clock](histogram: Histogram[F, Double]): Timer.Aux[F, Histogram] =
-    new Timer[F] {
-      override type Metric = Histogram[F, Double]
-      override def recordTime(duration: FiniteDuration): F[Unit] = histogram.observe(duration.toUnit(TimeUnit.SECONDS))
+  def fromHistogram[F[_]: MonadThrow: Clock, A](
+      histogram: Histogram[F, Double, A]
+  ): Timer.Aux[F, A, Histogram] =
+    new Timer[F, A] {
+      override type Metric = Histogram[F, Double, A]
+
+      override def recordTime(duration: FiniteDuration, labels: A): F[Unit] =
+        histogram.observe(duration.toUnit(TimeUnit.SECONDS), labels)
     }
 
   /** Create a [[Timer]] from a [[Summary]] instance.
@@ -88,11 +151,14 @@ object Timer {
     * @return
     *   a [[Timer.Aux]] that is annotated with the type of underlying metrics, in this case [[Summary]]
     */
-  def fromSummary[F[_]: FlatMap: Clock](summary: Summary[F, Double]): Timer.Aux[F, Summary] =
-    new Timer[F] {
-      override type Metric = Summary[F, Double]
+  def fromSummary[F[_]: MonadThrow: Clock, A](
+      summary: Summary[F, Double, A]
+  ): Timer.Aux[F, A, Summary] =
+    new Timer[F, A] {
+      override type Metric = Summary[F, Double, A]
 
-      override def recordTime(duration: FiniteDuration): F[Unit] = summary.observe(duration.toUnit(TimeUnit.SECONDS))
+      override def recordTime(duration: FiniteDuration, labels: A): F[Unit] =
+        summary.observe(duration.toUnit(TimeUnit.SECONDS), labels)
     }
 
   /** Create a [[Timer]] from a [[Gauge]] instance.
@@ -102,105 +168,36 @@ object Timer {
     *
     * Values are recorded in [[scala.Double]]s by converting a [[scala.concurrent.duration.FiniteDuration]] to seconds.
     *
-    * The best way to construct a gauge based [[Timer]] is to use the `.asTimer` on the gauge DSL provided by
+    * The best way to construct a gauge based [[Timer]] is to use the `.asTimer` on the histogram DSL provided by
     * [[MetricFactory]].
     *
     * @return
-    *   a [[Timer.Aux]] that is annotated with the type of underlying metrics, in this case [[Gauge.Labelled]]
+    *   a [[Timer.Aux]] that is annotated with the type of underlying metrics, in this case [[Gauge]]
     */
-  def fromGauge[F[_]: FlatMap: Clock](gauge: Gauge[F, Double]): Timer.Aux[F, Gauge] =
-    new Timer[F] {
-      override type Metric = Gauge[F, Double]
-      override def recordTime(duration: FiniteDuration): F[Unit] = gauge.set(duration.toUnit(TimeUnit.SECONDS))
-    }
+  def fromGauge[F[_]: MonadThrow: Clock, A](
+      gauge: Gauge[F, Double, A]
+  ): Timer.Aux[F, A, Gauge] = new Timer[F, A] {
+    override type Metric = Gauge[F, Double, A]
 
-  sealed abstract class Exemplar[F[_]: FlatMap: Clock] { self =>
+    override def recordTime(duration: FiniteDuration, labels: A): F[Unit] =
+      gauge.set(duration.toUnit(TimeUnit.SECONDS), labels)
+  }
+
+  sealed abstract class Exemplar[F[_]: MonadThrow: Clock, A] extends Metric.Labelled[A] {
+    self =>
     type Metric
 
-    /** Time an operation using an instance of [[cats.effect.kernel.Clock]].
-      *
-      * The resulting metrics depend on the underlying implementation. See [[Timer.Exemplar.fromHistogram]] and for more
-      * details.
-      *
-      * @param fa
-      *   operation to be timed
-      * @param recordExemplar
-      *   function to decide a duration threshold or the resulting value of `B` to record an exemplar
-      */
-    final def time[B](
-        fa: F[B]
-    )(recordExemplar: (FiniteDuration, B) => Boolean)(implicit exemplar: prometheus4cats.Exemplar[F]): F[B] =
-      Clock[F].timed(fa).flatMap { case (t, b) =>
-        (if (recordExemplar(t, b)) recordTimeWithExemplar(t)
-         else recordTime(t)).as(b)
-      }
+    def recordTime(duration: FiniteDuration, labels: A): F[Unit] = recordTimeWithExemplar(duration, labels, None)
 
-    final def time[B](
-        fa: F[B]
-    )(recordExemplar: (FiniteDuration, B) => Option[prometheus4cats.Exemplar.Labels]): F[B] =
-      Clock[F].timed(fa).flatMap { case (t, b) =>
-        recordTimeWithExemplar(t, recordExemplar(t, b)).as(b)
-      }
-
-    final def recordTime(duration: FiniteDuration): F[Unit] = recordTimeWithExemplar(duration, None)
-
-    final def recordTimeWithExemplar(duration: FiniteDuration)(implicit
+    def recordTimeWithExemplar(duration: FiniteDuration, labels: A)(implicit
         exemplar: prometheus4cats.Exemplar[F]
-    ): F[Unit] =
-      exemplar.get.flatMap(recordTimeWithExemplar(duration, _))
+    ): F[Unit] = exemplar.get.flatMap(recordTimeWithExemplar(duration, labels, _))
 
-    def recordTimeWithExemplar(duration: FiniteDuration, exemplar: Option[prometheus4cats.Exemplar.Labels]): F[Unit]
-
-    def mapK[G[_]: FlatMap: Clock](fk: F ~> G): Exemplar[G] = new Exemplar[G] {
-      override type Metric = self.Metric
-
-      override def recordTimeWithExemplar(
-          duration: FiniteDuration,
-          exemplar: Option[prometheus4cats.Exemplar.Labels]
-      ): G[Unit] = fk(self.recordTimeWithExemplar(duration, exemplar))
-    }
-  }
-
-  object Exemplar {
-    type Aux[F[_], M[_[_], _]] = Timer.Exemplar[F] {
-      type Metric = M[F, Double]
-    }
-
-    /** Create a [[Timer.Exemplar]] from a [[Histogram]] instance.
-      *
-      * This delegates to the underlying [[Histogram]] instance and assumes you have already set up sensible buckets for
-      * the distribution of values.
-      *
-      * Values are recorded in [[scala.Double]]s by converting a [[scala.concurrent.duration.FiniteDuration]] to
-      * seconds.
-      *
-      * The best way to construct a histogram based [[Timer]] is to use the `.asTimer` on the histogram DSL provided by
-      * [[MetricFactory]].
-      *
-      * @return
-      *   a [[Timer.Aux]] that is annotated with the type of underlying metrics, in this case [[Histogram]]
-      */
-    def fromHistogram[F[_]: Monad: Clock](
-        histogram: Histogram[F, Double]
-    ): Exemplar.Aux[F, Histogram] =
-      new Exemplar[F] {
-        override type Metric = Histogram[F, Double]
-
-        override def recordTimeWithExemplar(
-            duration: FiniteDuration,
-            exemplar: Option[prometheus4cats.Exemplar.Labels]
-        ): F[Unit] =
-          histogram.observeWithExemplar(duration.toUnit(TimeUnit.SECONDS), exemplar)
-      }
-  }
-
-  /** A derived metric type that can time a given operation. See [[Timer.Labelled.fromHistogram]] and
-    * [[Timer.Labelled.fromGauge]] for more information.
-    */
-  sealed abstract class Labelled[F[_]: MonadThrow: Clock, -A] extends Metric.Labelled[A] { self =>
-    type Metric
-
-    def recordTime(duration: FiniteDuration, labels: A): F[Unit]
+    def recordTimeWithExemplar(
+        duration: FiniteDuration,
+        labels: A,
+        exemplar: Option[prometheus4cats.Exemplar.Labels]
+    ): F[Unit]
 
     /** Time an operation using an instance of [[cats.effect.kernel.Clock]].
       *
@@ -212,8 +209,15 @@ object Timer {
       * @param labels
       *   labels to add to the underlying metric
       */
-    final def time[B](fb: F[B], labels: A): F[B] =
-      timeWithComputedLabels(fb)(_ => labels)
+    final def time[B](fb: F[B], labels: A)(recordExemplar: (FiniteDuration, B, A) => Boolean)(implicit
+        exemplar: prometheus4cats.Exemplar[F]
+    ): F[B] =
+      timeWithComputedLabels(fb)((_: B) => labels, recordExemplar)(exemplar)
+
+    final def timeWithExemplar[B](fb: F[B], labels: A)(
+        recordExemplar: (FiniteDuration, B, A) => Option[prometheus4cats.Exemplar.Labels]
+    ): F[B] =
+      timeWithComputedLabelsExemplar(fb)((_: B) => labels, recordExemplar)
 
     /** Time an operation using an instance of [[cats.effect.kernel.Clock]], computing labels from the result.
       *
@@ -222,8 +226,22 @@ object Timer {
       * @param labels
       *   function to convert the result of `fb` to labels
       */
-    final def timeWithComputedLabels[B](fb: F[B])(labels: B => A): F[B] =
-      Clock[F].timed(fb).flatMap { case (t, a) => recordTime(t, labels(a)).as(a) }
+    final def timeWithComputedLabels[B](
+        fb: F[B]
+    )(labels: B => A, recordExemplar: (FiniteDuration, B, A) => Boolean)(implicit
+        exemplar: prometheus4cats.Exemplar[F]
+    ): F[B] =
+      exemplar.get.flatMap(ex =>
+        timeWithComputedLabelsExemplar(fb)(labels, (t, b, a) => ex.filter(_ => recordExemplar(t, b, a)))
+      )
+
+    final def timeWithComputedLabelsExemplar[B](
+        fb: F[B]
+    )(labels: B => A, recordExemplar: (FiniteDuration, B, A) => Option[prometheus4cats.Exemplar.Labels]): F[B] =
+      Clock[F].timed(fb).flatMap { case (t, b) =>
+        val a = labels(b)
+        recordTimeWithExemplar(t, a, recordExemplar(t, b, a)).as(b)
+      }
 
     /** Time an operation using an instance of [[cats.effect.kernel.Clock]], handling failures and computing labels from
       * the result.
@@ -238,7 +256,11 @@ object Timer {
       */
     final def timeAttempt[B](fb: F[B])(
         labelsSuccess: B => A,
-        labelsError: PartialFunction[Throwable, A]
+        labelsError: PartialFunction[Throwable, A],
+        recordExemplarSuccess: (FiniteDuration, B, A) => Boolean,
+        recordExemplarFailure: (FiniteDuration, Throwable, A) => Boolean
+    )(implicit
+        exemplar: prometheus4cats.Exemplar[F]
     ): F[B] =
       for {
         x <- Clock[F].timed(fb.attempt)
@@ -246,299 +268,117 @@ object Timer {
           e =>
             labelsError
               .lift(e)
-              .fold(Applicative[F].unit)(b => recordTime(x._1, b)),
-          a => recordTime(x._1, labelsSuccess(a))
+              .fold(Applicative[F].unit)(a =>
+                if (recordExemplarFailure(x._1, e, a)) recordTimeWithExemplar(x._1, a) else recordTime(x._1, a)
+              ),
+          b => {
+            val a = labelsSuccess(b)
+
+            if (recordExemplarSuccess(x._1, b, a)) recordTimeWithExemplar(x._1, labelsSuccess(b))
+            else recordTime(x._1, labelsSuccess(b))
+          }
         )
         res <- x._2.liftTo[F]
       } yield res
 
-    def contramapLabels[B](f: B => A): Labelled[F, B] = new Labelled[F, B] {
+    /** Time an operation using an instance of [[cats.effect.kernel.Clock]], handling failures and computing labels from
+      * the result.
+      *
+      * @param fb
+      *   operation to be timed
+      * @param labelsSuccess
+      *   function to convert the successful result of `fb` to labels
+      * @param labelsError
+      *   partial function to convert an exception raised on unsuccessful operation of `fb`. If the exception does not
+      *   match the provided [[scala.PartialFunction]] then no value will be recorded.
+      */
+    final def timeAttemptWithExemplar[B](fb: F[B])(
+        labelsSuccess: B => A,
+        labelsError: PartialFunction[Throwable, A],
+        recordExemplarSuccess: (FiniteDuration, B, A) => Option[prometheus4cats.Exemplar.Labels],
+        recordExemplarFailure: (FiniteDuration, Throwable, A) => Option[prometheus4cats.Exemplar.Labels]
+    ): F[B] =
+      for {
+        x <- Clock[F].timed(fb.attempt)
+        _ <- x._2.fold(
+          e =>
+            labelsError
+              .lift(e)
+              .fold(Applicative[F].unit)(a => recordTimeWithExemplar(x._1, a, recordExemplarFailure(x._1, e, a))),
+          b => {
+            val a = labelsSuccess(b)
+
+            recordTimeWithExemplar(x._1, labelsSuccess(b), recordExemplarSuccess(x._1, b, a))
+          }
+        )
+        res <- x._2.liftTo[F]
+      } yield res
+
+    def contramapLabels[B](f: B => A): Exemplar[F, B] = new Exemplar[F, B] {
       override type Metric = self.Metric
 
-      override def recordTime(duration: FiniteDuration, labels: B): F[Unit] = self.recordTime(duration, f(labels))
+      override def recordTimeWithExemplar(
+          duration: FiniteDuration,
+          labels: B,
+          exemplar: Option[prometheus4cats.Exemplar.Labels]
+      ): F[Unit] = self.recordTimeWithExemplar(duration, f(labels), exemplar)
     }
 
-    def mapK[G[_]: MonadThrow: Clock](fk: F ~> G): Labelled[G, A] = new Labelled[G, A] {
+    def mapK[G[_]: MonadThrow: Clock](fk: F ~> G): Exemplar[G, A] = new Exemplar[G, A] {
       override type Metric = self.Metric
 
-      override def recordTime(duration: FiniteDuration, labels: A): G[Unit] = fk(self.recordTime(duration, labels))
-    }
-  }
-
-  object Labelled {
-    type Aux[F[_], A, M[_[_], _, _]] = Timer.Labelled[F, A] {
-      type Metric = M[F, Double, A]
-    }
-
-    sealed abstract class Exemplar[F[_]: MonadThrow: Clock, A] extends Metric.Labelled[A] {
-      self =>
-      type Metric
-
-      def recordTime(duration: FiniteDuration, labels: A): F[Unit] = recordTimeWithExemplar(duration, labels, None)
-
-      def recordTimeWithExemplar(duration: FiniteDuration, labels: A)(implicit
-          exemplar: prometheus4cats.Exemplar[F]
-      ): F[Unit] = exemplar.get.flatMap(recordTimeWithExemplar(duration, labels, _))
-
-      def recordTimeWithExemplar(
+      override def recordTimeWithExemplar(
           duration: FiniteDuration,
           labels: A,
           exemplar: Option[prometheus4cats.Exemplar.Labels]
-      ): F[Unit]
-
-      /** Time an operation using an instance of [[cats.effect.kernel.Clock]].
-        *
-        * The resulting metrics depend on the underlying implementation. See [[Timer.fromHistogram]] and
-        * [[Timer.fromGauge]] for more details.
-        *
-        * @param fb
-        *   operation to be timed
-        * @param labels
-        *   labels to add to the underlying metric
-        */
-      final def time[B](fb: F[B], labels: A)(recordExemplar: (FiniteDuration, B, A) => Boolean)(implicit
-          exemplar: prometheus4cats.Exemplar[F]
-      ): F[B] =
-        timeWithComputedLabels(fb)((_: B) => labels, recordExemplar)(exemplar)
-
-      final def timeWithExemplar[B](fb: F[B], labels: A)(
-          recordExemplar: (FiniteDuration, B, A) => Option[prometheus4cats.Exemplar.Labels]
-      ): F[B] =
-        timeWithComputedLabelsExemplar(fb)((_: B) => labels, recordExemplar)
-
-      /** Time an operation using an instance of [[cats.effect.kernel.Clock]], computing labels from the result.
-        *
-        * @param fb
-        *   operation to be timed
-        * @param labels
-        *   function to convert the result of `fb` to labels
-        */
-      final def timeWithComputedLabels[B](
-          fb: F[B]
-      )(labels: B => A, recordExemplar: (FiniteDuration, B, A) => Boolean)(implicit
-          exemplar: prometheus4cats.Exemplar[F]
-      ): F[B] =
-        exemplar.get.flatMap(ex =>
-          timeWithComputedLabelsExemplar(fb)(labels, (t, b, a) => ex.filter(_ => recordExemplar(t, b, a)))
-        )
-
-      final def timeWithComputedLabelsExemplar[B](
-          fb: F[B]
-      )(labels: B => A, recordExemplar: (FiniteDuration, B, A) => Option[prometheus4cats.Exemplar.Labels]): F[B] =
-        Clock[F].timed(fb).flatMap { case (t, b) =>
-          val a = labels(b)
-          recordTimeWithExemplar(t, a, recordExemplar(t, b, a)).as(b)
-        }
-
-      /** Time an operation using an instance of [[cats.effect.kernel.Clock]], handling failures and computing labels
-        * from the result.
-        *
-        * @param fb
-        *   operation to be timed
-        * @param labelsSuccess
-        *   function to convert the successful result of `fb` to labels
-        * @param labelsError
-        *   partial function to convert an exception raised on unsuccessful operation of `fb`. If the exception does not
-        *   match the provided [[scala.PartialFunction]] then no value will be recorded.
-        */
-      final def timeAttempt[B](fb: F[B])(
-          labelsSuccess: B => A,
-          labelsError: PartialFunction[Throwable, A],
-          recordExemplarSuccess: (FiniteDuration, B, A) => Boolean,
-          recordExemplarFailure: (FiniteDuration, Throwable, A) => Boolean
-      )(implicit
-          exemplar: prometheus4cats.Exemplar[F]
-      ): F[B] =
-        for {
-          x <- Clock[F].timed(fb.attempt)
-          _ <- x._2.fold(
-            e =>
-              labelsError
-                .lift(e)
-                .fold(Applicative[F].unit)(a =>
-                  if (recordExemplarFailure(x._1, e, a)) recordTimeWithExemplar(x._1, a) else recordTime(x._1, a)
-                ),
-            b => {
-              val a = labelsSuccess(b)
-
-              if (recordExemplarSuccess(x._1, b, a)) recordTimeWithExemplar(x._1, labelsSuccess(b))
-              else recordTime(x._1, labelsSuccess(b))
-            }
-          )
-          res <- x._2.liftTo[F]
-        } yield res
-
-      /** Time an operation using an instance of [[cats.effect.kernel.Clock]], handling failures and computing labels
-        * from the result.
-        *
-        * @param fb
-        *   operation to be timed
-        * @param labelsSuccess
-        *   function to convert the successful result of `fb` to labels
-        * @param labelsError
-        *   partial function to convert an exception raised on unsuccessful operation of `fb`. If the exception does not
-        *   match the provided [[scala.PartialFunction]] then no value will be recorded.
-        */
-      final def timeAttemptWithExemplar[B](fb: F[B])(
-          labelsSuccess: B => A,
-          labelsError: PartialFunction[Throwable, A],
-          recordExemplarSuccess: (FiniteDuration, B, A) => Option[prometheus4cats.Exemplar.Labels],
-          recordExemplarFailure: (FiniteDuration, Throwable, A) => Option[prometheus4cats.Exemplar.Labels]
-      ): F[B] =
-        for {
-          x <- Clock[F].timed(fb.attempt)
-          _ <- x._2.fold(
-            e =>
-              labelsError
-                .lift(e)
-                .fold(Applicative[F].unit)(a => recordTimeWithExemplar(x._1, a, recordExemplarFailure(x._1, e, a))),
-            b => {
-              val a = labelsSuccess(b)
-
-              recordTimeWithExemplar(x._1, labelsSuccess(b), recordExemplarSuccess(x._1, b, a))
-            }
-          )
-          res <- x._2.liftTo[F]
-        } yield res
-
-      def contramapLabels[B](f: B => A): Exemplar[F, B] = new Exemplar[F, B] {
-        override type Metric = self.Metric
-
-        override def recordTimeWithExemplar(
-            duration: FiniteDuration,
-            labels: B,
-            exemplar: Option[prometheus4cats.Exemplar.Labels]
-        ): F[Unit] = self.recordTimeWithExemplar(duration, f(labels), exemplar)
-      }
-
-      def mapK[G[_]: MonadThrow: Clock](fk: F ~> G): Exemplar[G, A] = new Exemplar[G, A] {
-        override type Metric = self.Metric
-
-        override def recordTimeWithExemplar(
-            duration: FiniteDuration,
-            labels: A,
-            exemplar: Option[prometheus4cats.Exemplar.Labels]
-        ): G[Unit] =
-          fk(self.recordTimeWithExemplar(duration, labels, exemplar))
-      }
+      ): G[Unit] =
+        fk(self.recordTimeWithExemplar(duration, labels, exemplar))
     }
 
-    object Exemplar {
-      type Aux[F[_], A, M[_[_], _, _]] = Timer.Labelled.Exemplar[F, A] {
-        type Metric = M[F, Double, A]
-      }
+  }
 
-      implicit def labelsExemplarContravariant[F[_]]: LabelsContravariant[Exemplar[F, *]] =
-        new LabelsContravariant[Exemplar[F, *]] {
-          override def contramapLabels[A, B](fa: Exemplar[F, A])(f: B => A): Exemplar[F, B] = fa.contramapLabels(f)
-        }
-
-      /** Create a [[Timer.Labelled.Exemplar]] from a [[Histogram.Labelled]] instance.
-        *
-        * This delegates to the underlying [[Histogram.Labelled]] instance and assumes you have already set up sensible
-        * buckets for the distribution of values.
-        *
-        * Values are recorded in [[scala.Double]]s by converting a [[scala.concurrent.duration.FiniteDuration]] to
-        * seconds.
-        *
-        * The best way to construct a histogram based [[Timer.Labelled.Exemplar]] is to use the `.asTimer` on the
-        * histogram DSL provided by [[MetricFactory]].
-        *
-        * @return
-        *   a [[Timer.Labelled.Exemplar.Aux]] that is annotated with the type of underlying metrics, in this case
-        *   [[Histogram.Labelled]]
-        */
-      def fromHistogram[F[_]: MonadThrow: Clock, A](
-          histogram: Histogram.Labelled[F, Double, A]
-      ): Exemplar.Aux[F, A, Histogram.Labelled] = new Labelled.Exemplar[F, A] {
-        override type Metric = Histogram.Labelled[F, Double, A]
-
-        override def recordTimeWithExemplar(
-            duration: FiniteDuration,
-            labels: A,
-            exemplar: Option[prometheus4cats.Exemplar.Labels]
-        ): F[Unit] =
-          histogram.observeWithExemplar(duration.toUnit(TimeUnit.SECONDS), labels, exemplar)
-      }
+  object Exemplar {
+    type Aux[F[_], A, M[_[_], _, _]] = Timer.Exemplar[F, A] {
+      type Metric = M[F, Double, A]
     }
 
-    implicit def labelsContravariant[F[_]]: LabelsContravariant[Labelled[F, *]] =
-      new LabelsContravariant[Labelled[F, *]] {
-        override def contramapLabels[A, B](fa: Labelled[F, A])(f: B => A): Labelled[F, B] = fa.contramapLabels(f)
+    implicit def labelsExemplarContravariant[F[_]]: LabelsContravariant[Exemplar[F, *]] =
+      new LabelsContravariant[Exemplar[F, *]] {
+        override def contramapLabels[A, B](fa: Exemplar[F, A])(f: B => A): Exemplar[F, B] = fa.contramapLabels(f)
       }
 
-    /** Create a [[Timer.Labelled]] from a [[Histogram.Labelled]] instance.
+    /** Create a [[Timer.Exemplar]] from a [[Histogram.Timer]] instance.
       *
-      * This delegates to the underlying [[Histogram.Labelled]] instance and assumes you have already set up sensible
+      * This delegates to the underlying [[Histogram.Timer]] instance and assumes you have already set up sensible
       * buckets for the distribution of values.
       *
       * Values are recorded in [[scala.Double]]s by converting a [[scala.concurrent.duration.FiniteDuration]] to
       * seconds.
       *
-      * The best way to construct a histogram based [[Timer.Labelled]] is to use the `.asTimer` on the histogram DSL
+      * The best way to construct a histogram based [[Timer.Exemplar]] is to use the `.asTimer` on the histogram DSL
       * provided by [[MetricFactory]].
       *
       * @return
-      *   a [[Timer.Labelled.Aux]] that is annotated with the type of underlying metrics, in this case
-      *   [[Histogram.Labelled]]
+      *   a [[Timer.Exemplar.Aux]] that is annotated with the type of underlying metrics, in this case
+      *   [[Histogram.Timer]]
       */
     def fromHistogram[F[_]: MonadThrow: Clock, A](
-        histogram: Histogram.Labelled[F, Double, A]
-    ): Labelled.Aux[F, A, Histogram.Labelled] =
-      new Labelled[F, A] {
-        override type Metric = Histogram.Labelled[F, Double, A]
+        histogram: Histogram[F, Double, A]
+    ): Exemplar.Aux[F, A, Histogram] = new Timer.Exemplar[F, A] {
+      override type Metric = Histogram[F, Double, A]
 
-        override def recordTime(duration: FiniteDuration, labels: A): F[Unit] =
-          histogram.observe(duration.toUnit(TimeUnit.SECONDS), labels)
-      }
-
-    /** Create a [[Timer.Labelled]] from a [[Summary.Labelled]] instance.
-      *
-      * This delegates to the underlying [[Summary.Labelled]] instance and assumes you have already set up sensible
-      * buckets for the distribution of values.
-      *
-      * Values are recorded in [[scala.Double]]s by converting a [[scala.concurrent.duration.FiniteDuration]] to
-      * seconds.
-      *
-      * The best way to construct a histogram based [[Timer.Labelled]] is to use the `.asTimer` on the summary DSL
-      * provided by [[MetricFactory]].
-      *
-      * @return
-      *   a [[Timer.Labelled.Aux]] that is annotated with the type of underlying metrics, in this case
-      *   [[Summary.Labelled]]
-      */
-    def fromSummary[F[_]: MonadThrow: Clock, A](
-        summary: Summary.Labelled[F, Double, A]
-    ): Labelled.Aux[F, A, Summary.Labelled] =
-      new Labelled[F, A] {
-        override type Metric = Summary.Labelled[F, Double, A]
-
-        override def recordTime(duration: FiniteDuration, labels: A): F[Unit] =
-          summary.observe(duration.toUnit(TimeUnit.SECONDS), labels)
-      }
-
-    /** Create a [[Timer.Labelled]] from a [[Gauge.Labelled]] instance.
-      *
-      * This delegates to the underlying [[Gauge.Labelled]] instance which will only ever show the last value for
-      * duration of the given operation.
-      *
-      * Values are recorded in [[scala.Double]]s by converting a [[scala.concurrent.duration.FiniteDuration]] to
-      * seconds.
-      *
-      * The best way to construct a gauge based [[Timer.Labelled]] is to use the `.asTimer` on the histogram DSL
-      * provided by [[MetricFactory]].
-      *
-      * @return
-      *   a [[Timer.Labelled.Aux]] that is annotated with the type of underlying metrics, in this case
-      *   [[Gauge.Labelled]]
-      */
-    def fromGauge[F[_]: MonadThrow: Clock, A](
-        gauge: Gauge.Labelled[F, Double, A]
-    ): Labelled.Aux[F, A, Gauge.Labelled] = new Labelled[F, A] {
-      override type Metric = Gauge.Labelled[F, Double, A]
-
-      override def recordTime(duration: FiniteDuration, labels: A): F[Unit] =
-        gauge.set(duration.toUnit(TimeUnit.SECONDS), labels)
+      override def recordTimeWithExemplar(
+          duration: FiniteDuration,
+          labels: A,
+          exemplar: Option[prometheus4cats.Exemplar.Labels]
+      ): F[Unit] =
+        histogram.observeWithExemplar(duration.toUnit(TimeUnit.SECONDS), labels, exemplar)
     }
   }
+
+  implicit def labelsContravariant[F[_]]: LabelsContravariant[Timer[F, *]] =
+    new LabelsContravariant[Timer[F, *]] {
+      override def contramapLabels[A, B](fa: Timer[F, A])(f: B => A): Timer[F, B] = fa.contramapLabels(f)
+    }
+
 }

--- a/core/src/main/scala/prometheus4cats/Timer.scala
+++ b/core/src/main/scala/prometheus4cats/Timer.scala
@@ -21,7 +21,7 @@ import cats.syntax.applicativeError._
 import cats.syntax.either._
 import cats.syntax.flatMap._
 import cats.syntax.functor._
-import cats.{Applicative, MonadThrow, ~>}
+import cats.{Applicative, FlatMap, MonadThrow, ~>}
 
 import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.FiniteDuration
@@ -29,83 +29,23 @@ import scala.concurrent.duration.FiniteDuration
 /** A derived metric type that can time a given operation. See [[Timer.fromHistogram]] and [[Timer.fromGauge]] for more
   * information.
   */
-sealed abstract class Timer[F[_]: MonadThrow: Clock, A] extends Metric.Labelled[A] { self =>
+sealed abstract class Timer[F[_], A] extends Metric.Labelled[A] { self =>
   type Metric
 
-  def recordTime(duration: FiniteDuration, labels: A): F[Unit]
-  def recordTime(duration: FiniteDuration)(implicit ev: Unit =:= A): F[Unit] =
-    recordTime(duration = duration, labels = ev(()))
-
-  /** Time an operation using an instance of [[cats.effect.kernel.Clock]].
-    *
-    * The resulting metrics depend on the underlying implementation. See [[Timer.fromHistogram]] and [[Timer.fromGauge]]
-    * for more details.
-    *
-    * @param fb
-    *   operation to be timed
-    * @param labels
-    *   labels to add to the underlying metric
-    */
-  final def time[B](fb: F[B], labels: A): F[B] =
-    timeWithComputedLabels(fb)(_ => labels)
-
-  /** Time an operation using an instance of [[cats.effect.kernel.Clock]].
-    *
-    * The resulting metrics depend on the underlying implementation. See [[Timer.fromHistogram]] and [[Timer.fromGauge]]
-    * for more details.
-    *
-    * @param fb
-    *   operation to be timed
-    */
-  final def time[B](fb: F[B])(implicit ev: Unit =:= A): F[B] = time(fb = fb, labels = ev(()))
-
-  /** Time an operation using an instance of [[cats.effect.kernel.Clock]], computing labels from the result.
-    *
-    * @param fb
-    *   operation to be timed
-    * @param labels
-    *   function to convert the result of `fb` to labels
-    */
-  final def timeWithComputedLabels[B](fb: F[B])(labels: B => A): F[B] =
-    Clock[F].timed(fb).flatMap { case (t, a) => recordTime(t, labels(a)).as(a) }
-
-  /** Time an operation using an instance of [[cats.effect.kernel.Clock]], handling failures and computing labels from
-    * the result.
-    *
-    * @param fb
-    *   operation to be timed
-    * @param labelsSuccess
-    *   function to convert the successful result of `fb` to labels
-    * @param labelsError
-    *   partial function to convert an exception raised on unsuccessful operation of `fb`. If the exception does not
-    *   match the provided [[scala.PartialFunction]] then no value will be recorded.
-    */
-  final def timeAttempt[B](fb: F[B])(
-      labelsSuccess: B => A,
-      labelsError: PartialFunction[Throwable, A]
-  ): F[B] =
-    for {
-      x <- Clock[F].timed(fb.attempt)
-      _ <- x._2.fold(
-        e =>
-          labelsError
-            .lift(e)
-            .fold(Applicative[F].unit)(b => recordTime(x._1, b)),
-        a => recordTime(x._1, labelsSuccess(a))
-      )
-      res <- x._2.liftTo[F]
-    } yield res
+  protected def recordTimeImpl(duration: FiniteDuration, labels: A): F[Unit]
 
   def contramapLabels[B](f: B => A): Timer[F, B] = new Timer[F, B] {
     override type Metric = self.Metric
 
-    override def recordTime(duration: FiniteDuration, labels: B): F[Unit] = self.recordTime(duration, f(labels))
+    override def recordTimeImpl(duration: FiniteDuration, labels: B): F[Unit] = self.recordTimeImpl(duration, f(labels))
   }
 
-  def mapK[G[_]: MonadThrow: Clock](fk: F ~> G): Timer[G, A] = new Timer[G, A] {
+  def mapK[G[_]](fk: F ~> G): Timer[G, A] = new Timer[G, A] {
     override type Metric = self.Metric
 
-    override def recordTime(duration: FiniteDuration, labels: A): G[Unit] = fk(self.recordTime(duration, labels))
+    override def recordTimeImpl(duration: FiniteDuration, labels: A): G[Unit] = fk(
+      self.recordTimeImpl(duration, labels)
+    )
   }
 }
 
@@ -113,6 +53,75 @@ object Timer {
 
   type Aux[F[_], A, M[_[_], _, _]] = Timer[F, A] {
     type Metric = M[F, Double, A]
+  }
+
+  implicit class TimerSyntax[F[_]](timer: Timer[F, Unit]) {
+    final def recordTime(duration: FiniteDuration): F[Unit] = timer.recordTimeImpl(duration, ())
+
+    /** Time an operation using an instance of [[cats.effect.kernel.Clock]].
+      *
+      * The resulting metrics depend on the underlying implementation. See [[Timer.fromHistogram]] and
+      * [[Timer.fromGauge]] for more details.
+      *
+      * @param fb
+      *   operation to be timed
+      */
+    final def time[B](fb: F[B])(implicit F: MonadThrow[F], clock: Clock[F]): F[B] =
+      clock.timed(fb.attempt).flatMap { case (duration, b) => recordTime(duration).flatMap(_ => b.liftTo[F]) }
+  }
+
+  implicit class LabelledTimerSyntax[F[_], A](timer: Timer[F, A])(implicit ev: Unit =:!= A) {
+    final def recordTime(duration: FiniteDuration, labels: A): F[Unit] = timer.recordTimeImpl(duration, labels)
+
+    /** Time an operation using an instance of [[cats.effect.kernel.Clock]].
+      *
+      * The resulting metrics depend on the underlying implementation. See [[Timer.fromHistogram]] and
+      * [[Timer.fromGauge]] for more details.
+      *
+      * @param fb
+      *   operation to be timed
+      * @param labels
+      *   labels to add to the underlying metric
+      */
+    final def time[B](fb: F[B], labels: A)(implicit F: MonadThrow[F], clock: Clock[F]): F[B] =
+      timeWithComputedLabels(fb)(_ => labels)
+
+    /** Time an operation using an instance of [[cats.effect.kernel.Clock]], computing labels from the result.
+      *
+      * @param fb
+      *   operation to be timed
+      * @param labels
+      *   function to convert the result of `fb` to labels
+      */
+    final def timeWithComputedLabels[B](fb: F[B])(labels: B => A)(implicit F: MonadThrow[F], clock: Clock[F]): F[B] =
+      clock.timed(fb).flatMap { case (t, a) => recordTime(t, labels(a)).as(a) }
+
+    /** Time an operation using an instance of [[cats.effect.kernel.Clock]], handling failures and computing labels from
+      * the result.
+      *
+      * @param fb
+      *   operation to be timed
+      * @param labelsSuccess
+      *   function to convert the successful result of `fb` to labels
+      * @param labelsError
+      *   partial function to convert an exception raised on unsuccessful operation of `fb`. If the exception does not
+      *   match the provided [[scala.PartialFunction]] then no value will be recorded.
+      */
+    final def timeAttempt[B](fb: F[B])(
+        labelsSuccess: B => A,
+        labelsError: PartialFunction[Throwable, A]
+    )(implicit F: MonadThrow[F], clock: Clock[F]): F[B] =
+      for {
+        x <- clock.timed(fb.attempt)
+        _ <- x._2.fold(
+          e =>
+            labelsError
+              .lift(e)
+              .fold(Applicative[F].unit)(b => recordTime(x._1, b)),
+          a => recordTime(x._1, labelsSuccess(a))
+        )
+        res <- x._2.liftTo[F]
+      } yield res
   }
 
   /** Create a [[Timer]] from a [[Histogram.Timer]] instance.
@@ -128,13 +137,13 @@ object Timer {
     * @return
     *   a [[Timer.Aux]] that is annotated with the type of underlying metrics, in this case [[Histogram.Timer]]
     */
-  def fromHistogram[F[_]: MonadThrow: Clock, A](
+  def fromHistogram[F[_], A](
       histogram: Histogram[F, Double, A]
   ): Timer.Aux[F, A, Histogram] =
     new Timer[F, A] {
       override type Metric = Histogram[F, Double, A]
 
-      override def recordTime(duration: FiniteDuration, labels: A): F[Unit] =
+      override def recordTimeImpl(duration: FiniteDuration, labels: A): F[Unit] =
         histogram.observe(duration.toUnit(TimeUnit.SECONDS), labels)
     }
 
@@ -151,13 +160,13 @@ object Timer {
     * @return
     *   a [[Timer.Aux]] that is annotated with the type of underlying metrics, in this case [[Summary]]
     */
-  def fromSummary[F[_]: MonadThrow: Clock, A](
+  def fromSummary[F[_], A](
       summary: Summary[F, Double, A]
   ): Timer.Aux[F, A, Summary] =
     new Timer[F, A] {
       override type Metric = Summary[F, Double, A]
 
-      override def recordTime(duration: FiniteDuration, labels: A): F[Unit] =
+      override def recordTimeImpl(duration: FiniteDuration, labels: A): F[Unit] =
         summary.observe(duration.toUnit(TimeUnit.SECONDS), labels)
     }
 
@@ -174,165 +183,47 @@ object Timer {
     * @return
     *   a [[Timer.Aux]] that is annotated with the type of underlying metrics, in this case [[Gauge]]
     */
-  def fromGauge[F[_]: MonadThrow: Clock, A](
+  def fromGauge[F[_], A](
       gauge: Gauge[F, Double, A]
   ): Timer.Aux[F, A, Gauge] = new Timer[F, A] {
     override type Metric = Gauge[F, Double, A]
 
-    override def recordTime(duration: FiniteDuration, labels: A): F[Unit] =
+    override def recordTimeImpl(duration: FiniteDuration, labels: A): F[Unit] =
       gauge.set(duration.toUnit(TimeUnit.SECONDS), labels)
   }
 
-  sealed abstract class Exemplar[F[_]: MonadThrow: Clock, A] extends Metric.Labelled[A] {
+  sealed abstract class Exemplar[F[_], A] extends Metric.Labelled[A] {
     self =>
     type Metric
 
-    def recordTime(duration: FiniteDuration, labels: A): F[Unit] = recordTimeWithExemplar(duration, labels, None)
+    protected def recordTimeImpl(duration: FiniteDuration, labels: A): F[Unit] =
+      recordTimeWithExemplarImpl(duration, labels, None)
 
-    def recordTimeWithExemplar(duration: FiniteDuration, labels: A)(implicit
-        exemplar: prometheus4cats.Exemplar[F]
-    ): F[Unit] = exemplar.get.flatMap(recordTimeWithExemplar(duration, labels, _))
-
-    def recordTimeWithExemplar(
+    protected def recordTimeWithExemplarImpl(
         duration: FiniteDuration,
         labels: A,
         exemplar: Option[prometheus4cats.Exemplar.Labels]
     ): F[Unit]
 
-    /** Time an operation using an instance of [[cats.effect.kernel.Clock]].
-      *
-      * The resulting metrics depend on the underlying implementation. See [[Timer.fromHistogram]] and
-      * [[Timer.fromGauge]] for more details.
-      *
-      * @param fb
-      *   operation to be timed
-      * @param labels
-      *   labels to add to the underlying metric
-      */
-    final def time[B](fb: F[B], labels: A)(recordExemplar: (FiniteDuration, B, A) => Boolean)(implicit
-        exemplar: prometheus4cats.Exemplar[F]
-    ): F[B] =
-      timeWithComputedLabels(fb)((_: B) => labels, recordExemplar)(exemplar)
-
-    final def timeWithExemplar[B](fb: F[B], labels: A)(
-        recordExemplar: (FiniteDuration, B, A) => Option[prometheus4cats.Exemplar.Labels]
-    ): F[B] =
-      timeWithComputedLabelsExemplar(fb)((_: B) => labels, recordExemplar)
-
-    /** Time an operation using an instance of [[cats.effect.kernel.Clock]], computing labels from the result.
-      *
-      * @param fb
-      *   operation to be timed
-      * @param labels
-      *   function to convert the result of `fb` to labels
-      */
-    final def timeWithComputedLabels[B](
-        fb: F[B]
-    )(labels: B => A, recordExemplar: (FiniteDuration, B, A) => Boolean)(implicit
-        exemplar: prometheus4cats.Exemplar[F]
-    ): F[B] =
-      exemplar.get.flatMap(ex =>
-        timeWithComputedLabelsExemplar(fb)(labels, (t, b, a) => ex.filter(_ => recordExemplar(t, b, a)))
-      )
-
-    final def timeWithComputedLabelsExemplar[B](
-        fb: F[B]
-    )(labels: B => A, recordExemplar: (FiniteDuration, B, A) => Option[prometheus4cats.Exemplar.Labels]): F[B] =
-      Clock[F].timed(fb).flatMap { case (t, b) =>
-        val a = labels(b)
-        recordTimeWithExemplar(t, a, recordExemplar(t, b, a)).as(b)
-      }
-
-    /** Time an operation using an instance of [[cats.effect.kernel.Clock]], handling failures and computing labels from
-      * the result.
-      *
-      * @param fb
-      *   operation to be timed
-      * @param labelsSuccess
-      *   function to convert the successful result of `fb` to labels
-      * @param labelsError
-      *   partial function to convert an exception raised on unsuccessful operation of `fb`. If the exception does not
-      *   match the provided [[scala.PartialFunction]] then no value will be recorded.
-      */
-    final def timeAttempt[B](fb: F[B])(
-        labelsSuccess: B => A,
-        labelsError: PartialFunction[Throwable, A],
-        recordExemplarSuccess: (FiniteDuration, B, A) => Boolean,
-        recordExemplarFailure: (FiniteDuration, Throwable, A) => Boolean
-    )(implicit
-        exemplar: prometheus4cats.Exemplar[F]
-    ): F[B] =
-      for {
-        x <- Clock[F].timed(fb.attempt)
-        _ <- x._2.fold(
-          e =>
-            labelsError
-              .lift(e)
-              .fold(Applicative[F].unit)(a =>
-                if (recordExemplarFailure(x._1, e, a)) recordTimeWithExemplar(x._1, a) else recordTime(x._1, a)
-              ),
-          b => {
-            val a = labelsSuccess(b)
-
-            if (recordExemplarSuccess(x._1, b, a)) recordTimeWithExemplar(x._1, labelsSuccess(b))
-            else recordTime(x._1, labelsSuccess(b))
-          }
-        )
-        res <- x._2.liftTo[F]
-      } yield res
-
-    /** Time an operation using an instance of [[cats.effect.kernel.Clock]], handling failures and computing labels from
-      * the result.
-      *
-      * @param fb
-      *   operation to be timed
-      * @param labelsSuccess
-      *   function to convert the successful result of `fb` to labels
-      * @param labelsError
-      *   partial function to convert an exception raised on unsuccessful operation of `fb`. If the exception does not
-      *   match the provided [[scala.PartialFunction]] then no value will be recorded.
-      */
-    final def timeAttemptWithExemplar[B](fb: F[B])(
-        labelsSuccess: B => A,
-        labelsError: PartialFunction[Throwable, A],
-        recordExemplarSuccess: (FiniteDuration, B, A) => Option[prometheus4cats.Exemplar.Labels],
-        recordExemplarFailure: (FiniteDuration, Throwable, A) => Option[prometheus4cats.Exemplar.Labels]
-    ): F[B] =
-      for {
-        x <- Clock[F].timed(fb.attempt)
-        _ <- x._2.fold(
-          e =>
-            labelsError
-              .lift(e)
-              .fold(Applicative[F].unit)(a => recordTimeWithExemplar(x._1, a, recordExemplarFailure(x._1, e, a))),
-          b => {
-            val a = labelsSuccess(b)
-
-            recordTimeWithExemplar(x._1, labelsSuccess(b), recordExemplarSuccess(x._1, b, a))
-          }
-        )
-        res <- x._2.liftTo[F]
-      } yield res
-
     def contramapLabels[B](f: B => A): Exemplar[F, B] = new Exemplar[F, B] {
       override type Metric = self.Metric
 
-      override def recordTimeWithExemplar(
+      override def recordTimeWithExemplarImpl(
           duration: FiniteDuration,
           labels: B,
           exemplar: Option[prometheus4cats.Exemplar.Labels]
-      ): F[Unit] = self.recordTimeWithExemplar(duration, f(labels), exemplar)
+      ): F[Unit] = self.recordTimeWithExemplarImpl(duration, f(labels), exemplar)
     }
 
-    def mapK[G[_]: MonadThrow: Clock](fk: F ~> G): Exemplar[G, A] = new Exemplar[G, A] {
+    def mapK[G[_]](fk: F ~> G): Exemplar[G, A] = new Exemplar[G, A] {
       override type Metric = self.Metric
 
-      override def recordTimeWithExemplar(
+      override def recordTimeWithExemplarImpl(
           duration: FiniteDuration,
           labels: A,
           exemplar: Option[prometheus4cats.Exemplar.Labels]
       ): G[Unit] =
-        fk(self.recordTimeWithExemplar(duration, labels, exemplar))
+        fk(self.recordTimeWithExemplarImpl(duration, labels, exemplar))
     }
 
   }
@@ -340,6 +231,178 @@ object Timer {
   object Exemplar {
     type Aux[F[_], A, M[_[_], _, _]] = Timer.Exemplar[F, A] {
       type Metric = M[F, Double, A]
+    }
+
+    implicit class TimerSyntax[F[_]](timer: Timer.Exemplar[F, Unit]) {
+      final def recordTime(duration: FiniteDuration): F[Unit] = timer.recordTimeImpl(duration, ())
+
+      def recordTimeWithExemplar(
+          duration: FiniteDuration
+      )(implicit F: FlatMap[F], exemplar: prometheus4cats.Exemplar[F]): F[Unit] =
+        exemplar.get.flatMap(recordTimeWithExemplar(duration, _))
+
+      def recordTimeWithExemplar(
+          duration: FiniteDuration,
+          exemplar: Option[prometheus4cats.Exemplar.Labels]
+      ): F[Unit] = timer.recordTimeWithExemplarImpl(duration, (), exemplar)
+
+      /** Time an operation using an instance of [[cats.effect.kernel.Clock]].
+        *
+        * The resulting metrics depend on the underlying implementation. See [[Timer.fromHistogram]] and
+        * [[Timer.fromGauge]] for more details.
+        *
+        * @param fb
+        *   operation to be timed
+        */
+      final def time[B](fb: F[B])(
+          recordExemplar: (FiniteDuration, B) => Boolean
+      )(implicit F: MonadThrow[F], clock: Clock[F], exemplar: prometheus4cats.Exemplar[F]): F[B] =
+        exemplar.get.flatMap(ex => timeWithExemplar(fb)((dur, b) => if (recordExemplar(dur, b)) ex else None))
+
+      final def timeWithExemplar[B](fb: F[B])(
+          recordExemplar: (FiniteDuration, B) => Option[prometheus4cats.Exemplar.Labels]
+      )(implicit F: MonadThrow[F], clock: Clock[F]): F[B] =
+        clock.timed(fb.attempt).flatMap { case (duration, b) =>
+          b match {
+            case Left(_) => recordTime(duration).flatMap(_ => b.liftTo[F])
+            case Right(value) => recordTimeWithExemplar(duration, recordExemplar(duration, value)).as(value)
+          }
+        }
+    }
+
+    implicit class LabelledTimerSyntax[F[_], A](timer: Timer.Exemplar[F, A])(implicit ev: Unit =:!= A) {
+      final def recordTime(duration: FiniteDuration, labels: A): F[Unit] = timer.recordTimeImpl(duration, labels)
+
+      def recordTimeWithExemplar(duration: FiniteDuration, labels: A)(implicit
+          F: FlatMap[F],
+          exemplar: prometheus4cats.Exemplar[F]
+      ): F[Unit] = exemplar.get.flatMap(recordTimeWithExemplar(duration, labels, _))
+
+      def recordTimeWithExemplar(
+          duration: FiniteDuration,
+          labels: A,
+          exemplar: Option[prometheus4cats.Exemplar.Labels]
+      ): F[Unit] = timer.recordTimeWithExemplarImpl(duration, labels, exemplar)
+
+      /** Time an operation using an instance of [[cats.effect.kernel.Clock]].
+        *
+        * The resulting metrics depend on the underlying implementation. See [[Timer.fromHistogram]] and
+        * [[Timer.fromGauge]] for more details.
+        *
+        * @param fb
+        *   operation to be timed
+        * @param labels
+        *   labels to add to the underlying metric
+        */
+      final def time[B](fb: F[B], labels: A)(recordExemplar: (FiniteDuration, B, A) => Boolean)(implicit
+          F: MonadThrow[F],
+          clock: Clock[F],
+          exemplar: prometheus4cats.Exemplar[F]
+      ): F[B] =
+        timeWithComputedLabels(fb)((_: B) => labels, recordExemplar)
+
+      final def timeWithExemplar[B](fb: F[B], labels: A)(
+          recordExemplar: (FiniteDuration, B, A) => Option[prometheus4cats.Exemplar.Labels]
+      )(implicit F: MonadThrow[F], clock: Clock[F]): F[B] =
+        timeWithComputedLabelsExemplar(fb)((_: B) => labels, recordExemplar)
+
+      /** Time an operation using an instance of [[cats.effect.kernel.Clock]], computing labels from the result.
+        *
+        * @param fb
+        *   operation to be timed
+        * @param labels
+        *   function to convert the result of `fb` to labels
+        */
+      final def timeWithComputedLabels[B](
+          fb: F[B]
+      )(labels: B => A, recordExemplar: (FiniteDuration, B, A) => Boolean)(implicit
+          F: MonadThrow[F],
+          clock: Clock[F],
+          exemplar: prometheus4cats.Exemplar[F]
+      ): F[B] =
+        exemplar.get.flatMap(ex =>
+          timeWithComputedLabelsExemplar(fb)(labels, (t, b, a) => ex.filter(_ => recordExemplar(t, b, a)))
+        )
+
+      final def timeWithComputedLabelsExemplar[B](
+          fb: F[B]
+      )(labels: B => A, recordExemplar: (FiniteDuration, B, A) => Option[prometheus4cats.Exemplar.Labels])(implicit
+          F: MonadThrow[F],
+          clock: Clock[F]
+      ): F[B] =
+        Clock[F].timed(fb).flatMap { case (t, b) =>
+          val a = labels(b)
+          recordTimeWithExemplar(t, a, recordExemplar(t, b, a)).as(b)
+        }
+
+      /** Time an operation using an instance of [[cats.effect.kernel.Clock]], handling failures and computing labels
+        * from the result.
+        *
+        * @param fb
+        *   operation to be timed
+        * @param labelsSuccess
+        *   function to convert the successful result of `fb` to labels
+        * @param labelsError
+        *   partial function to convert an exception raised on unsuccessful operation of `fb`. If the exception does not
+        *   match the provided [[scala.PartialFunction]] then no value will be recorded.
+        */
+      final def timeAttempt[B](fb: F[B])(
+          labelsSuccess: B => A,
+          labelsError: PartialFunction[Throwable, A],
+          recordExemplarSuccess: (FiniteDuration, B, A) => Boolean,
+          recordExemplarFailure: (FiniteDuration, Throwable, A) => Boolean
+      )(implicit F: MonadThrow[F], clock: Clock[F], exemplar: prometheus4cats.Exemplar[F]): F[B] =
+        for {
+          x <- clock.timed(fb.attempt)
+          _ <- x._2.fold(
+            e =>
+              labelsError
+                .lift(e)
+                .fold(Applicative[F].unit)(a =>
+                  if (recordExemplarFailure(x._1, e, a)) recordTimeWithExemplar(x._1, a) else recordTime(x._1, a)
+                ),
+            b => {
+              val a = labelsSuccess(b)
+
+              if (recordExemplarSuccess(x._1, b, a)) recordTimeWithExemplar(x._1, labelsSuccess(b))
+              else recordTime(x._1, labelsSuccess(b))
+            }
+          )
+          res <- x._2.liftTo[F]
+        } yield res
+
+      /** Time an operation using an instance of [[cats.effect.kernel.Clock]], handling failures and computing labels
+        * from the result.
+        *
+        * @param fb
+        *   operation to be timed
+        * @param labelsSuccess
+        *   function to convert the successful result of `fb` to labels
+        * @param labelsError
+        *   partial function to convert an exception raised on unsuccessful operation of `fb`. If the exception does not
+        *   match the provided [[scala.PartialFunction]] then no value will be recorded.
+        */
+      final def timeAttemptWithExemplar[B](fb: F[B])(
+          labelsSuccess: B => A,
+          labelsError: PartialFunction[Throwable, A],
+          recordExemplarSuccess: (FiniteDuration, B, A) => Option[prometheus4cats.Exemplar.Labels],
+          recordExemplarFailure: (FiniteDuration, Throwable, A) => Option[prometheus4cats.Exemplar.Labels]
+      )(implicit F: MonadThrow[F], clock: Clock[F]): F[B] =
+        for {
+          x <- clock.timed(fb.attempt)
+          _ <- x._2.fold(
+            e =>
+              labelsError
+                .lift(e)
+                .fold(Applicative[F].unit)(a => recordTimeWithExemplar(x._1, a, recordExemplarFailure(x._1, e, a))),
+            b => {
+              val a = labelsSuccess(b)
+
+              recordTimeWithExemplar(x._1, labelsSuccess(b), recordExemplarSuccess(x._1, b, a))
+            }
+          )
+          res <- x._2.liftTo[F]
+        } yield res
     }
 
     implicit def labelsExemplarContravariant[F[_]]: LabelsContravariant[Exemplar[F, *]] =
@@ -362,12 +425,12 @@ object Timer {
       *   a [[Timer.Exemplar.Aux]] that is annotated with the type of underlying metrics, in this case
       *   [[Histogram.Timer]]
       */
-    def fromHistogram[F[_]: MonadThrow: Clock, A](
+    def fromHistogram[F[_], A](
         histogram: Histogram[F, Double, A]
     ): Exemplar.Aux[F, A, Histogram] = new Timer.Exemplar[F, A] {
       override type Metric = Histogram[F, Double, A]
 
-      override def recordTimeWithExemplar(
+      override def recordTimeWithExemplarImpl(
           duration: FiniteDuration,
           labels: A,
           exemplar: Option[prometheus4cats.Exemplar.Labels]

--- a/core/src/main/scala/prometheus4cats/Timer.scala
+++ b/core/src/main/scala/prometheus4cats/Timer.scala
@@ -57,7 +57,7 @@ sealed abstract class Timer[F[_]: MonadThrow: Clock, A] extends Metric.Labelled[
     * @param fb
     *   operation to be timed
     */
-  final def time[B](fb: F[B])(implicit ev: A =:= Unit): F[B] = time(fb = fb, labels = ev.flip(()))
+  final def time[B](fb: F[B])(implicit ev: Unit =:= A): F[B] = time(fb = fb, labels = ev(()))
 
   /** Time an operation using an instance of [[cats.effect.kernel.Clock]], computing labels from the result.
     *

--- a/core/src/main/scala/prometheus4cats/Timer.scala
+++ b/core/src/main/scala/prometheus4cats/Timer.scala
@@ -124,10 +124,10 @@ object Timer {
       } yield res
   }
 
-  /** Create a [[Timer]] from a [[Histogram.Timer]] instance.
+  /** Create a [[Timer]] from a [[Histogram]] instance.
     *
-    * This delegates to the underlying [[Histogram.Timer]] instance and assumes you have already set up sensible buckets
-    * for the distribution of values.
+    * This delegates to the underlying [[Histogram]] instance and assumes you have already set up sensible buckets for
+    * the distribution of values.
     *
     * Values are recorded in [[scala.Double]]s by converting a [[scala.concurrent.duration.FiniteDuration]] to seconds.
     *
@@ -135,7 +135,7 @@ object Timer {
     * [[MetricFactory]].
     *
     * @return
-    *   a [[Timer.Aux]] that is annotated with the type of underlying metrics, in this case [[Histogram.Timer]]
+    *   a [[Timer.Aux]] that is annotated with the type of underlying metrics, in this case [[Histogram]]
     */
   def fromHistogram[F[_], A](
       histogram: Histogram[F, Double, A]
@@ -410,10 +410,10 @@ object Timer {
         override def contramapLabels[A, B](fa: Exemplar[F, A])(f: B => A): Exemplar[F, B] = fa.contramapLabels(f)
       }
 
-    /** Create a [[Timer.Exemplar]] from a [[Histogram.Timer]] instance.
+    /** Create a [[Timer.Exemplar]] from a [[Histogram]] instance.
       *
-      * This delegates to the underlying [[Histogram.Timer]] instance and assumes you have already set up sensible
-      * buckets for the distribution of values.
+      * This delegates to the underlying [[Histogram]] instance and assumes you have already set up sensible buckets for
+      * the distribution of values.
       *
       * Values are recorded in [[scala.Double]]s by converting a [[scala.concurrent.duration.FiniteDuration]] to
       * seconds.
@@ -422,8 +422,7 @@ object Timer {
       * provided by [[MetricFactory]].
       *
       * @return
-      *   a [[Timer.Exemplar.Aux]] that is annotated with the type of underlying metrics, in this case
-      *   [[Histogram.Timer]]
+      *   a [[Timer.Exemplar.Aux]] that is annotated with the type of underlying metrics, in this case [[Histogram]]
       */
     def fromHistogram[F[_], A](
         histogram: Histogram[F, Double, A]

--- a/core/src/main/scala/prometheus4cats/internal/package.scala
+++ b/core/src/main/scala/prometheus4cats/internal/package.scala
@@ -50,22 +50,22 @@ object BuildStep {
     def asTimer(implicit F: MonadThrow[F], clock: Clock[F]): BuildStep[F, Timer.Aux[F, Unit, Gauge]] =
       bs.map(Timer.fromGauge[F, Unit])
 
-    def asCurrentTimeRecorder(implicit F: FlatMap[F], clock: Clock[F]): BuildStep[F, CurrentTimeRecorder[F]] =
+    def asCurrentTimeRecorder(implicit F: FlatMap[F], clock: Clock[F]): BuildStep[F, CurrentTimeRecorder[F, Unit]] =
       asCurrentTimeRecorder(_.toSeconds.toDouble)
 
     def asCurrentTimeRecorder(
         f: FiniteDuration => Double
-    )(implicit F: FlatMap[F], clock: Clock[F]): BuildStep[F, CurrentTimeRecorder[F]] =
+    )(implicit F: FlatMap[F], clock: Clock[F]): BuildStep[F, CurrentTimeRecorder[F, Unit]] =
       bs.map(CurrentTimeRecorder.fromDoubleGauge(_)(f))
   }
 
   implicit class LongGaugeSyntax[F[_]](bs: BuildStep[F, Gauge[F, Long, Unit]]) {
-    def asCurrentTimeRecorder(implicit F: FlatMap[F], clock: Clock[F]): BuildStep[F, CurrentTimeRecorder[F]] =
+    def asCurrentTimeRecorder(implicit F: FlatMap[F], clock: Clock[F]): BuildStep[F, CurrentTimeRecorder[F, Unit]] =
       asCurrentTimeRecorder(_.toSeconds)
 
     def asCurrentTimeRecorder(
         f: FiniteDuration => Long
-    )(implicit F: FlatMap[F], clock: Clock[F]): BuildStep[F, CurrentTimeRecorder[F]] =
+    )(implicit F: FlatMap[F], clock: Clock[F]): BuildStep[F, CurrentTimeRecorder[F, Unit]] =
       bs.map(CurrentTimeRecorder.fromLongGauge(_)(f))
   }
 
@@ -89,14 +89,14 @@ object BuildStep {
     def asCurrentTimeRecorder(implicit
         F: FlatMap[F],
         clock: Clock[F]
-    ): BuildStep[F, CurrentTimeRecorder.Labelled[F, A]] = asCurrentTimeRecorder(
+    ): BuildStep[F, CurrentTimeRecorder[F, A]] = asCurrentTimeRecorder(
       _.toSeconds.toDouble
     )
 
     def asCurrentTimeRecorder(
         f: FiniteDuration => Double
-    )(implicit F: FlatMap[F], clock: Clock[F]): BuildStep[F, CurrentTimeRecorder.Labelled[F, A]] =
-      bs.map(CurrentTimeRecorder.Labelled.fromDoubleGauge(_)(f))
+    )(implicit F: FlatMap[F], clock: Clock[F]): BuildStep[F, CurrentTimeRecorder[F, A]] =
+      bs.map(CurrentTimeRecorder.fromDoubleGauge(_)(f))
   }
 
   implicit class LongLabelledGaugeSyntax[F[_], A](
@@ -105,12 +105,12 @@ object BuildStep {
     def asCurrentTimeRecorder(implicit
         F: FlatMap[F],
         clock: Clock[F]
-    ): BuildStep[F, CurrentTimeRecorder.Labelled[F, A]] = asCurrentTimeRecorder(_.toSeconds)
+    ): BuildStep[F, CurrentTimeRecorder[F, A]] = asCurrentTimeRecorder(_.toSeconds)
 
     def asCurrentTimeRecorder(
         f: FiniteDuration => Long
-    )(implicit F: FlatMap[F], clock: Clock[F]): BuildStep[F, CurrentTimeRecorder.Labelled[F, A]] =
-      bs.map(CurrentTimeRecorder.Labelled.fromLongGauge(_)(f))
+    )(implicit F: FlatMap[F], clock: Clock[F]): BuildStep[F, CurrentTimeRecorder[F, A]] =
+      bs.map(CurrentTimeRecorder.fromLongGauge(_)(f))
   }
 
   implicit class DoubleLabelledHistogramSyntax[F[_], A](

--- a/core/src/main/scala/prometheus4cats/internal/summary/SummaryDsl.scala
+++ b/core/src/main/scala/prometheus4cats/internal/summary/SummaryDsl.scala
@@ -27,23 +27,23 @@ final class SummaryDsl[F[_], A] private[prometheus4cats] (
     quantiles: Seq[QuantileDefinition] = SummaryDsl.defaultQuantiles,
     maxAgeValue: FiniteDuration = SummaryDsl.defaultMaxAge,
     ageBucketsValue: Summary.AgeBuckets = Summary.AgeBuckets.Default,
-    makeLabelledSummary: (
+    makeSummary: (
         Seq[QuantileDefinition],
         FiniteDuration,
         Summary.AgeBuckets
     ) => LabelledMetricPartiallyApplied[F, A, Summary]
-) extends MetricDsl[F, A, Summary](makeLabelledSummary(quantiles, maxAgeValue, ageBucketsValue))
+) extends MetricDsl[F, A, Summary](makeSummary(quantiles, maxAgeValue, ageBucketsValue))
     with SummaryDsl.Base[F, A] {
   override def quantile(quantile: Summary.Quantile, error: Summary.AllowedError): SummaryDsl[F, A] =
     new SummaryDsl[F, A](
       quantiles :+ QuantileDefinition(quantile, error),
       maxAgeValue,
       ageBucketsValue,
-      makeLabelledSummary
+      makeSummary
     )
 
   override def maxAge(age: FiniteDuration): AgeBucketsStep[F, A] =
-    new AgeBucketsStep[F, A](quantiles, age, ageBucketsValue, makeLabelledSummary)
+    new AgeBucketsStep[F, A](quantiles, age, ageBucketsValue, makeSummary)
 }
 
 object SummaryDsl {
@@ -75,15 +75,15 @@ object SummaryDsl {
       quantiles: Seq[QuantileDefinition] = SummaryDsl.defaultQuantiles,
       maxAgeValue: FiniteDuration = SummaryDsl.defaultMaxAge,
       ageBucketsValue: Summary.AgeBuckets = Summary.AgeBuckets.Default,
-      makeLabelledSummary: (
+      makeSummary: (
           Seq[QuantileDefinition],
           FiniteDuration,
           Summary.AgeBuckets
       ) => LabelledMetricPartiallyApplied[F, A, Summary],
-      makeLabelledSummaryCallback: LabelledCallbackPartiallyApplied[F, A0]
+      makeSummaryCallback: LabelledCallbackPartiallyApplied[F, A0]
   ) extends MetricDsl.WithCallbacks[F, A, A0, Summary](
-        makeLabelledSummary(quantiles, maxAgeValue, ageBucketsValue),
-        makeLabelledSummaryCallback
+        makeSummary(quantiles, maxAgeValue, ageBucketsValue),
+        makeSummaryCallback
       )
       with Base[F, A] {
     override def quantile(quantile: Summary.Quantile, error: Summary.AllowedError): SummaryDsl[F, A] =
@@ -91,11 +91,11 @@ object SummaryDsl {
         quantiles :+ QuantileDefinition(quantile, error),
         maxAgeValue,
         ageBucketsValue,
-        makeLabelledSummary
+        makeSummary
       )
 
     override def maxAge(age: FiniteDuration): AgeBucketsStep[F, A] =
-      new AgeBucketsStep[F, A](quantiles, age, ageBucketsValue, makeLabelledSummary)
+      new AgeBucketsStep[F, A](quantiles, age, ageBucketsValue, makeSummary)
   }
 }
 
@@ -103,16 +103,16 @@ final class AgeBucketsStep[F[_], A] private[summary] (
     quantiles: Seq[QuantileDefinition],
     maxAgeValue: FiniteDuration,
     ageBucketsValue: Summary.AgeBuckets,
-    makeLabelledSummary: (
+    makeSummary: (
         Seq[QuantileDefinition],
         FiniteDuration,
         Summary.AgeBuckets
     ) => LabelledMetricPartiallyApplied[F, A, Summary]
 ) extends MetricDsl[F, A, Summary](
-      makeLabelledSummary(quantiles, maxAgeValue, ageBucketsValue)
+      makeSummary(quantiles, maxAgeValue, ageBucketsValue)
     ) {
   def ageBuckets(buckets: Summary.AgeBuckets): MetricDsl[F, A, Summary] =
     new MetricDsl[F, A, Summary](
-      makeLabelledSummary(quantiles, maxAgeValue, buckets)
+      makeSummary(quantiles, maxAgeValue, buckets)
     )
 }

--- a/core/src/main/scala/prometheus4cats/package.scala
+++ b/core/src/main/scala/prometheus4cats/package.scala
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
+import scala.annotation.nowarn
+
 import prometheus4cats.internal.ShapelessPolyfill
 
 package object prometheus4cats extends ShapelessPolyfill {
   def unexpected: Nothing = sys.error("Unexpected invocation")
 
-  trait =:!=[A, B] extends Serializable
+  @nowarn trait =:!=[A, B] extends Serializable
 
   implicit def neq[A, B]: A =:!= B = new =:!=[A, B] {}
 

--- a/core/src/main/scala/prometheus4cats/package.scala
+++ b/core/src/main/scala/prometheus4cats/package.scala
@@ -16,4 +16,14 @@
 
 import prometheus4cats.internal.ShapelessPolyfill
 
-package object prometheus4cats extends ShapelessPolyfill
+package object prometheus4cats extends ShapelessPolyfill {
+  def unexpected: Nothing = sys.error("Unexpected invocation")
+
+  trait =:!=[A, B] extends Serializable
+
+  implicit def neq[A, B]: A =:!= B = new =:!=[A, B] {}
+
+  implicit def neqAmbig1[A]: A =:!= A = unexpected
+
+  implicit def neqAmbig2[A]: A =:!= A = unexpected
+}

--- a/core/src/main/scala/prometheus4cats/util/DoubleCallbackRegistry.scala
+++ b/core/src/main/scala/prometheus4cats/util/DoubleCallbackRegistry.scala
@@ -25,22 +25,14 @@ import prometheus4cats._
 trait DoubleCallbackRegistry[F[_]] extends CallbackRegistry[F] {
   implicit protected val F: Functor[F]
 
-  override def registerLongCounterCallback(
-      prefix: Option[Metric.Prefix],
-      name: Counter.Name,
-      help: Metric.Help,
-      commonLabels: Metric.CommonLabels,
-      callback: F[Long]
-  ): Resource[F, Unit] = registerDoubleCounterCallback(prefix, name, help, commonLabels, callback.map(_.toDouble))
-
-  override def registerLabelledLongCounterCallback[A](
+  override def registerLongCounterCallback[A](
       prefix: Option[Metric.Prefix],
       name: Counter.Name,
       help: Metric.Help,
       commonLabels: Metric.CommonLabels,
       labelNames: IndexedSeq[Label.Name],
       callback: F[NonEmptyList[(Long, A)]]
-  )(f: A => IndexedSeq[String]): Resource[F, Unit] = registerLabelledDoubleCounterCallback(
+  )(f: A => IndexedSeq[String]): Resource[F, Unit] = registerDoubleCounterCallback(
     prefix,
     name,
     help,
@@ -49,22 +41,14 @@ trait DoubleCallbackRegistry[F[_]] extends CallbackRegistry[F] {
     callback.map(_.map { case (v, a) => v.toDouble -> a })
   )(f)
 
-  override def registerLongGaugeCallback(
-      prefix: Option[Metric.Prefix],
-      name: Gauge.Name,
-      help: Metric.Help,
-      commonLabels: Metric.CommonLabels,
-      callback: F[Long]
-  ): Resource[F, Unit] = registerDoubleGaugeCallback(prefix, name, help, commonLabels, callback.map(_.toDouble))
-
-  override def registerLabelledLongGaugeCallback[A](
+  override def registerLongGaugeCallback[A](
       prefix: Option[Metric.Prefix],
       name: Gauge.Name,
       help: Metric.Help,
       commonLabels: Metric.CommonLabels,
       labelNames: IndexedSeq[Label.Name],
       callback: F[NonEmptyList[(Long, A)]]
-  )(f: A => IndexedSeq[String]): Resource[F, Unit] = registerLabelledDoubleGaugeCallback(
+  )(f: A => IndexedSeq[String]): Resource[F, Unit] = registerDoubleGaugeCallback(
     prefix,
     name,
     help,
@@ -73,23 +57,7 @@ trait DoubleCallbackRegistry[F[_]] extends CallbackRegistry[F] {
     callback.map(_.map { case (v, a) => v.toDouble -> a })
   )(f)
 
-  override def registerLongHistogramCallback(
-      prefix: Option[Metric.Prefix],
-      name: Histogram.Name,
-      help: Metric.Help,
-      commonLabels: Metric.CommonLabels,
-      buckets: NonEmptySeq[Long],
-      callback: F[Histogram.Value[Long]]
-  ): Resource[F, Unit] = registerDoubleHistogramCallback(
-    prefix,
-    name,
-    help,
-    commonLabels,
-    buckets.map(_.toDouble),
-    callback.map(_.map(_.toDouble))
-  )
-
-  override def registerLabelledLongHistogramCallback[A](
+  override def registerLongHistogramCallback[A](
       prefix: Option[Metric.Prefix],
       name: Histogram.Name,
       help: Metric.Help,
@@ -97,7 +65,7 @@ trait DoubleCallbackRegistry[F[_]] extends CallbackRegistry[F] {
       labelNames: IndexedSeq[Label.Name],
       buckets: NonEmptySeq[Long],
       callback: F[NonEmptyList[(Histogram.Value[Long], A)]]
-  )(f: A => IndexedSeq[String]): Resource[F, Unit] = registerLabelledDoubleHistogramCallback(
+  )(f: A => IndexedSeq[String]): Resource[F, Unit] = registerDoubleHistogramCallback(
     prefix,
     name,
     help,
@@ -107,28 +75,14 @@ trait DoubleCallbackRegistry[F[_]] extends CallbackRegistry[F] {
     callback.map(_.map { case (v, a) => v.map(_.toDouble) -> a })
   )(f)
 
-  override def registerLongSummaryCallback(
-      prefix: Option[Metric.Prefix],
-      name: Summary.Name,
-      help: Metric.Help,
-      commonLabels: Metric.CommonLabels,
-      callback: F[Summary.Value[Long]]
-  ): Resource[F, Unit] = registerDoubleSummaryCallback(
-    prefix,
-    name,
-    help,
-    commonLabels,
-    callback.map(_.map(_.toDouble))
-  )
-
-  override def registerLabelledLongSummaryCallback[A](
+  override def registerLongSummaryCallback[A](
       prefix: Option[Metric.Prefix],
       name: Summary.Name,
       help: Metric.Help,
       commonLabels: Metric.CommonLabels,
       labelNames: IndexedSeq[Label.Name],
       callback: F[NonEmptyList[(Summary.Value[Long], A)]]
-  )(f: A => IndexedSeq[String]): Resource[F, Unit] = registerLabelledDoubleSummaryCallback(
+  )(f: A => IndexedSeq[String]): Resource[F, Unit] = registerDoubleSummaryCallback(
     prefix,
     name,
     help,

--- a/core/src/main/scala/prometheus4cats/util/DoubleMetricRegistry.scala
+++ b/core/src/main/scala/prometheus4cats/util/DoubleMetricRegistry.scala
@@ -28,7 +28,7 @@ trait DoubleMetricRegistry[F[_]] extends MetricRegistry[F] {
       name: Counter.Name,
       help: Metric.Help,
       commonLabels: Metric.CommonLabels
-  ): Resource[F, Counter[F, Long]] =
+  ): Resource[F, Counter[F, Long, Unit]] =
     createAndRegisterDoubleCounter(prefix, name, help, commonLabels).map(_.contramap(_.toDouble))
 
   override def createAndRegisterLabelledLongCounter[A](
@@ -37,7 +37,7 @@ trait DoubleMetricRegistry[F[_]] extends MetricRegistry[F] {
       help: Metric.Help,
       commonLabels: Metric.CommonLabels,
       labelNames: IndexedSeq[Label.Name]
-  )(f: A => IndexedSeq[String]): Resource[F, Counter.Labelled[F, Long, A]] =
+  )(f: A => IndexedSeq[String]): Resource[F, Counter[F, Long, A]] =
     createAndRegisterLabelledDoubleCounter(prefix, name, help, commonLabels, labelNames)(f).map(_.contramap(_.toDouble))
 
   override def createAndRegisterLongGauge(
@@ -45,7 +45,7 @@ trait DoubleMetricRegistry[F[_]] extends MetricRegistry[F] {
       name: Gauge.Name,
       help: Metric.Help,
       commonLabels: Metric.CommonLabels
-  ): Resource[F, Gauge[F, Long]] =
+  ): Resource[F, Gauge[F, Long, Unit]] =
     createAndRegisterDoubleGauge(prefix, name, help, commonLabels).map(_.contramap(_.toDouble))
 
   override def createAndRegisterLabelledLongGauge[A](
@@ -54,7 +54,7 @@ trait DoubleMetricRegistry[F[_]] extends MetricRegistry[F] {
       help: Metric.Help,
       commonLabels: Metric.CommonLabels,
       labelNames: IndexedSeq[Label.Name]
-  )(f: A => IndexedSeq[String]): Resource[F, Gauge.Labelled[F, Long, A]] =
+  )(f: A => IndexedSeq[String]): Resource[F, Gauge[F, Long, A]] =
     createAndRegisterLabelledDoubleGauge(prefix, name, help, commonLabels, labelNames)(f).map(_.contramap(_.toDouble))
 
   override def createAndRegisterLongHistogram(
@@ -63,7 +63,7 @@ trait DoubleMetricRegistry[F[_]] extends MetricRegistry[F] {
       help: Metric.Help,
       commonLabels: Metric.CommonLabels,
       buckets: NonEmptySeq[Long]
-  ): Resource[F, Histogram[F, Long]] =
+  ): Resource[F, Histogram[F, Long, Unit]] =
     createAndRegisterDoubleHistogram(prefix, name, help, commonLabels, buckets.map(_.toDouble))
       .map(_.contramap(_.toDouble))
 
@@ -74,7 +74,7 @@ trait DoubleMetricRegistry[F[_]] extends MetricRegistry[F] {
       commonLabels: Metric.CommonLabels,
       labelNames: IndexedSeq[Label.Name],
       buckets: NonEmptySeq[Long]
-  )(f: A => IndexedSeq[String]): Resource[F, Histogram.Labelled[F, Long, A]] =
+  )(f: A => IndexedSeq[String]): Resource[F, Histogram[F, Long, A]] =
     createAndRegisterLabelledDoubleHistogram(prefix, name, help, commonLabels, labelNames, buckets.map(_.toDouble))(f)
       .map(
         _.contramap(_.toDouble)
@@ -88,7 +88,7 @@ trait DoubleMetricRegistry[F[_]] extends MetricRegistry[F] {
       quantiles: Seq[Summary.QuantileDefinition],
       maxAge: FiniteDuration,
       ageBuckets: Summary.AgeBuckets
-  ): Resource[F, Summary[F, Long]] =
+  ): Resource[F, Summary[F, Long, Unit]] =
     createAndRegisterDoubleSummary(prefix, name, help, commonLabels, quantiles, maxAge, ageBuckets).map(
       _.contramap(_.toDouble)
     )
@@ -102,7 +102,7 @@ trait DoubleMetricRegistry[F[_]] extends MetricRegistry[F] {
       quantiles: Seq[Summary.QuantileDefinition],
       maxAge: FiniteDuration,
       ageBuckets: Summary.AgeBuckets
-  )(f: A => IndexedSeq[String]): Resource[F, Summary.Labelled[F, Long, A]] =
+  )(f: A => IndexedSeq[String]): Resource[F, Summary[F, Long, A]] =
     createAndRegisterLabelledDoubleSummary(prefix, name, help, commonLabels, labelNames, quantiles, maxAge, ageBuckets)(
       f
     ).map(_.contramap(_.toDouble))

--- a/core/src/main/scala/prometheus4cats/util/DoubleMetricRegistry.scala
+++ b/core/src/main/scala/prometheus4cats/util/DoubleMetricRegistry.scala
@@ -23,51 +23,26 @@ import prometheus4cats._
 import scala.concurrent.duration.FiniteDuration
 
 trait DoubleMetricRegistry[F[_]] extends MetricRegistry[F] {
-  override def createAndRegisterLongCounter(
-      prefix: Option[Metric.Prefix],
-      name: Counter.Name,
-      help: Metric.Help,
-      commonLabels: Metric.CommonLabels
-  ): Resource[F, Counter[F, Long, Unit]] =
-    createAndRegisterDoubleCounter(prefix, name, help, commonLabels).map(_.contramap(_.toDouble))
 
-  override def createAndRegisterLabelledLongCounter[A](
+  override def createAndRegisterLongCounter[A](
       prefix: Option[Metric.Prefix],
       name: Counter.Name,
       help: Metric.Help,
       commonLabels: Metric.CommonLabels,
       labelNames: IndexedSeq[Label.Name]
   )(f: A => IndexedSeq[String]): Resource[F, Counter[F, Long, A]] =
-    createAndRegisterLabelledDoubleCounter(prefix, name, help, commonLabels, labelNames)(f).map(_.contramap(_.toDouble))
+    createAndRegisterDoubleCounter(prefix, name, help, commonLabels, labelNames)(f).map(_.contramap(_.toDouble))
 
-  override def createAndRegisterLongGauge(
-      prefix: Option[Metric.Prefix],
-      name: Gauge.Name,
-      help: Metric.Help,
-      commonLabels: Metric.CommonLabels
-  ): Resource[F, Gauge[F, Long, Unit]] =
-    createAndRegisterDoubleGauge(prefix, name, help, commonLabels).map(_.contramap(_.toDouble))
-
-  override def createAndRegisterLabelledLongGauge[A](
+  override def createAndRegisterLongGauge[A](
       prefix: Option[Metric.Prefix],
       name: Gauge.Name,
       help: Metric.Help,
       commonLabels: Metric.CommonLabels,
       labelNames: IndexedSeq[Label.Name]
   )(f: A => IndexedSeq[String]): Resource[F, Gauge[F, Long, A]] =
-    createAndRegisterLabelledDoubleGauge(prefix, name, help, commonLabels, labelNames)(f).map(_.contramap(_.toDouble))
+    createAndRegisterDoubleGauge(prefix, name, help, commonLabels, labelNames)(f).map(_.contramap(_.toDouble))
 
-  override def createAndRegisterLongHistogram(
-      prefix: Option[Metric.Prefix],
-      name: Histogram.Name,
-      help: Metric.Help,
-      commonLabels: Metric.CommonLabels,
-      buckets: NonEmptySeq[Long]
-  ): Resource[F, Histogram[F, Long, Unit]] =
-    createAndRegisterDoubleHistogram(prefix, name, help, commonLabels, buckets.map(_.toDouble))
-      .map(_.contramap(_.toDouble))
-
-  override def createAndRegisterLabelledLongHistogram[A](
+  override def createAndRegisterLongHistogram[A](
       prefix: Option[Metric.Prefix],
       name: Histogram.Name,
       help: Metric.Help,
@@ -75,25 +50,12 @@ trait DoubleMetricRegistry[F[_]] extends MetricRegistry[F] {
       labelNames: IndexedSeq[Label.Name],
       buckets: NonEmptySeq[Long]
   )(f: A => IndexedSeq[String]): Resource[F, Histogram[F, Long, A]] =
-    createAndRegisterLabelledDoubleHistogram(prefix, name, help, commonLabels, labelNames, buckets.map(_.toDouble))(f)
+    createAndRegisterDoubleHistogram(prefix, name, help, commonLabels, labelNames, buckets.map(_.toDouble))(f)
       .map(
         _.contramap(_.toDouble)
       )
 
-  override def createAndRegisterLongSummary(
-      prefix: Option[Metric.Prefix],
-      name: Summary.Name,
-      help: Metric.Help,
-      commonLabels: Metric.CommonLabels,
-      quantiles: Seq[Summary.QuantileDefinition],
-      maxAge: FiniteDuration,
-      ageBuckets: Summary.AgeBuckets
-  ): Resource[F, Summary[F, Long, Unit]] =
-    createAndRegisterDoubleSummary(prefix, name, help, commonLabels, quantiles, maxAge, ageBuckets).map(
-      _.contramap(_.toDouble)
-    )
-
-  override def createAndRegisterLabelledLongSummary[A](
+  override def createAndRegisterLongSummary[A](
       prefix: Option[Metric.Prefix],
       name: Summary.Name,
       help: Metric.Help,
@@ -103,7 +65,7 @@ trait DoubleMetricRegistry[F[_]] extends MetricRegistry[F] {
       maxAge: FiniteDuration,
       ageBuckets: Summary.AgeBuckets
   )(f: A => IndexedSeq[String]): Resource[F, Summary[F, Long, A]] =
-    createAndRegisterLabelledDoubleSummary(prefix, name, help, commonLabels, labelNames, quantiles, maxAge, ageBuckets)(
+    createAndRegisterDoubleSummary(prefix, name, help, commonLabels, labelNames, quantiles, maxAge, ageBuckets)(
       f
     ).map(_.contramap(_.toDouble))
 }

--- a/core/src/test/scala/prometheus4cats/CurrentTimeRecorderSuite.scala
+++ b/core/src/test/scala/prometheus4cats/CurrentTimeRecorderSuite.scala
@@ -28,7 +28,7 @@ import org.scalacheck.{Arbitrary, Gen}
 import scala.concurrent.duration._
 
 class CurrentTimeRecorderSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
-  def write[A]: A => WriterT[IO, List[A], Unit] = d => WriterT.tell(List(d))
+  def write[A]: (A, Unit) => WriterT[IO, List[A], Unit] = (d, _: Unit) => WriterT.tell(List(d))
 
   val longGauge =
     CurrentTimeRecorder.fromLongGauge(
@@ -50,7 +50,7 @@ class CurrentTimeRecorderSuite extends CatsEffectSuite with ScalaCheckEffectSuit
   def writeLabels[A, B]: (A, B) => WriterT[IO, List[(A, B)], Unit] = (a, b) => WriterT.tell(List(a -> b))
 
   val labelledLongGauge = CurrentTimeRecorder.Labelled.fromLongGauge(
-    Gauge.Labelled.make(
+    Gauge.make(
       writeLabels[Long, String],
       writeLabels[Long, String],
       writeLabels[Long, String]
@@ -58,7 +58,7 @@ class CurrentTimeRecorderSuite extends CatsEffectSuite with ScalaCheckEffectSuit
   )(_)
 
   val labelledDoubleGauge = CurrentTimeRecorder.Labelled.fromDoubleGauge(
-    Gauge.Labelled.make(
+    Gauge.make(
       writeLabels[Double, String],
       writeLabels[Double, String],
       writeLabels[Double, String]

--- a/core/src/test/scala/prometheus4cats/CurrentTimeRecorderSuite.scala
+++ b/core/src/test/scala/prometheus4cats/CurrentTimeRecorderSuite.scala
@@ -49,7 +49,7 @@ class CurrentTimeRecorderSuite extends CatsEffectSuite with ScalaCheckEffectSuit
 
   def writeLabels[A, B]: (A, B) => WriterT[IO, List[(A, B)], Unit] = (a, b) => WriterT.tell(List(a -> b))
 
-  val labelledLongGauge = CurrentTimeRecorder.Labelled.fromLongGauge(
+  val labelledLongGauge = CurrentTimeRecorder.fromLongGauge(
     Gauge.make(
       writeLabels[Long, String],
       writeLabels[Long, String],
@@ -57,7 +57,7 @@ class CurrentTimeRecorderSuite extends CatsEffectSuite with ScalaCheckEffectSuit
     )
   )(_)
 
-  val labelledDoubleGauge = CurrentTimeRecorder.Labelled.fromDoubleGauge(
+  val labelledDoubleGauge = CurrentTimeRecorder.fromDoubleGauge(
     Gauge.make(
       writeLabels[Double, String],
       writeLabels[Double, String],

--- a/core/src/test/scala/prometheus4cats/OutcomeRecorderSuite.scala
+++ b/core/src/test/scala/prometheus4cats/OutcomeRecorderSuite.scala
@@ -71,7 +71,7 @@ class OutcomeRecorderSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
       val nonZero = Math.abs(i) + 1
 
       opCounter.flatMap { case (counter, res) =>
-        counter.surround(IO.unit, ()).replicateA(nonZero) >> res.map(
+        counter.surround(IO.unit).replicateA(nonZero) >> res.map(
           assertEquals(_, Map[Status, Int](Status.Succeeded -> nonZero))
         )
       }
@@ -83,7 +83,7 @@ class OutcomeRecorderSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
       val nonZero = Math.abs(i) + 1
 
       opGauge.flatMap { case (gauge, res) =>
-        gauge.surround(IO.unit, ()).replicateA(nonZero) >> res.map(
+        gauge.surround(IO.unit).replicateA(nonZero) >> res.map(
           assertEquals(_, Map[Status, Int](Status.Succeeded -> 1, Status.Errored -> 0, Status.Canceled -> 0))
         )
       }
@@ -97,7 +97,7 @@ class OutcomeRecorderSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
       opCounter.flatMap { case (counter, res) =>
         // the deferred in the race here gives time for the finalizers to be registered on the first IO
         IO.deferred[Unit]
-          .flatMap(wait => counter.surround(wait.complete(()) >> IO.never, ()).race(wait.get))
+          .flatMap(wait => counter.surround(wait.complete(()) >> IO.never).race(wait.get))
           .replicateA(nonZero) >> res
           .map(
             assertEquals(_, Map[Status, Int](Status.Canceled -> nonZero))
@@ -113,7 +113,7 @@ class OutcomeRecorderSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
       opGauge.flatMap { case (gauge, res) =>
         // the deferred in the race here gives time for the finalizers to be registered on the first IO
         IO.deferred[Unit]
-          .flatMap(wait => gauge.surround(wait.complete(()) >> IO.never, ()).race(wait.get))
+          .flatMap(wait => gauge.surround(wait.complete(()) >> IO.never).race(wait.get))
           .replicateA(nonZero) >> res
           .map(
             assertEquals(_, Map[Status, Int](Status.Succeeded -> 0, Status.Errored -> 0, Status.Canceled -> 1))
@@ -127,7 +127,7 @@ class OutcomeRecorderSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
       val nonZero = Math.abs(i) + 1
 
       opCounter.flatMap { case (counter, res) =>
-        counter.surround(IO.raiseError(new RuntimeException()), ()).attempt.replicateA(nonZero) >> res.map(
+        counter.surround(IO.raiseError(new RuntimeException())).attempt.replicateA(nonZero) >> res.map(
           assertEquals(_, Map[Status, Int](Status.Errored -> nonZero))
         )
       }
@@ -139,7 +139,7 @@ class OutcomeRecorderSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
       val nonZero = Math.abs(i) + 1
 
       opGauge.flatMap { case (gauge, res) =>
-        gauge.surround(IO.raiseError(new RuntimeException()), ()).attempt.replicateA(nonZero) >> res.map(
+        gauge.surround(IO.raiseError(new RuntimeException())).attempt.replicateA(nonZero) >> res.map(
           assertEquals(_, Map[Status, Int](Status.Succeeded -> 0, Status.Errored -> 1, Status.Canceled -> 0))
         )
       }

--- a/core/src/test/scala/prometheus4cats/OutcomeRecorderSuite.scala
+++ b/core/src/test/scala/prometheus4cats/OutcomeRecorderSuite.scala
@@ -27,16 +27,14 @@ class OutcomeRecorderSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
   val opCounter: IO[(OutcomeRecorder[IO], IO[Map[Status, Int]])] =
     Ref.of[IO, Map[Status, Int]](Map.empty).map { ref =>
       OutcomeRecorder.fromCounter(
-        Counter.Labelled.make[IO, Int, Status]((i: Int, s: Status, _: Option[Exemplar.Labels]) =>
-          ref.update(_ |+| Map(s -> i))
-        )
+        Counter.make[IO, Int, Status]((i: Int, s: Status, _: Option[Exemplar.Labels]) => ref.update(_ |+| Map(s -> i)))
       ) -> ref.get
     }
 
   val opGauge: IO[(OutcomeRecorder[IO], IO[Map[Status, Int]])] =
     Ref.of[IO, Map[Status, Int]](Map.empty).map { ref =>
       OutcomeRecorder.fromGauge(
-        Gauge.Labelled.make[IO, Int, Status](
+        Gauge.make[IO, Int, Status](
           (i: Int, s: Status) => ref.update(_ |+| Map(s -> i)),
           (i: Int, s: Status) => ref.update(_ |+| Map(s -> -i)),
           (i: Int, s: Status) => ref.update(_.updated(s, i))
@@ -47,7 +45,7 @@ class OutcomeRecorderSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
   val labelledOpCounter: IO[(OutcomeRecorder.Labelled[IO, String], IO[Map[(String, Status), Int]])] =
     Ref.of[IO, Map[(String, Status), Int]](Map.empty).map { ref =>
       OutcomeRecorder.Labelled.fromCounter(
-        Counter.Labelled.make[IO, Int, (String, Status)]((i: Int, s: (String, Status), _: Option[Exemplar.Labels]) =>
+        Counter.make[IO, Int, (String, Status)]((i: Int, s: (String, Status), _: Option[Exemplar.Labels]) =>
           ref.update(_ |+| Map(s -> i))
         )
       ) -> ref.get
@@ -56,7 +54,7 @@ class OutcomeRecorderSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
   val labelledOpGauge: IO[(OutcomeRecorder.Labelled[IO, String], IO[Map[(String, Status), Int]])] =
     Ref.of[IO, Map[(String, Status), Int]](Map.empty).map { ref =>
       OutcomeRecorder.Labelled.fromGauge(
-        Gauge.Labelled.make[IO, Int, (String, Status)](
+        Gauge.make[IO, Int, (String, Status)](
           (i: Int, s: (String, Status)) => ref.update(_ |+| Map(s -> i)),
           (i: Int, s: (String, Status)) => ref.update(_ |+| Map(s -> -i)),
           (i: Int, s: (String, Status)) => ref.update(_.updated(s, i))

--- a/core/src/test/scala/prometheus4cats/TimerSuite.scala
+++ b/core/src/test/scala/prometheus4cats/TimerSuite.scala
@@ -34,7 +34,7 @@ class TimerSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
   val write: (Double, Unit) => WriterT[IO, List[Double], Unit] = (d, _: Unit) => WriterT.tell[IO, List[Double]](List(d))
 
   val hist =
-    Timer.fromHistogram(Histogram.make((d, l, _) => write(d, l)))
+    Timer.fromHistogram(Histogram.make[WriterT[IO, List[Double], *], Double, Unit]((d, l, _) => write(d, l)))
 
   val gauge =
     Timer.fromGauge(

--- a/core/src/test/scala/prometheus4cats/TimerSuite.scala
+++ b/core/src/test/scala/prometheus4cats/TimerSuite.scala
@@ -31,10 +31,10 @@ import org.scalacheck.{Arbitrary, Gen}
 import scala.concurrent.duration._
 
 class TimerSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
-  val write: Double => WriterT[IO, List[Double], Unit] = d => WriterT.tell[IO, List[Double]](List(d))
+  val write: (Double, Unit) => WriterT[IO, List[Double], Unit] = (d, _: Unit) => WriterT.tell[IO, List[Double]](List(d))
 
   val hist =
-    Timer.fromHistogram(Histogram.make((d, _) => write(d)))
+    Timer.fromHistogram(Histogram.make((d, l, _) => write(d, l)))
 
   val gauge =
     Timer.fromGauge(
@@ -49,10 +49,10 @@ class TimerSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
     WriterT.tell[IO, List[(Double, A)]](List(d -> a))
 
   val labelledHistogram =
-    Timer.Labelled.fromHistogram(Histogram.Labelled.make((d, a: String, _) => writeLabels[String](d, a)))
+    Timer.fromHistogram(Histogram.make((d, a: String, _) => writeLabels[String](d, a)))
 
-  val labelledGauge = Timer.Labelled.fromGauge(
-    Gauge.Labelled.make(
+  val labelledGauge = Timer.fromGauge(
+    Gauge.make(
       writeLabels[String],
       writeLabels[String],
       writeLabels[String]
@@ -105,7 +105,7 @@ class TimerSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
             } yield ()
 
           }
-      test(hist.time) >> test(gauge.time)
+      test(hist.time(_)) >> test(gauge.time(_))
     }
   }
 
@@ -131,7 +131,8 @@ class TimerSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
 
           }
 
-      test(labelledHistogram.time) >> test(labelledGauge.time)
+      test { case (fa, labels) => labelledHistogram.time(fa, labels) } >>
+        test { case (fa, labels) => labelledGauge.time(fa, labels) }
     }
   }
 
@@ -194,13 +195,13 @@ class TimerSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
         (d, s) => ref.update(_ :+ (d -> s))
 
       test((ref, s) =>
-        Timer.Labelled
-          .fromHistogram(Histogram.Labelled.make[IO, Double, String]((d, s, _) => ref.update(_ :+ (d -> s))))
+        Timer
+          .fromHistogram(Histogram.make[IO, Double, String]((d, s, _) => ref.update(_ :+ (d -> s))))
           .timeAttempt[String](s)(identity, { case th => th.getMessage })
       ) >> test((ref, s) =>
-        Timer.Labelled
+        Timer
           .fromGauge(
-            Gauge.Labelled.make[IO, Double, String](
+            Gauge.make[IO, Double, String](
               gaugeSet(ref),
               gaugeSet(ref),
               gaugeSet(ref)

--- a/core/src/test/scala/test/ExternalPackageMetricRegistry.scala
+++ b/core/src/test/scala/test/ExternalPackageMetricRegistry.scala
@@ -30,14 +30,14 @@ class ExternalPackageMetricRegistry extends MetricRegistry[IO] with CallbackRegi
       name: Counter.Name,
       help: Metric.Help,
       commonLabels: Metric.CommonLabels
-  ): Resource[IO, Counter[IO, Double]] = ???
+  ): Resource[IO, Counter[IO, Double, Unit]] = ???
 
   override def createAndRegisterLongCounter(
       prefix: Option[Metric.Prefix],
       name: Counter.Name,
       help: Metric.Help,
       commonLabels: Metric.CommonLabels
-  ): Resource[IO, Counter[IO, Long]] = ???
+  ): Resource[IO, Counter[IO, Long, Unit]] = ???
 
   override def createAndRegisterLabelledDoubleCounter[A](
       prefix: Option[Metric.Prefix],
@@ -45,7 +45,7 @@ class ExternalPackageMetricRegistry extends MetricRegistry[IO] with CallbackRegi
       help: Metric.Help,
       commonLabels: Metric.CommonLabels,
       labelNames: IndexedSeq[Label.Name]
-  )(f: A => IndexedSeq[String]): Resource[IO, Counter.Labelled[IO, Double, A]] = ???
+  )(f: A => IndexedSeq[String]): Resource[IO, Counter[IO, Double, A]] = ???
 
   override def createAndRegisterLabelledLongCounter[A](
       prefix: Option[Metric.Prefix],
@@ -53,21 +53,21 @@ class ExternalPackageMetricRegistry extends MetricRegistry[IO] with CallbackRegi
       help: Metric.Help,
       commonLabels: Metric.CommonLabels,
       labelNames: IndexedSeq[Label.Name]
-  )(f: A => IndexedSeq[String]): Resource[IO, Counter.Labelled[IO, Long, A]] = ???
+  )(f: A => IndexedSeq[String]): Resource[IO, Counter[IO, Long, A]] = ???
 
   override def createAndRegisterDoubleGauge(
       prefix: Option[Metric.Prefix],
       name: Gauge.Name,
       help: Metric.Help,
       commonLabels: Metric.CommonLabels
-  ): Resource[IO, Gauge[IO, Double]] = ???
+  ): Resource[IO, Gauge[IO, Double, Unit]] = ???
 
   override def createAndRegisterLongGauge(
       prefix: Option[Metric.Prefix],
       name: Gauge.Name,
       help: Metric.Help,
       commonLabels: Metric.CommonLabels
-  ): Resource[IO, Gauge[IO, Long]] = ???
+  ): Resource[IO, Gauge[IO, Long, Unit]] = ???
 
   override def createAndRegisterLabelledDoubleGauge[A](
       prefix: Option[Metric.Prefix],
@@ -75,7 +75,7 @@ class ExternalPackageMetricRegistry extends MetricRegistry[IO] with CallbackRegi
       help: Metric.Help,
       commonLabels: Metric.CommonLabels,
       labelNames: IndexedSeq[Label.Name]
-  )(f: A => IndexedSeq[String]): Resource[IO, Gauge.Labelled[IO, Double, A]] = ???
+  )(f: A => IndexedSeq[String]): Resource[IO, Gauge[IO, Double, A]] = ???
 
   override def createAndRegisterLabelledLongGauge[A](
       prefix: Option[Metric.Prefix],
@@ -83,7 +83,7 @@ class ExternalPackageMetricRegistry extends MetricRegistry[IO] with CallbackRegi
       help: Metric.Help,
       commonLabels: Metric.CommonLabels,
       labelNames: IndexedSeq[Label.Name]
-  )(f: A => IndexedSeq[String]): Resource[IO, Gauge.Labelled[IO, Long, A]] = ???
+  )(f: A => IndexedSeq[String]): Resource[IO, Gauge[IO, Long, A]] = ???
 
   override def createAndRegisterDoubleHistogram(
       prefix: Option[Metric.Prefix],
@@ -91,7 +91,7 @@ class ExternalPackageMetricRegistry extends MetricRegistry[IO] with CallbackRegi
       help: Metric.Help,
       commonLabels: Metric.CommonLabels,
       buckets: NonEmptySeq[Double]
-  ): Resource[IO, Histogram[IO, Double]] = ???
+  ): Resource[IO, Histogram[IO, Double, Unit]] = ???
 
   override def createAndRegisterLongHistogram(
       prefix: Option[Metric.Prefix],
@@ -99,7 +99,7 @@ class ExternalPackageMetricRegistry extends MetricRegistry[IO] with CallbackRegi
       help: Metric.Help,
       commonLabels: Metric.CommonLabels,
       buckets: NonEmptySeq[Long]
-  ): Resource[IO, Histogram[IO, Long]] = ???
+  ): Resource[IO, Histogram[IO, Long, Unit]] = ???
 
   override def createAndRegisterLabelledDoubleHistogram[A](
       prefix: Option[Metric.Prefix],
@@ -108,7 +108,7 @@ class ExternalPackageMetricRegistry extends MetricRegistry[IO] with CallbackRegi
       commonLabels: Metric.CommonLabels,
       labelNames: IndexedSeq[Label.Name],
       buckets: NonEmptySeq[Double]
-  )(f: A => IndexedSeq[String]): Resource[IO, Histogram.Labelled[IO, Double, A]] = ???
+  )(f: A => IndexedSeq[String]): Resource[IO, Histogram[IO, Double, A]] = ???
 
   override def createAndRegisterLabelledLongHistogram[A](
       prefix: Option[Metric.Prefix],
@@ -117,7 +117,7 @@ class ExternalPackageMetricRegistry extends MetricRegistry[IO] with CallbackRegi
       commonLabels: Metric.CommonLabels,
       labelNames: IndexedSeq[Label.Name],
       buckets: NonEmptySeq[Long]
-  )(f: A => IndexedSeq[String]): Resource[IO, Histogram.Labelled[IO, Long, A]] = ???
+  )(f: A => IndexedSeq[String]): Resource[IO, Histogram[IO, Long, A]] = ???
 
   override def createAndRegisterDoubleSummary(
       prefix: Option[Metric.Prefix],
@@ -127,7 +127,7 @@ class ExternalPackageMetricRegistry extends MetricRegistry[IO] with CallbackRegi
       quantiles: Seq[Summary.QuantileDefinition],
       maxAge: FiniteDuration,
       ageBuckets: Summary.AgeBuckets
-  ): Resource[IO, Summary[IO, Double]] = ???
+  ): Resource[IO, Summary[IO, Double, Unit]] = ???
 
   override def createAndRegisterLongSummary(
       prefix: Option[Metric.Prefix],
@@ -137,7 +137,7 @@ class ExternalPackageMetricRegistry extends MetricRegistry[IO] with CallbackRegi
       quantiles: Seq[Summary.QuantileDefinition],
       maxAge: FiniteDuration,
       ageBuckets: Summary.AgeBuckets
-  ): Resource[IO, Summary[IO, Long]] = ???
+  ): Resource[IO, Summary[IO, Long, Unit]] = ???
 
   override def createAndRegisterLabelledDoubleSummary[A](
       prefix: Option[Metric.Prefix],
@@ -148,7 +148,7 @@ class ExternalPackageMetricRegistry extends MetricRegistry[IO] with CallbackRegi
       quantiles: Seq[Summary.QuantileDefinition],
       maxAge: FiniteDuration,
       ageBuckets: Summary.AgeBuckets
-  )(f: A => IndexedSeq[String]): Resource[IO, Summary.Labelled[IO, Double, A]] = ???
+  )(f: A => IndexedSeq[String]): Resource[IO, Summary[IO, Double, A]] = ???
 
   override def createAndRegisterLabelledLongSummary[A](
       prefix: Option[Metric.Prefix],
@@ -159,7 +159,7 @@ class ExternalPackageMetricRegistry extends MetricRegistry[IO] with CallbackRegi
       quantiles: Seq[Summary.QuantileDefinition],
       maxAge: FiniteDuration,
       ageBuckets: Summary.AgeBuckets
-  )(f: A => IndexedSeq[String]): Resource[IO, Summary.Labelled[IO, Long, A]] = ???
+  )(f: A => IndexedSeq[String]): Resource[IO, Summary[IO, Long, A]] = ???
 
   override def createAndRegisterInfo(
       prefix: Option[Metric.Prefix],

--- a/core/src/test/scala/test/ExternalPackageMetricRegistry.scala
+++ b/core/src/test/scala/test/ExternalPackageMetricRegistry.scala
@@ -25,21 +25,8 @@ import scala.concurrent.duration.FiniteDuration
 
 // Functions as a compile-time test to ensure methods are implementable outside of `prometheus4cats` package scope
 class ExternalPackageMetricRegistry extends MetricRegistry[IO] with CallbackRegistry[IO] {
-  override def createAndRegisterDoubleCounter(
-      prefix: Option[Metric.Prefix],
-      name: Counter.Name,
-      help: Metric.Help,
-      commonLabels: Metric.CommonLabels
-  ): Resource[IO, Counter[IO, Double, Unit]] = ???
 
-  override def createAndRegisterLongCounter(
-      prefix: Option[Metric.Prefix],
-      name: Counter.Name,
-      help: Metric.Help,
-      commonLabels: Metric.CommonLabels
-  ): Resource[IO, Counter[IO, Long, Unit]] = ???
-
-  override def createAndRegisterLabelledDoubleCounter[A](
+  override def createAndRegisterDoubleCounter[A](
       prefix: Option[Metric.Prefix],
       name: Counter.Name,
       help: Metric.Help,
@@ -47,7 +34,7 @@ class ExternalPackageMetricRegistry extends MetricRegistry[IO] with CallbackRegi
       labelNames: IndexedSeq[Label.Name]
   )(f: A => IndexedSeq[String]): Resource[IO, Counter[IO, Double, A]] = ???
 
-  override def createAndRegisterLabelledLongCounter[A](
+  override def createAndRegisterLongCounter[A](
       prefix: Option[Metric.Prefix],
       name: Counter.Name,
       help: Metric.Help,
@@ -55,21 +42,7 @@ class ExternalPackageMetricRegistry extends MetricRegistry[IO] with CallbackRegi
       labelNames: IndexedSeq[Label.Name]
   )(f: A => IndexedSeq[String]): Resource[IO, Counter[IO, Long, A]] = ???
 
-  override def createAndRegisterDoubleGauge(
-      prefix: Option[Metric.Prefix],
-      name: Gauge.Name,
-      help: Metric.Help,
-      commonLabels: Metric.CommonLabels
-  ): Resource[IO, Gauge[IO, Double, Unit]] = ???
-
-  override def createAndRegisterLongGauge(
-      prefix: Option[Metric.Prefix],
-      name: Gauge.Name,
-      help: Metric.Help,
-      commonLabels: Metric.CommonLabels
-  ): Resource[IO, Gauge[IO, Long, Unit]] = ???
-
-  override def createAndRegisterLabelledDoubleGauge[A](
+  override def createAndRegisterDoubleGauge[A](
       prefix: Option[Metric.Prefix],
       name: Gauge.Name,
       help: Metric.Help,
@@ -77,7 +50,7 @@ class ExternalPackageMetricRegistry extends MetricRegistry[IO] with CallbackRegi
       labelNames: IndexedSeq[Label.Name]
   )(f: A => IndexedSeq[String]): Resource[IO, Gauge[IO, Double, A]] = ???
 
-  override def createAndRegisterLabelledLongGauge[A](
+  override def createAndRegisterLongGauge[A](
       prefix: Option[Metric.Prefix],
       name: Gauge.Name,
       help: Metric.Help,
@@ -85,23 +58,7 @@ class ExternalPackageMetricRegistry extends MetricRegistry[IO] with CallbackRegi
       labelNames: IndexedSeq[Label.Name]
   )(f: A => IndexedSeq[String]): Resource[IO, Gauge[IO, Long, A]] = ???
 
-  override def createAndRegisterDoubleHistogram(
-      prefix: Option[Metric.Prefix],
-      name: Histogram.Name,
-      help: Metric.Help,
-      commonLabels: Metric.CommonLabels,
-      buckets: NonEmptySeq[Double]
-  ): Resource[IO, Histogram[IO, Double, Unit]] = ???
-
-  override def createAndRegisterLongHistogram(
-      prefix: Option[Metric.Prefix],
-      name: Histogram.Name,
-      help: Metric.Help,
-      commonLabels: Metric.CommonLabels,
-      buckets: NonEmptySeq[Long]
-  ): Resource[IO, Histogram[IO, Long, Unit]] = ???
-
-  override def createAndRegisterLabelledDoubleHistogram[A](
+  override def createAndRegisterDoubleHistogram[A](
       prefix: Option[Metric.Prefix],
       name: Histogram.Name,
       help: Metric.Help,
@@ -110,7 +67,7 @@ class ExternalPackageMetricRegistry extends MetricRegistry[IO] with CallbackRegi
       buckets: NonEmptySeq[Double]
   )(f: A => IndexedSeq[String]): Resource[IO, Histogram[IO, Double, A]] = ???
 
-  override def createAndRegisterLabelledLongHistogram[A](
+  override def createAndRegisterLongHistogram[A](
       prefix: Option[Metric.Prefix],
       name: Histogram.Name,
       help: Metric.Help,
@@ -119,27 +76,7 @@ class ExternalPackageMetricRegistry extends MetricRegistry[IO] with CallbackRegi
       buckets: NonEmptySeq[Long]
   )(f: A => IndexedSeq[String]): Resource[IO, Histogram[IO, Long, A]] = ???
 
-  override def createAndRegisterDoubleSummary(
-      prefix: Option[Metric.Prefix],
-      name: Summary.Name,
-      help: Metric.Help,
-      commonLabels: Metric.CommonLabels,
-      quantiles: Seq[Summary.QuantileDefinition],
-      maxAge: FiniteDuration,
-      ageBuckets: Summary.AgeBuckets
-  ): Resource[IO, Summary[IO, Double, Unit]] = ???
-
-  override def createAndRegisterLongSummary(
-      prefix: Option[Metric.Prefix],
-      name: Summary.Name,
-      help: Metric.Help,
-      commonLabels: Metric.CommonLabels,
-      quantiles: Seq[Summary.QuantileDefinition],
-      maxAge: FiniteDuration,
-      ageBuckets: Summary.AgeBuckets
-  ): Resource[IO, Summary[IO, Long, Unit]] = ???
-
-  override def createAndRegisterLabelledDoubleSummary[A](
+  override def createAndRegisterDoubleSummary[A](
       prefix: Option[Metric.Prefix],
       name: Summary.Name,
       help: Metric.Help,
@@ -150,7 +87,7 @@ class ExternalPackageMetricRegistry extends MetricRegistry[IO] with CallbackRegi
       ageBuckets: Summary.AgeBuckets
   )(f: A => IndexedSeq[String]): Resource[IO, Summary[IO, Double, A]] = ???
 
-  override def createAndRegisterLabelledLongSummary[A](
+  override def createAndRegisterLongSummary[A](
       prefix: Option[Metric.Prefix],
       name: Summary.Name,
       help: Metric.Help,
@@ -167,23 +104,7 @@ class ExternalPackageMetricRegistry extends MetricRegistry[IO] with CallbackRegi
       help: Metric.Help
   ): Resource[IO, Info[IO, Map[Label.Name, String]]] = ???
 
-  override def registerDoubleCounterCallback(
-      prefix: Option[Metric.Prefix],
-      name: Counter.Name,
-      help: Metric.Help,
-      commonLabels: Metric.CommonLabels,
-      callback: IO[Double]
-  ): Resource[IO, Unit] = ???
-
-  override def registerLongCounterCallback(
-      prefix: Option[Metric.Prefix],
-      name: Counter.Name,
-      help: Metric.Help,
-      commonLabels: Metric.CommonLabels,
-      callback: IO[Long]
-  ): Resource[IO, Unit] = ???
-
-  override def registerLabelledDoubleCounterCallback[A](
+  override def registerDoubleCounterCallback[A](
       prefix: Option[Metric.Prefix],
       name: Counter.Name,
       help: Metric.Help,
@@ -192,7 +113,7 @@ class ExternalPackageMetricRegistry extends MetricRegistry[IO] with CallbackRegi
       callback: IO[NonEmptyList[(Double, A)]]
   )(f: A => IndexedSeq[String]): Resource[IO, Unit] = ???
 
-  override def registerLabelledLongCounterCallback[A](
+  override def registerLongCounterCallback[A](
       prefix: Option[Metric.Prefix],
       name: Counter.Name,
       help: Metric.Help,
@@ -201,23 +122,7 @@ class ExternalPackageMetricRegistry extends MetricRegistry[IO] with CallbackRegi
       callback: IO[NonEmptyList[(Long, A)]]
   )(f: A => IndexedSeq[String]): Resource[IO, Unit] = ???
 
-  override def registerDoubleGaugeCallback(
-      prefix: Option[Metric.Prefix],
-      name: Gauge.Name,
-      help: Metric.Help,
-      commonLabels: Metric.CommonLabels,
-      callback: IO[Double]
-  ): Resource[IO, Unit] = ???
-
-  override def registerLongGaugeCallback(
-      prefix: Option[Metric.Prefix],
-      name: Gauge.Name,
-      help: Metric.Help,
-      commonLabels: Metric.CommonLabels,
-      callback: IO[Long]
-  ): Resource[IO, Unit] = ???
-
-  override def registerLabelledDoubleGaugeCallback[A](
+  override def registerDoubleGaugeCallback[A](
       prefix: Option[Metric.Prefix],
       name: Gauge.Name,
       help: Metric.Help,
@@ -226,7 +131,7 @@ class ExternalPackageMetricRegistry extends MetricRegistry[IO] with CallbackRegi
       callback: IO[NonEmptyList[(Double, A)]]
   )(f: A => IndexedSeq[String]): Resource[IO, Unit] = ???
 
-  override def registerLabelledLongGaugeCallback[A](
+  override def registerLongGaugeCallback[A](
       prefix: Option[Metric.Prefix],
       name: Gauge.Name,
       help: Metric.Help,
@@ -235,25 +140,7 @@ class ExternalPackageMetricRegistry extends MetricRegistry[IO] with CallbackRegi
       callback: IO[NonEmptyList[(Long, A)]]
   )(f: A => IndexedSeq[String]): Resource[IO, Unit] = ???
 
-  override def registerDoubleHistogramCallback(
-      prefix: Option[Metric.Prefix],
-      name: Histogram.Name,
-      help: Metric.Help,
-      commonLabels: Metric.CommonLabels,
-      buckets: NonEmptySeq[Double],
-      callback: IO[Histogram.Value[Double]]
-  ): Resource[IO, Unit] = ???
-
-  override def registerLongHistogramCallback(
-      prefix: Option[Metric.Prefix],
-      name: Histogram.Name,
-      help: Metric.Help,
-      commonLabels: Metric.CommonLabels,
-      buckets: NonEmptySeq[Long],
-      callback: IO[Histogram.Value[Long]]
-  ): Resource[IO, Unit] = ???
-
-  override def registerLabelledDoubleHistogramCallback[A](
+  override def registerDoubleHistogramCallback[A](
       prefix: Option[Metric.Prefix],
       name: Histogram.Name,
       help: Metric.Help,
@@ -263,7 +150,7 @@ class ExternalPackageMetricRegistry extends MetricRegistry[IO] with CallbackRegi
       callback: IO[NonEmptyList[(Histogram.Value[Double], A)]]
   )(f: A => IndexedSeq[String]): Resource[IO, Unit] = ???
 
-  override def registerLabelledLongHistogramCallback[A](
+  override def registerLongHistogramCallback[A](
       prefix: Option[Metric.Prefix],
       name: Histogram.Name,
       help: Metric.Help,
@@ -273,23 +160,7 @@ class ExternalPackageMetricRegistry extends MetricRegistry[IO] with CallbackRegi
       callback: IO[NonEmptyList[(Histogram.Value[Long], A)]]
   )(f: A => IndexedSeq[String]): Resource[IO, Unit] = ???
 
-  override def registerDoubleSummaryCallback(
-      prefix: Option[Metric.Prefix],
-      name: Summary.Name,
-      help: Metric.Help,
-      commonLabels: Metric.CommonLabels,
-      callback: IO[Summary.Value[Double]]
-  ): Resource[IO, Unit] = ???
-
-  override def registerLongSummaryCallback(
-      prefix: Option[Metric.Prefix],
-      name: Summary.Name,
-      help: Metric.Help,
-      commonLabels: Metric.CommonLabels,
-      callback: IO[Summary.Value[Long]]
-  ): Resource[IO, Unit] = ???
-
-  override def registerLabelledDoubleSummaryCallback[A](
+  override def registerDoubleSummaryCallback[A](
       prefix: Option[Metric.Prefix],
       name: Summary.Name,
       help: Metric.Help,
@@ -298,7 +169,7 @@ class ExternalPackageMetricRegistry extends MetricRegistry[IO] with CallbackRegi
       callback: IO[NonEmptyList[(Summary.Value[Double], A)]]
   )(f: A => IndexedSeq[String]): Resource[IO, Unit] = ???
 
-  override def registerLabelledLongSummaryCallback[A](
+  override def registerLongSummaryCallback[A](
       prefix: Option[Metric.Prefix],
       name: Summary.Name,
       help: Metric.Help,

--- a/core/src/test/scala/test/MetricsFactoryDslTest.scala
+++ b/core/src/test/scala/test/MetricsFactoryDslTest.scala
@@ -21,6 +21,7 @@ import java.math.BigInteger
 import java.util.concurrent.TimeUnit
 
 import cats.effect.IO
+
 import prometheus4cats._
 
 import scala.concurrent.duration._
@@ -34,7 +35,6 @@ object MetricsFactoryDslTest {
   doubleGaugeBuilder.build
   doubleGaugeBuilder.asCurrentTimeRecorder
   doubleGaugeBuilder.asCurrentTimeRecorder(_.toUnit(TimeUnit.NANOSECONDS))
-  doubleGaugeBuilder.contramap[Int](_.toDouble).build
   doubleGaugeBuilder.asTimer.build
   doubleGaugeBuilder.asOutcomeRecorder.build
 
@@ -98,7 +98,6 @@ object MetricsFactoryDslTest {
   longHistogramBuilder.unsafeLabels(Label.Name("label1"), Label.Name("label2")).build
 
   val infoBuilder = factory.info("test_info").help("help")
-  infoBuilder.contramap[List[(Label.Name, String)]](_.toMap)
   infoBuilder.build
 
   val doubleSummaryBuilder =

--- a/core/src/test/scala/test/MetricsFactoryDslTest.scala
+++ b/core/src/test/scala/test/MetricsFactoryDslTest.scala
@@ -60,6 +60,8 @@ object MetricsFactoryDslTest {
 
   val counterBuilder = factory.counter("test_total")
 
+  counterBuilder.ofDouble.help("sdfs").build.map(_.inc)
+
   val doubleCounterBuilder = counterBuilder.ofDouble.help("help")
   doubleCounterBuilder.build
   doubleCounterBuilder.asOutcomeRecorder.build
@@ -73,7 +75,12 @@ object MetricsFactoryDslTest {
 
   val longCounterBuilder = counterBuilder.ofLong.help("help")
   longCounterBuilder.build
-  longCounterBuilder.label[String]("label1").label[Int]("label2").label[BigInteger]("label3", _.toString).build
+  longCounterBuilder
+    .label[String]("label1")
+    .label[Int]("label2")
+    .label[BigInteger]("label3", _.toString)
+    .build
+    .map(_.inc(("dsfsf", 1, BigInteger.ONE)))
   longCounterBuilder.unsafeLabels(Label.Name("label1"), Label.Name("label2")).build
 
   val histogramBuilder = factory.histogram("test2")

--- a/docs/interface/dsl.md
+++ b/docs/interface/dsl.md
@@ -155,7 +155,7 @@ val shortCounter: Resource[IO, Counter[IO, Short]] = intCounter.map(_.contramap[
 #### Labelled Metric
 
 ```scala mdoc:silent
-val intLabelledCounter: Resource[IO, Counter.Labelled[IO, Int, (String, Int)]] = factory
+val intLabelledCounter: Resource[IO, Counter[IO, Int, (String, Int)]] = factory
   .counter("counter_total")
   .ofLong
   .help("Describe what this metric does")
@@ -166,7 +166,7 @@ val intLabelledCounter: Resource[IO, Counter.Labelled[IO, Int, (String, Int)]] =
 ```
 
 ```scala mdoc:silent
-val shortLabelledCounter: Resource[IO, Counter.Labelled[IO, Short, (String, Int)]] =
+val shortLabelledCounter: Resource[IO, Counter[IO, Short, (String, Int)]] =
   intLabelledCounter.map(_.contramap[Short](_.toInt))
 ```
 
@@ -178,7 +178,7 @@ This can work as a nice alternative to
 ```scala mdoc:silent
 case class LabelsClass(string: String, int: Int)
 
-val updatedLabelsCounter: Resource[IO, Counter.Labelled[IO, Long, LabelsClass]] = factory
+val updatedLabelsCounter: Resource[IO, Counter[IO, Long, LabelsClass]] = factory
   .counter("counter_total")
   .ofLong
   .help("Describe what this metric does")

--- a/docs/interface/dsl.md
+++ b/docs/interface/dsl.md
@@ -140,7 +140,7 @@ unsafeLabelledCounter.build.evalMap(_.inc(3.0, labels))
 #### Simple Metric
 
 ```scala mdoc:silent
-val intCounter: Resource[IO, Counter[IO, Int]] = factory
+val intCounter: Resource[IO, Counter[IO, Int, Unit]] = factory
   .counter("counter_total")
   .ofLong
   .help("Describe what this metric does")
@@ -149,7 +149,7 @@ val intCounter: Resource[IO, Counter[IO, Int]] = factory
 ```
 
 ```scala mdoc:silent
-val shortCounter: Resource[IO, Counter[IO, Short]] = intCounter.map(_.contramap[Short](_.toInt))
+val shortCounter: Resource[IO, Counter[IO, Short, Unit]] = intCounter.map(_.contramap[Short](_.toInt))
 ```
 
 #### Labelled Metric

--- a/docs/metrics/derived-metric-types.md
+++ b/docs/metrics/derived-metric-types.md
@@ -112,7 +112,7 @@ val simpleCurrentTimeRecorderGauge: Resource[IO, CurrentTimeRecorder[IO]] = fact
 
 ```scala mdoc:silent
 val labelledCurrentTimeRecorderGauge:
-  Resource[IO, CurrentTimeRecorder.Labelled[IO, String]] =
+  Resource[IO, CurrentTimeRecorder[IO, String]] =
     factory
       .gauge("current_time")
       .ofDouble

--- a/docs/metrics/derived-metric-types.md
+++ b/docs/metrics/derived-metric-types.md
@@ -42,7 +42,7 @@ val simpleTimerHistogram: Resource[IO, Timer.Aux[IO, Histogram]] = factory
 ```
 
 ```scala mdoc:silent
-val labelledTimerHistogram: Resource[IO, Timer.Labelled.Aux[IO, String, Histogram.Labelled]] = factory
+val labelledTimerHistogram: Resource[IO, Timer.Aux[IO, String, Histogram]] = factory
   .histogram("time")
   .ofDouble
   .help("Records the how long an opertation took")
@@ -64,7 +64,7 @@ val simpleTimerSummary: Resource[IO, Timer.Aux[IO, Summary]] = factory
 ```
 
 ```scala mdoc:silent
-val labelledTimerSummary: Resource[IO, Timer.Labelled.Aux[IO, String, Summary.Labelled]] = factory
+val labelledTimerSummary: Resource[IO, Timer.Aux[IO, String, Summary]] = factory
   .summary("time")
   .ofDouble
   .help("Records the how long an opertation took")
@@ -85,7 +85,7 @@ val simpleTimerGauge: Resource[IO, Timer.Aux[IO, Gauge]] = factory
 ```
 
 ```scala mdoc:silent
-val labelledTimerGauge: Resource[IO, Timer.Labelled.Aux[IO, String, Gauge.Labelled]] = factory
+val labelledTimerGauge: Resource[IO, Timer.Aux[IO, String, Gauge]] = factory
   .gauge("time")
   .ofDouble
   .help("Records the how long an opertation took")
@@ -142,7 +142,7 @@ To help disambiguate the difference in behaviour the `OutcomeRecorder` type will
 #### Obtaining from a `Counter`
 
 ```scala mdoc:silent
-val simpleOutcomeCounter: Resource[IO, OutcomeRecorder.Aux[IO, Long, Counter.Labelled]] = factory
+val simpleOutcomeCounter: Resource[IO, OutcomeRecorder.Aux[IO, Long, Counter]] = factory
   .counter("outcome_total")
   .ofLong
   .help("Records the outcome of some operation")
@@ -152,7 +152,7 @@ val simpleOutcomeCounter: Resource[IO, OutcomeRecorder.Aux[IO, Long, Counter.Lab
 
 ```scala mdoc:silent
 val labelledOutcomeCounter:
-  Resource[IO, OutcomeRecorder.Labelled.Aux[IO, Long, String, Counter.Labelled]] = factory
+  Resource[IO, OutcomeRecorder.Labelled.Aux[IO, Long, String, Counter]] = factory
     .counter("outcome_total")
     .ofLong
     .help("Records the outcome of some operation")
@@ -164,7 +164,7 @@ val labelledOutcomeCounter:
 #### Obtaining from a `Gauge`
 
 ```scala mdoc:silent
-val simpleOutcomeGauge: Resource[IO, OutcomeRecorder.Aux[IO, Long, Gauge.Labelled]] = factory
+val simpleOutcomeGauge: Resource[IO, OutcomeRecorder.Aux[IO, Long, Gauge]] = factory
   .gauge("outcome")
   .ofLong
   .help("Records the outcome of some operation")
@@ -174,7 +174,7 @@ val simpleOutcomeGauge: Resource[IO, OutcomeRecorder.Aux[IO, Long, Gauge.Labelle
 
 ```scala mdoc:silent
 val labelledOutcomeGauge:
-  Resource[IO, OutcomeRecorder.Labelled.Aux[IO, Long, String, Gauge.Labelled]] = factory
+  Resource[IO, OutcomeRecorder.Labelled.Aux[IO, Long, String, Gauge]] = factory
     .gauge("outcome")
     .ofLong
     .help("Records the outcome of some operation")

--- a/docs/metrics/derived-metric-types.md
+++ b/docs/metrics/derived-metric-types.md
@@ -152,7 +152,7 @@ val simpleOutcomeCounter: Resource[IO, OutcomeRecorder.Aux[IO, Long, Counter]] =
 
 ```scala mdoc:silent
 val labelledOutcomeCounter:
-  Resource[IO, OutcomeRecorder.Labelled.Aux[IO, Long, String, Counter]] = factory
+  Resource[IO, OutcomeRecorder.Aux[IO, Long, String, Counter]] = factory
     .counter("outcome_total")
     .ofLong
     .help("Records the outcome of some operation")
@@ -174,7 +174,7 @@ val simpleOutcomeGauge: Resource[IO, OutcomeRecorder.Aux[IO, Long, Gauge]] = fac
 
 ```scala mdoc:silent
 val labelledOutcomeGauge:
-  Resource[IO, OutcomeRecorder.Labelled.Aux[IO, Long, String, Gauge]] = factory
+  Resource[IO, OutcomeRecorder.Aux[IO, Long, String, Gauge]] = factory
     .gauge("outcome")
     .ofLong
     .help("Records the outcome of some operation")

--- a/docs/metrics/derived-metric-types.md
+++ b/docs/metrics/derived-metric-types.md
@@ -32,7 +32,7 @@ operations.
 #### Obtaining from a `Histogram`
 
 ```scala mdoc:silent
-val simpleTimerHistogram: Resource[IO, Timer.Aux[IO, Histogram]] = factory
+val simpleTimerHistogram: Resource[IO, Timer.Aux[IO, Unit, Histogram]] = factory
   .histogram("time")
   .ofDouble
   .help("Records the how long an opertation took")
@@ -55,7 +55,7 @@ val labelledTimerHistogram: Resource[IO, Timer.Aux[IO, String, Histogram]] = fac
 #### Obtaining from a `Summary`
 
 ```scala mdoc:silent
-val simpleTimerSummary: Resource[IO, Timer.Aux[IO, Summary]] = factory
+val simpleTimerSummary: Resource[IO, Timer.Aux[IO, Unit, Summary]] = factory
   .summary("time")
   .ofDouble
   .help("Records the how long an opertation took")
@@ -76,7 +76,7 @@ val labelledTimerSummary: Resource[IO, Timer.Aux[IO, String, Summary]] = factory
 #### Obtaining from a `Gauge`
 
 ```scala mdoc:silent
-val simpleTimerGauge: Resource[IO, Timer.Aux[IO, Gauge]] = factory
+val simpleTimerGauge: Resource[IO, Timer.Aux[IO, Unit, Gauge]] = factory
   .gauge("time")
   .ofDouble
   .help("Records the how long an opertation took")
@@ -102,7 +102,7 @@ system time.
 #### Obtaining from a `Gauge`
 
 ```scala mdoc:silent
-val simpleCurrentTimeRecorderGauge: Resource[IO, CurrentTimeRecorder[IO]] = factory
+val simpleCurrentTimeRecorderGauge: Resource[IO, CurrentTimeRecorder[IO, Unit]] = factory
   .gauge("current_time")
   .ofDouble
   .help("Records the how long an opertation took")
@@ -142,7 +142,7 @@ To help disambiguate the difference in behaviour the `OutcomeRecorder` type will
 #### Obtaining from a `Counter`
 
 ```scala mdoc:silent
-val simpleOutcomeCounter: Resource[IO, OutcomeRecorder.Aux[IO, Long, Counter]] = factory
+val simpleOutcomeCounter: Resource[IO, OutcomeRecorder.Aux[IO, Long, Unit, Counter]] = factory
   .counter("outcome_total")
   .ofLong
   .help("Records the outcome of some operation")
@@ -164,7 +164,7 @@ val labelledOutcomeCounter:
 #### Obtaining from a `Gauge`
 
 ```scala mdoc:silent
-val simpleOutcomeGauge: Resource[IO, OutcomeRecorder.Aux[IO, Long, Gauge]] = factory
+val simpleOutcomeGauge: Resource[IO, OutcomeRecorder.Aux[IO, Long, Unit, Gauge]] = factory
   .gauge("outcome")
   .ofLong
   .help("Records the outcome of some operation")

--- a/java/src/test/scala/prometheus4cats/javasimpleclient/JavaMetricRegistrySuite.scala
+++ b/java/src/test/scala/prometheus4cats/javasimpleclient/JavaMetricRegistrySuite.scala
@@ -234,7 +234,7 @@ class JavaMetricRegistrySuite
       ) =>
         stateResource.flatMap(metricRegistryResource).use { reg =>
           val metric = reg
-            .createAndRegisterLabelledDoubleCounter[Map[Label.Name, String]](
+            .createAndRegisterDoubleCounter[Map[Label.Name, String]](
               prefix,
               name,
               help,
@@ -260,7 +260,7 @@ class JavaMetricRegistrySuite
           .flatMap(JavaMetricRegistry.Builder().withRegistry(_).build)
           .use { reg =>
             val metric = reg
-              .createAndRegisterLabelledDoubleCounter[Map[Label.Name, String]](
+              .createAndRegisterDoubleCounter[Map[Label.Name, String]](
                 prefix,
                 name,
                 help,
@@ -269,7 +269,7 @@ class JavaMetricRegistrySuite
               )(_.values.toIndexedSeq)
 
             val callback = reg
-              .registerLabelledDoubleCounterCallback[Map[Label.Name, String]](
+              .registerDoubleCounterCallback[Map[Label.Name, String]](
                 prefix,
                 name,
                 help,
@@ -305,7 +305,7 @@ class JavaMetricRegistrySuite
           .flatMap(JavaMetricRegistry.Builder().withRegistry(_).build)
           .use { reg =>
             val metric = reg
-              .createAndRegisterLabelledDoubleCounter[Map[Label.Name, String]](
+              .createAndRegisterDoubleCounter[Map[Label.Name, String]](
                 prefix,
                 name,
                 help,
@@ -314,7 +314,7 @@ class JavaMetricRegistrySuite
               )(_.values.toIndexedSeq)
 
             val callback = reg
-              .registerLabelledDoubleCounterCallback[Map[Label.Name, String]](
+              .registerDoubleCounterCallback[Map[Label.Name, String]](
                 prefix,
                 name,
                 help,
@@ -351,14 +351,14 @@ class JavaMetricRegistrySuite
           .flatMap(metricRegistryResource)
           .use { reg =>
             (reg
-              .createAndRegisterLabelledDoubleCounter[Map[Label.Name, String]](
+              .createAndRegisterDoubleCounter[Map[Label.Name, String]](
                 prefix,
                 name,
                 help,
                 commonLabels,
                 labels.toIndexedSeq
               )(_.values.toIndexedSeq) >> reg
-              .createAndRegisterLabelledDoubleCounter[Map[Label.Name, String]](
+              .createAndRegisterDoubleCounter[Map[Label.Name, String]](
                 prefix,
                 name,
                 help,
@@ -395,14 +395,14 @@ class JavaMetricRegistrySuite
           .flatMap(metricRegistryResource)
           .use { reg =>
             (reg
-              .createAndRegisterLabelledDoubleCounter[Map[Label.Name, String]](
+              .createAndRegisterDoubleCounter[Map[Label.Name, String]](
                 prefix,
                 counterName,
                 help,
                 commonLabels,
                 labels.toIndexedSeq
               )(_.values.toIndexedSeq) >> reg
-              .createAndRegisterLabelledDoubleGauge[Map[Label.Name, String]](
+              .createAndRegisterDoubleGauge[Map[Label.Name, String]](
                 prefix,
                 gaugeName,
                 help,

--- a/testing/src/main/scala/prometheus4cats/testing/TestingMetricRegistry.scala
+++ b/testing/src/main/scala/prometheus4cats/testing/TestingMetricRegistry.scala
@@ -256,24 +256,7 @@ sealed abstract class TestingMetricRegistry[F[_]] private (
       name: Summary.Name
   ): F[Option[Double]] = info(NameUtils.makeName(prefix, name.value)).get.map(_.as(1.0))
 
-  override def createAndRegisterDoubleCounter(
-      prefix: Option[Metric.Prefix],
-      name: Counter.Name,
-      help: Metric.Help,
-      commonLabels: Metric.CommonLabels
-  ): Resource[F, Counter[F, Double, Unit]] =
-    store(
-      NameUtils.makeName(prefix, name.value),
-      names(commonLabels),
-      MetricType.Counter,
-      (ref: MapRef[F, List[String], Chain[(Double, Option[Exemplar.Labels])]]) =>
-        Counter.make[F, Double, Unit]((d: Double, _: Unit, e: Option[Exemplar.Labels]) =>
-          ref(values(commonLabels)).update(c => c.append((c.lastOption.get._1 + d, e)))
-        ),
-      Chain.one(0.0 -> None)
-    )
-
-  override def createAndRegisterLabelledDoubleCounter[A](
+  override def createAndRegisterDoubleCounter[A](
       prefix: Option[Metric.Prefix],
       name: Counter.Name,
       help: Metric.Help,
@@ -291,26 +274,7 @@ sealed abstract class TestingMetricRegistry[F[_]] private (
       Chain.one(0.0 -> None)
     )
 
-  override def createAndRegisterDoubleGauge(
-      prefix: Option[Metric.Prefix],
-      name: Gauge.Name,
-      help: Metric.Help,
-      commonLabels: Metric.CommonLabels
-  ): Resource[F, Gauge[F, Double, Unit]] =
-    store(
-      NameUtils.makeName(prefix, name.value),
-      names(commonLabels),
-      MetricType.Gauge,
-      (ref: MapRef[F, List[String], Chain[(Double, Option[Exemplar.Labels])]]) =>
-        Gauge.make[F, Double, Unit](
-          (d: Double, _: Unit) => ref(values(commonLabels)).update(c => c.append((c.lastOption.get._1 + d, None))),
-          (d: Double, _: Unit) => ref(values(commonLabels)).update(c => c.append((c.lastOption.get._1 - d, None))),
-          (d: Double, _: Unit) => ref(values(commonLabels)).update(_.append(d -> None))
-        ),
-      Chain.one(0.0 -> None)
-    )
-
-  override def createAndRegisterLabelledDoubleGauge[A](
+  override def createAndRegisterDoubleGauge[A](
       prefix: Option[Metric.Prefix],
       name: Gauge.Name,
       help: Metric.Help,
@@ -330,25 +294,7 @@ sealed abstract class TestingMetricRegistry[F[_]] private (
       Chain.one(0.0 -> None)
     )
 
-  override def createAndRegisterDoubleHistogram(
-      prefix: Option[Metric.Prefix],
-      name: Histogram.Name,
-      help: Metric.Help,
-      commonLabels: Metric.CommonLabels,
-      buckets: NonEmptySeq[Double]
-  ): Resource[F, Histogram[F, Double, Unit]] =
-    store(
-      NameUtils.makeName(prefix, name.value),
-      names(commonLabels),
-      MetricType.Histogram,
-      (ref: MapRef[F, List[String], Chain[(Double, Option[Exemplar.Labels])]]) =>
-        Histogram.make[F, Double, Unit]((d: Double, _: Unit, e: Option[Exemplar.Labels]) =>
-          ref(values(commonLabels)).update(_.append(d -> e))
-        ),
-      Chain.nil
-    )
-
-  override def createAndRegisterLabelledDoubleHistogram[A](
+  override def createAndRegisterDoubleHistogram[A](
       prefix: Option[Metric.Prefix],
       name: Histogram.Name,
       help: Metric.Help,
@@ -367,25 +313,7 @@ sealed abstract class TestingMetricRegistry[F[_]] private (
       Chain.nil
     )
 
-  override def createAndRegisterDoubleSummary(
-      prefix: Option[Metric.Prefix],
-      name: Summary.Name,
-      help: Metric.Help,
-      commonLabels: Metric.CommonLabels,
-      quantiles: Seq[Summary.QuantileDefinition],
-      maxAge: FiniteDuration,
-      ageBuckets: Summary.AgeBuckets
-  ): Resource[F, Summary[F, Double, Unit]] =
-    store(
-      NameUtils.makeName(prefix, name.value),
-      names(commonLabels),
-      MetricType.Summary,
-      (ref: MapRef[F, List[String], Chain[(Double, Option[Exemplar.Labels])]]) =>
-        Summary.make[F, Double, Unit]((d: Double, _: Unit) => ref(values(commonLabels)).update(_.append(d -> None))),
-      Chain.nil
-    )
-
-  override def createAndRegisterLabelledDoubleSummary[A](
+  override def createAndRegisterDoubleSummary[A](
       prefix: Option[Metric.Prefix],
       name: Summary.Name,
       help: Metric.Help,
@@ -424,15 +352,7 @@ sealed abstract class TestingMetricRegistry[F[_]] private (
     )(_ => release)
   }
 
-  override def registerDoubleCounterCallback(
-      prefix: Option[Metric.Prefix],
-      name: Counter.Name,
-      help: Metric.Help,
-      commonLabels: Metric.CommonLabels,
-      callback: F[Double]
-  ): Resource[F, Unit] = Resource.unit
-
-  override def registerLabelledDoubleCounterCallback[A](
+  override def registerDoubleCounterCallback[A](
       prefix: Option[Metric.Prefix],
       name: Counter.Name,
       help: Metric.Help,
@@ -441,15 +361,7 @@ sealed abstract class TestingMetricRegistry[F[_]] private (
       callback: F[NonEmptyList[(Double, A)]]
   )(f: A => IndexedSeq[String]): Resource[F, Unit] = Resource.unit
 
-  override def registerDoubleGaugeCallback(
-      prefix: Option[Metric.Prefix],
-      name: Gauge.Name,
-      help: Metric.Help,
-      commonLabels: Metric.CommonLabels,
-      callback: F[Double]
-  ): Resource[F, Unit] = Resource.unit
-
-  override def registerLabelledDoubleGaugeCallback[A](
+  override def registerDoubleGaugeCallback[A](
       prefix: Option[Metric.Prefix],
       name: Gauge.Name,
       help: Metric.Help,
@@ -458,16 +370,7 @@ sealed abstract class TestingMetricRegistry[F[_]] private (
       callback: F[NonEmptyList[(Double, A)]]
   )(f: A => IndexedSeq[String]): Resource[F, Unit] = Resource.unit
 
-  override def registerDoubleHistogramCallback(
-      prefix: Option[Metric.Prefix],
-      name: Histogram.Name,
-      help: Metric.Help,
-      commonLabels: Metric.CommonLabels,
-      buckets: NonEmptySeq[Double],
-      callback: F[Histogram.Value[Double]]
-  ): Resource[F, Unit] = Resource.unit
-
-  override def registerLabelledDoubleHistogramCallback[A](
+  override def registerDoubleHistogramCallback[A](
       prefix: Option[Metric.Prefix],
       name: Histogram.Name,
       help: Metric.Help,
@@ -477,15 +380,7 @@ sealed abstract class TestingMetricRegistry[F[_]] private (
       callback: F[NonEmptyList[(Histogram.Value[Double], A)]]
   )(f: A => IndexedSeq[String]): Resource[F, Unit] = Resource.unit
 
-  override def registerDoubleSummaryCallback(
-      prefix: Option[Metric.Prefix],
-      name: Summary.Name,
-      help: Metric.Help,
-      commonLabels: Metric.CommonLabels,
-      callback: F[Summary.Value[Double]]
-  ): Resource[F, Unit] = Resource.unit
-
-  override def registerLabelledDoubleSummaryCallback[A](
+  override def registerDoubleSummaryCallback[A](
       prefix: Option[Metric.Prefix],
       name: Summary.Name,
       help: Metric.Help,

--- a/testing/src/test/scala/prometheus4cats/testing/TestingMetricRegistrySuite.scala
+++ b/testing/src/test/scala/prometheus4cats/testing/TestingMetricRegistrySuite.scala
@@ -25,15 +25,15 @@ import scala.concurrent.duration._
 
 class TestingMetricRegistrySuite extends CatsEffectSuite {
 
-  suite[Counter[IO, Double]]("Counter")(
+  suite[Counter[IO, Double, Unit]]("Counter")(
     (reg: TestingMetricRegistry[IO], prefix: Option[Metric.Prefix], name: String, commonLabels: Metric.CommonLabels) =>
       reg.createAndRegisterDoubleCounter(prefix, Counter.Name.unsafeFrom(name), Metric.Help("help"), commonLabels),
-    (c: Counter[IO, Double], _: Metric.CommonLabels) => (c.inc >> c.inc(2.0), Chain(0.0, 1.0, 3.0)),
+    (c: Counter[IO, Double, Unit], _: Metric.CommonLabels) => (c.inc >> c.inc(2.0), Chain(0.0, 1.0, 3.0)),
     (reg: TestingMetricRegistry[IO], prefix: Option[Metric.Prefix], name: String, commonLabels: Metric.CommonLabels) =>
       reg.counterHistory(prefix, Counter.Name.unsafeFrom(name), commonLabels)
   )
 
-  labelledSuite[Counter.Labelled[IO, Double, IndexedSeq[String]]]("Counter")(
+  labelledSuite[Counter[IO, Double, IndexedSeq[String]]]("Counter")(
     (
         reg: TestingMetricRegistry[IO],
         prefix: Option[Metric.Prefix],
@@ -49,7 +49,7 @@ class TestingMetricRegistrySuite extends CatsEffectSuite {
         labels
       )(identity[IndexedSeq[String]](_)),
     (
-        c: Counter.Labelled[IO, Double, IndexedSeq[String]],
+        c: Counter[IO, Double, IndexedSeq[String]],
         _: Metric.CommonLabels,
         labels: IndexedSeq[String]
     ) => (c.inc(labels) >> c.inc(2.0, labels), Chain(0.0, 1.0, 3.0)),
@@ -63,16 +63,16 @@ class TestingMetricRegistrySuite extends CatsEffectSuite {
     ) => reg.counterHistory(prefix, Counter.Name.unsafeFrom(name), commonLabels, labelNames, labelValues)
   )
 
-  suite[Gauge[IO, Double]]("Gauge")(
+  suite[Gauge[IO, Double, Unit]]("Gauge")(
     (reg: TestingMetricRegistry[IO], prefix: Option[Metric.Prefix], name: String, commonLabels: Metric.CommonLabels) =>
       reg.createAndRegisterDoubleGauge(prefix, Gauge.Name.unsafeFrom(name), Metric.Help("help"), commonLabels),
-    (g: Gauge[IO, Double], _: Metric.CommonLabels) =>
+    (g: Gauge[IO, Double, Unit], _: Metric.CommonLabels) =>
       (g.inc >> g.dec >> g.inc(2.0) >> g.dec(2.0) >> g.set(-1.0) >> g.reset, Chain(0.0, 1.0, 0.0, 2.0, 0.0, -1.0, 0.0)),
     (reg: TestingMetricRegistry[IO], prefix: Option[Metric.Prefix], name: String, commonLabels: Metric.CommonLabels) =>
       reg.gaugeHistory(prefix, Gauge.Name.unsafeFrom(name), commonLabels)
   )
 
-  labelledSuite[Gauge.Labelled[IO, Double, IndexedSeq[String]]]("Gauge")(
+  labelledSuite[Gauge[IO, Double, IndexedSeq[String]]]("Gauge")(
     (
         reg: TestingMetricRegistry[IO],
         prefix: Option[Metric.Prefix],
@@ -88,7 +88,7 @@ class TestingMetricRegistrySuite extends CatsEffectSuite {
         labels
       )(identity[IndexedSeq[String]](_)),
     (
-        g: Gauge.Labelled[IO, Double, IndexedSeq[String]],
+        g: Gauge[IO, Double, IndexedSeq[String]],
         _: Metric.CommonLabels,
         labels: IndexedSeq[String]
     ) =>
@@ -108,7 +108,7 @@ class TestingMetricRegistrySuite extends CatsEffectSuite {
     ) => reg.gaugeHistory(prefix, Gauge.Name.unsafeFrom(name), commonLabels, labelNames, labelValues)
   )
 
-  suite[Histogram[IO, Double]]("Histogram")(
+  suite[Histogram[IO, Double, Unit]]("Histogram")(
     (reg: TestingMetricRegistry[IO], prefix: Option[Metric.Prefix], name: String, commonLabels: Metric.CommonLabels) =>
       reg.createAndRegisterDoubleHistogram(
         prefix,
@@ -117,13 +117,13 @@ class TestingMetricRegistrySuite extends CatsEffectSuite {
         commonLabels,
         NonEmptySeq.of(0.0, 5.0, 10.0)
       ),
-    (h: Histogram[IO, Double], _: Metric.CommonLabels) =>
+    (h: Histogram[IO, Double, Unit], _: Metric.CommonLabels) =>
       (h.observe(1.0) >> h.observe(2.0) >> h.observe(3.0), Chain(1.0, 2.0, 3.0)),
     (reg: TestingMetricRegistry[IO], prefix: Option[Metric.Prefix], name: String, commonLabels: Metric.CommonLabels) =>
       reg.histogramHistory(prefix, Histogram.Name.unsafeFrom(name), commonLabels)
   )
 
-  labelledSuite[Histogram.Labelled[IO, Double, IndexedSeq[String]]]("Histogram")(
+  labelledSuite[Histogram[IO, Double, IndexedSeq[String]]]("Histogram")(
     (
         reg: TestingMetricRegistry[IO],
         prefix: Option[Metric.Prefix],
@@ -140,7 +140,7 @@ class TestingMetricRegistrySuite extends CatsEffectSuite {
         NonEmptySeq.of(0.0, 5.0, 10.0)
       )(identity[IndexedSeq[String]](_)),
     (
-        h: Histogram.Labelled[IO, Double, IndexedSeq[String]],
+        h: Histogram[IO, Double, IndexedSeq[String]],
         _: Metric.CommonLabels,
         labels: IndexedSeq[String]
     ) => (h.observe(1.0, labels) >> h.observe(2.0, labels) >> h.observe(3.0, labels), Chain(1.0, 2.0, 3.0)),
@@ -154,7 +154,7 @@ class TestingMetricRegistrySuite extends CatsEffectSuite {
     ) => reg.histogramHistory(prefix, Histogram.Name.unsafeFrom(name), commonLabels, labelNames, labelValues)
   )
 
-  suite[Summary[IO, Double]]("Summary")(
+  suite[Summary[IO, Double, Unit]]("Summary")(
     (reg: TestingMetricRegistry[IO], prefix: Option[Metric.Prefix], name: String, commonLabels: Metric.CommonLabels) =>
       reg.createAndRegisterDoubleSummary(
         prefix,
@@ -165,13 +165,13 @@ class TestingMetricRegistrySuite extends CatsEffectSuite {
         5.seconds,
         Summary.AgeBuckets(5)
       ),
-    (s: Summary[IO, Double], _: Metric.CommonLabels) =>
+    (s: Summary[IO, Double, Unit], _: Metric.CommonLabels) =>
       (s.observe(1.0) >> s.observe(2.0) >> s.observe(3.0), Chain(1.0, 2.0, 3.0)),
     (reg: TestingMetricRegistry[IO], prefix: Option[Metric.Prefix], name: String, commonLabels: Metric.CommonLabels) =>
       reg.summaryHistory(prefix, Summary.Name.unsafeFrom(name), commonLabels)
   )
 
-  labelledSuite[Summary.Labelled[IO, Double, IndexedSeq[String]]]("Summary")(
+  labelledSuite[Summary[IO, Double, IndexedSeq[String]]]("Summary")(
     (
         reg: TestingMetricRegistry[IO],
         prefix: Option[Metric.Prefix],
@@ -190,7 +190,7 @@ class TestingMetricRegistrySuite extends CatsEffectSuite {
         Summary.AgeBuckets(5)
       )(identity[IndexedSeq[String]](_)),
     (
-        s: Summary.Labelled[IO, Double, IndexedSeq[String]],
+        s: Summary[IO, Double, IndexedSeq[String]],
         _: Metric.CommonLabels,
         labels: IndexedSeq[String]
     ) => (s.observe(1.0, labels) >> s.observe(2.0, labels) >> s.observe(3.0, labels), Chain(1.0, 2.0, 3.0)),

--- a/testing/src/test/scala/prometheus4cats/testing/TestingMetricRegistrySuite.scala
+++ b/testing/src/test/scala/prometheus4cats/testing/TestingMetricRegistrySuite.scala
@@ -27,7 +27,13 @@ class TestingMetricRegistrySuite extends CatsEffectSuite {
 
   suite[Counter[IO, Double, Unit]]("Counter")(
     (reg: TestingMetricRegistry[IO], prefix: Option[Metric.Prefix], name: String, commonLabels: Metric.CommonLabels) =>
-      reg.createAndRegisterDoubleCounter(prefix, Counter.Name.unsafeFrom(name), Metric.Help("help"), commonLabels),
+      reg.createAndRegisterDoubleCounter(
+        prefix,
+        Counter.Name.unsafeFrom(name),
+        Metric.Help("help"),
+        commonLabels,
+        IndexedSeq.empty
+      )((_: Unit) => IndexedSeq.empty),
     (c: Counter[IO, Double, Unit], _: Metric.CommonLabels) => (c.inc >> c.inc(2.0), Chain(0.0, 1.0, 3.0)),
     (reg: TestingMetricRegistry[IO], prefix: Option[Metric.Prefix], name: String, commonLabels: Metric.CommonLabels) =>
       reg.counterHistory(prefix, Counter.Name.unsafeFrom(name), commonLabels)
@@ -41,7 +47,7 @@ class TestingMetricRegistrySuite extends CatsEffectSuite {
         commonLabels: Metric.CommonLabels,
         labels: IndexedSeq[Label.Name]
     ) =>
-      reg.createAndRegisterLabelledDoubleCounter(
+      reg.createAndRegisterDoubleCounter(
         prefix,
         Counter.Name.unsafeFrom(name),
         Metric.Help("help"),
@@ -65,7 +71,13 @@ class TestingMetricRegistrySuite extends CatsEffectSuite {
 
   suite[Gauge[IO, Double, Unit]]("Gauge")(
     (reg: TestingMetricRegistry[IO], prefix: Option[Metric.Prefix], name: String, commonLabels: Metric.CommonLabels) =>
-      reg.createAndRegisterDoubleGauge(prefix, Gauge.Name.unsafeFrom(name), Metric.Help("help"), commonLabels),
+      reg.createAndRegisterDoubleGauge(
+        prefix,
+        Gauge.Name.unsafeFrom(name),
+        Metric.Help("help"),
+        commonLabels,
+        IndexedSeq.empty
+      )((_: Unit) => IndexedSeq.empty),
     (g: Gauge[IO, Double, Unit], _: Metric.CommonLabels) =>
       (g.inc >> g.dec >> g.inc(2.0) >> g.dec(2.0) >> g.set(-1.0) >> g.reset, Chain(0.0, 1.0, 0.0, 2.0, 0.0, -1.0, 0.0)),
     (reg: TestingMetricRegistry[IO], prefix: Option[Metric.Prefix], name: String, commonLabels: Metric.CommonLabels) =>
@@ -80,7 +92,7 @@ class TestingMetricRegistrySuite extends CatsEffectSuite {
         commonLabels: Metric.CommonLabels,
         labels: IndexedSeq[Label.Name]
     ) =>
-      reg.createAndRegisterLabelledDoubleGauge(
+      reg.createAndRegisterDoubleGauge(
         prefix,
         Gauge.Name.unsafeFrom(name),
         Metric.Help("help"),
@@ -115,8 +127,9 @@ class TestingMetricRegistrySuite extends CatsEffectSuite {
         Histogram.Name.unsafeFrom(name),
         Metric.Help("help"),
         commonLabels,
+        IndexedSeq.empty,
         NonEmptySeq.of(0.0, 5.0, 10.0)
-      ),
+      )((_: Unit) => IndexedSeq.empty),
     (h: Histogram[IO, Double, Unit], _: Metric.CommonLabels) =>
       (h.observe(1.0) >> h.observe(2.0) >> h.observe(3.0), Chain(1.0, 2.0, 3.0)),
     (reg: TestingMetricRegistry[IO], prefix: Option[Metric.Prefix], name: String, commonLabels: Metric.CommonLabels) =>
@@ -131,7 +144,7 @@ class TestingMetricRegistrySuite extends CatsEffectSuite {
         commonLabels: Metric.CommonLabels,
         labels: IndexedSeq[Label.Name]
     ) =>
-      reg.createAndRegisterLabelledDoubleHistogram(
+      reg.createAndRegisterDoubleHistogram(
         prefix,
         Histogram.Name.unsafeFrom(name),
         Metric.Help("help"),
@@ -161,10 +174,11 @@ class TestingMetricRegistrySuite extends CatsEffectSuite {
         Summary.Name.unsafeFrom(name),
         Metric.Help("help"),
         commonLabels,
+        IndexedSeq.empty,
         Seq(Summary.QuantileDefinition(Summary.Quantile(0.5), Summary.AllowedError(0.1))),
         5.seconds,
         Summary.AgeBuckets(5)
-      ),
+      )((_: Unit) => IndexedSeq.empty),
     (s: Summary[IO, Double, Unit], _: Metric.CommonLabels) =>
       (s.observe(1.0) >> s.observe(2.0) >> s.observe(3.0), Chain(1.0, 2.0, 3.0)),
     (reg: TestingMetricRegistry[IO], prefix: Option[Metric.Prefix], name: String, commonLabels: Metric.CommonLabels) =>
@@ -179,7 +193,7 @@ class TestingMetricRegistrySuite extends CatsEffectSuite {
         commonLabels: Metric.CommonLabels,
         labels: IndexedSeq[Label.Name]
     ) =>
-      reg.createAndRegisterLabelledDoubleSummary(
+      reg.createAndRegisterDoubleSummary(
         prefix,
         Summary.Name.unsafeFrom(name),
         Metric.Help("help"),
@@ -377,8 +391,20 @@ class TestingMetricRegistrySuite extends CatsEffectSuite {
     List.range(0, 100).traverse { _ =>
       TestingMetricRegistry[IO].flatMap { reg =>
         (
-          reg.createAndRegisterDoubleCounter(None, Counter.Name("test_total"), Metric.Help("help"), labels),
-          reg.createAndRegisterDoubleGauge(None, Gauge.Name("test_total"), Metric.Help("help"), labels)
+          reg.createAndRegisterDoubleCounter(
+            None,
+            Counter.Name("test_total"),
+            Metric.Help("help"),
+            labels,
+            IndexedSeq.empty
+          )((_: Unit) => IndexedSeq.empty),
+          reg.createAndRegisterDoubleGauge(
+            None,
+            Gauge.Name("test_total"),
+            Metric.Help("help"),
+            labels,
+            IndexedSeq.empty
+          )((_: Unit) => IndexedSeq.empty)
           // TODO improve assertion when we have a common interface across registry implementations for this error
         ).parTupled.use_.intercept[RuntimeException]
       }

--- a/testkit/src/main/scala/prometheus4cats/testkit/CallbackRegistrySuite.scala
+++ b/testkit/src/main/scala/prometheus4cats/testkit/CallbackRegistrySuite.scala
@@ -53,7 +53,14 @@ trait CallbackRegistrySuite[State] extends RegistrySuite[State] { self: CatsEffe
             )
 
             reg
-              .registerDoubleCounterCallback(prefix, name, help, commonLabels, IO(value))
+              .registerDoubleCounterCallback[Unit](
+                prefix,
+                name,
+                help,
+                commonLabels,
+                IndexedSeq.empty,
+                IO(NonEmptyList.of((value, ())))
+              )((_: Unit) => IndexedSeq.empty)
               .surround(
                 get.map(res => if (value >= 0) assertEquals(res, Some(value)) else assertEquals(res, Some(0.0)))
               ) >> get.map(assertEquals(_, None))
@@ -78,7 +85,7 @@ trait CallbackRegistrySuite[State] extends RegistrySuite[State] { self: CatsEffe
             val get = getCounterValue(state, prefix, name, help, commonLabels, labels)
 
             reg
-              .registerLabelledDoubleCounterCallback[Map[Label.Name, String]](
+              .registerDoubleCounterCallback[Map[Label.Name, String]](
                 prefix,
                 name,
                 help,
@@ -114,7 +121,14 @@ trait CallbackRegistrySuite[State] extends RegistrySuite[State] { self: CatsEffe
 
           callbackRegistryResource(state).use { reg =>
             reg
-              .registerDoubleGaugeCallback(prefix, name, help, commonLabels, IO(value))
+              .registerDoubleGaugeCallback[Unit](
+                prefix,
+                name,
+                help,
+                commonLabels,
+                IndexedSeq.empty,
+                IO(NonEmptyList.of((value, ())))
+              )((_: Unit) => IndexedSeq.empty)
               .surround(
                 get.map(assertEquals(_, Some(value)))
               ) >> get.map(assertEquals(_, None))
@@ -138,7 +152,7 @@ trait CallbackRegistrySuite[State] extends RegistrySuite[State] { self: CatsEffe
             val get = getGaugeValue(state, prefix, name, help, commonLabels, labels)
 
             reg
-              .registerLabelledDoubleGaugeCallback[Map[Label.Name, String]](
+              .registerDoubleGaugeCallback[Map[Label.Name, String]](
                 prefix,
                 name,
                 help,
@@ -179,14 +193,15 @@ trait CallbackRegistrySuite[State] extends RegistrySuite[State] { self: CatsEffe
             val get = getHistogramValue(state, prefix, name, help, commonLabels, buckets)
 
             reg
-              .registerDoubleHistogramCallback(
+              .registerDoubleHistogramCallback[Unit](
                 prefix,
                 name,
                 help,
                 commonLabels,
+                IndexedSeq.empty,
                 buckets,
-                IO(Histogram.Value(sum, bucketValues))
-              )
+                IO(NonEmptyList.of((Histogram.Value(sum, bucketValues), ())))
+              )((_: Unit) => IndexedSeq.empty)
               .surround(get.map { res =>
                 assertEquals(res, Some(expected))
               }) >> get.map(assertEquals(_, None))
@@ -222,7 +237,7 @@ trait CallbackRegistrySuite[State] extends RegistrySuite[State] { self: CatsEffe
             val get = getHistogramValue(state, prefix, name, help, commonLabels, buckets, labels)
 
             reg
-              .registerLabelledDoubleHistogramCallback[Map[Label.Name, String]](
+              .registerDoubleHistogramCallback[Map[Label.Name, String]](
                 prefix,
                 name,
                 help,
@@ -255,13 +270,16 @@ trait CallbackRegistrySuite[State] extends RegistrySuite[State] { self: CatsEffe
             val get = getSummaryValue(state, prefix, name, help, commonLabels, Map.empty)
 
             reg
-              .registerDoubleSummaryCallback(
+              .registerDoubleSummaryCallback[Unit](
                 prefix,
                 name,
                 help,
                 commonLabels,
-                IO(Summary.Value(count, sum, quantiles.map { case (q, v) => q.value -> v }))
-              )
+                IndexedSeq.empty,
+                IO(NonEmptyList.of(Summary.Value(count, sum, quantiles.map { case (q, v) => q.value -> v }) -> ()))
+              ) { (_: Unit) =>
+                IndexedSeq.empty
+              }
               .surround(get.map { case (q, c, s) =>
                 assertEquals(q, Some(quantiles.map { case (q, v) => q.value.toString -> v }))
                 assertEquals(c, Some(count))
@@ -293,7 +311,7 @@ trait CallbackRegistrySuite[State] extends RegistrySuite[State] { self: CatsEffe
             val get = getSummaryValue(state, prefix, name, help, commonLabels, labels)
 
             reg
-              .registerLabelledDoubleSummaryCallback[Map[Label.Name, String]](
+              .registerDoubleSummaryCallback[Map[Label.Name, String]](
                 prefix,
                 name,
                 help,
@@ -440,7 +458,7 @@ trait CallbackRegistrySuite[State] extends RegistrySuite[State] { self: CatsEffe
           .flatMap(callbackRegistryResource(_))
           .use { reg =>
             val callback = reg
-              .registerLabelledDoubleCounterCallback[Map[Label.Name, String]](
+              .registerDoubleCounterCallback[Map[Label.Name, String]](
                 prefix,
                 name,
                 help,
@@ -465,7 +483,7 @@ trait CallbackRegistrySuite[State] extends RegistrySuite[State] { self: CatsEffe
         stateResource.use { state =>
           callbackRegistryResource(state).use { reg =>
             val callback = reg
-              .registerLabelledDoubleCounterCallback[Map[Label.Name, String]](
+              .registerDoubleCounterCallback[Map[Label.Name, String]](
                 prefix,
                 name,
                 help,
@@ -503,7 +521,7 @@ trait CallbackRegistrySuite[State] extends RegistrySuite[State] { self: CatsEffe
         stateResource.use { state =>
           callbackRegistryResource(state).use { reg =>
             val callback1 = reg
-              .registerLabelledDoubleCounterCallback[Map[Label.Name, String]](
+              .registerDoubleCounterCallback[Map[Label.Name, String]](
                 prefix,
                 name,
                 help,
@@ -513,7 +531,7 @@ trait CallbackRegistrySuite[State] extends RegistrySuite[State] { self: CatsEffe
               )(_.values.toIndexedSeq)
 
             val callback2 = reg
-              .registerLabelledDoubleCounterCallback[Map[Label.Name, String]](
+              .registerDoubleCounterCallback[Map[Label.Name, String]](
                 prefix,
                 name,
                 help,
@@ -551,7 +569,7 @@ trait CallbackRegistrySuite[State] extends RegistrySuite[State] { self: CatsEffe
         stateResource.use { state =>
           callbackRegistryResource(state).use { reg =>
             val callback1 = reg
-              .registerLabelledDoubleCounterCallback[Map[Label.Name, String]](
+              .registerDoubleCounterCallback[Map[Label.Name, String]](
                 prefix,
                 name,
                 help,
@@ -561,7 +579,7 @@ trait CallbackRegistrySuite[State] extends RegistrySuite[State] { self: CatsEffe
               )(_.values.toIndexedSeq)
 
             val callback2 = reg
-              .registerLabelledDoubleCounterCallback[Map[Label.Name, String]](
+              .registerDoubleCounterCallback[Map[Label.Name, String]](
                 prefix,
                 name,
                 help,
@@ -600,7 +618,7 @@ trait CallbackRegistrySuite[State] extends RegistrySuite[State] { self: CatsEffe
         stateResource.use { state =>
           callbackRegistryResource(state).use { reg =>
             val callback1 = reg
-              .registerLabelledDoubleCounterCallback[Map[Label.Name, String]](
+              .registerDoubleCounterCallback[Map[Label.Name, String]](
                 prefix,
                 name,
                 help,
@@ -610,7 +628,7 @@ trait CallbackRegistrySuite[State] extends RegistrySuite[State] { self: CatsEffe
               )(_.values.toIndexedSeq)
 
             val callback2 = reg
-              .registerLabelledDoubleCounterCallback[Map[Label.Name, String]](
+              .registerDoubleCounterCallback[Map[Label.Name, String]](
                 prefix,
                 name,
                 help,

--- a/testkit/src/main/scala/prometheus4cats/testkit/CallbackRegistrySuite.scala
+++ b/testkit/src/main/scala/prometheus4cats/testkit/CallbackRegistrySuite.scala
@@ -276,7 +276,7 @@ trait CallbackRegistrySuite[State] extends RegistrySuite[State] { self: CatsEffe
                 help,
                 commonLabels,
                 IndexedSeq.empty,
-                IO(NonEmptyList.of(Summary.Value(count, sum, quantiles.map { case (q, v) => q.value -> v }) -> ()))
+                IO(NonEmptyList.of((Summary.Value(count, sum, quantiles.map { case (q, v) => q.value -> v }), ())))
               ) { (_: Unit) =>
                 IndexedSeq.empty
               }

--- a/testkit/src/main/scala/prometheus4cats/testkit/MetricRegistrySuite.scala
+++ b/testkit/src/main/scala/prometheus4cats/testkit/MetricRegistrySuite.scala
@@ -63,7 +63,9 @@ trait MetricRegistrySuite[State] extends RegistrySuite[State] { self: CatsEffect
             )
 
             reg
-              .createAndRegisterDoubleCounter(prefix, name, help, commonLabels)
+              .createAndRegisterDoubleCounter(prefix, name, help, commonLabels, IndexedSeq.empty) { (_: Unit) =>
+                IndexedSeq.empty
+              }
               .evalMap(_.inc(incBy))
               .surround(
                 get.map(res => if (incBy >= 0) assertEquals(res, Some(incBy)) else assertEquals(res, Some(0.0)))
@@ -93,7 +95,9 @@ trait MetricRegistrySuite[State] extends RegistrySuite[State] { self: CatsEffect
             )
 
             reg
-              .createAndRegisterDoubleCounter(prefix, name, help, commonLabels)
+              .createAndRegisterDoubleCounter(prefix, name, help, commonLabels, IndexedSeq.empty) { (_: Unit) =>
+                IndexedSeq.empty
+              }
               .evalMap(_.incWithExemplar(incBy))
               .surround(
                 get.map(res =>
@@ -128,7 +132,7 @@ trait MetricRegistrySuite[State] extends RegistrySuite[State] { self: CatsEffect
             )
 
             reg
-              .createAndRegisterLabelledDoubleCounter[Map[Label.Name, String]](
+              .createAndRegisterDoubleCounter[Map[Label.Name, String]](
                 prefix,
                 name,
                 help,
@@ -166,7 +170,7 @@ trait MetricRegistrySuite[State] extends RegistrySuite[State] { self: CatsEffect
             )
 
             reg
-              .createAndRegisterLabelledDoubleCounter[Map[Label.Name, String]](
+              .createAndRegisterDoubleCounter[Map[Label.Name, String]](
                 prefix,
                 name,
                 help,
@@ -207,7 +211,9 @@ trait MetricRegistrySuite[State] extends RegistrySuite[State] { self: CatsEffect
             )
 
             reg
-              .createAndRegisterDoubleGauge(prefix, name, help, commonLabels)
+              .createAndRegisterDoubleGauge(prefix, name, help, commonLabels, IndexedSeq.empty) { (_: Unit) =>
+                IndexedSeq.empty
+              }
               .use(gauge =>
                 for {
                   _ <- gauge.set(set)
@@ -258,7 +264,7 @@ trait MetricRegistrySuite[State] extends RegistrySuite[State] { self: CatsEffect
             )
 
             reg
-              .createAndRegisterLabelledDoubleGauge[Map[Label.Name, String]](
+              .createAndRegisterDoubleGauge[Map[Label.Name, String]](
                 prefix,
                 name,
                 help,
@@ -317,7 +323,9 @@ trait MetricRegistrySuite[State] extends RegistrySuite[State] { self: CatsEffect
             )
 
             reg
-              .createAndRegisterDoubleHistogram(prefix, name, help, commonLabels, buckets)
+              .createAndRegisterDoubleHistogram(prefix, name, help, commonLabels, IndexedSeq.empty, buckets) {
+                (_: Unit) => IndexedSeq.empty
+              }
               .evalMap(_.observe(value))
               .surround(
                 get.map(res => assertEquals(res, Some(expected)))
@@ -365,7 +373,9 @@ trait MetricRegistrySuite[State] extends RegistrySuite[State] { self: CatsEffect
             )
 
             reg
-              .createAndRegisterDoubleHistogram(prefix, name, help, commonLabels, buckets)
+              .createAndRegisterDoubleHistogram(prefix, name, help, commonLabels, IndexedSeq.empty, buckets) {
+                (_: Unit) => IndexedSeq.empty
+              }
               .evalMap(_.observeWithExemplar(value))
               .surround(
                 get.map(res => assertEquals(res, Some(expected)))
@@ -405,7 +415,7 @@ trait MetricRegistrySuite[State] extends RegistrySuite[State] { self: CatsEffect
             )
 
             reg
-              .createAndRegisterLabelledDoubleHistogram[Map[Label.Name, String]](
+              .createAndRegisterDoubleHistogram[Map[Label.Name, String]](
                 prefix,
                 name,
                 help,
@@ -461,7 +471,7 @@ trait MetricRegistrySuite[State] extends RegistrySuite[State] { self: CatsEffect
             )
 
             reg
-              .createAndRegisterLabelledDoubleHistogram[Map[Label.Name, String]](
+              .createAndRegisterDoubleHistogram[Map[Label.Name, String]](
                 prefix,
                 name,
                 help,
@@ -499,10 +509,11 @@ trait MetricRegistrySuite[State] extends RegistrySuite[State] { self: CatsEffect
                 name,
                 help,
                 commonLabels,
+                IndexedSeq.empty,
                 quantiles,
                 age._1 + 1.second,
                 age._2
-              )
+              )((_: Unit) => IndexedSeq.empty)
               .evalTap(_.observe(value))
               .surround(get.map { case (q, count, sum) =>
                 assertEquals(q, Some(quantiles.map(qd => qd.value.value.toString -> value).toMap))
@@ -542,7 +553,7 @@ trait MetricRegistrySuite[State] extends RegistrySuite[State] { self: CatsEffect
             )
 
             reg
-              .createAndRegisterLabelledDoubleSummary[Map[Label.Name, String]](
+              .createAndRegisterDoubleSummary[Map[Label.Name, String]](
                 prefix,
                 name,
                 help,
@@ -612,7 +623,10 @@ trait MetricRegistrySuite[State] extends RegistrySuite[State] { self: CatsEffect
               commonLabels
             )
 
-            val create = reg.createAndRegisterDoubleCounter(prefix, name, help, commonLabels)
+            val create =
+              reg.createAndRegisterDoubleCounter(prefix, name, help, commonLabels, IndexedSeq.empty) { (_: Unit) =>
+                IndexedSeq.empty
+              }
 
             create.use { c =>
               c.inc(1.0) >> create.use_ >> get.map(_.isDefined).assert
@@ -640,7 +654,10 @@ trait MetricRegistrySuite[State] extends RegistrySuite[State] { self: CatsEffect
               commonLabels
             )
 
-            val create = reg.createAndRegisterDoubleGauge(prefix, name, help, commonLabels)
+            val create =
+              reg.createAndRegisterDoubleGauge(prefix, name, help, commonLabels, IndexedSeq.empty) { (_: Unit) =>
+                IndexedSeq.empty
+              }
 
             create.use { g =>
               g.set(1.0) >> create.use_ >> get.map(_.isDefined).assert
@@ -672,7 +689,10 @@ trait MetricRegistrySuite[State] extends RegistrySuite[State] { self: CatsEffect
               buckets
             )
 
-            val create = reg.createAndRegisterDoubleHistogram(prefix, name, help, commonLabels, buckets)
+            val create =
+              reg.createAndRegisterDoubleHistogram(prefix, name, help, commonLabels, IndexedSeq.empty, buckets) {
+                (_: Unit) => IndexedSeq.empty
+              }
 
             create.use { h =>
               h.observe(value) >> create.use_ >> get.map(_.isDefined).assert
@@ -703,10 +723,11 @@ trait MetricRegistrySuite[State] extends RegistrySuite[State] { self: CatsEffect
                 name,
                 help,
                 commonLabels,
+                IndexedSeq.empty,
                 quantiles,
                 age._1 + 1.second,
                 age._2
-              )
+              )((_: Unit) => IndexedSeq.empty)
 
             create.use { s =>
               s.observe(value) >> create.use_ >> get.map(_._2.isDefined).assert
@@ -756,7 +777,10 @@ trait MetricRegistrySuite[State] extends RegistrySuite[State] { self: CatsEffect
               commonLabels
             )
 
-            val create = reg.createAndRegisterDoubleCounter(prefix, name, help, commonLabels)
+            val create =
+              reg.createAndRegisterDoubleCounter(prefix, name, help, commonLabels, IndexedSeq.empty) { (_: Unit) =>
+                IndexedSeq.empty
+              }
 
             IO.deferred[Unit].flatMap { wait =>
               create.use { c =>
@@ -792,7 +816,10 @@ trait MetricRegistrySuite[State] extends RegistrySuite[State] { self: CatsEffect
               commonLabels
             )
 
-            val create = reg.createAndRegisterDoubleGauge(prefix, name, help, commonLabels)
+            val create =
+              reg.createAndRegisterDoubleGauge(prefix, name, help, commonLabels, IndexedSeq.empty) { (_: Unit) =>
+                IndexedSeq.empty
+              }
 
             IO.deferred[Unit].flatMap { wait =>
               create.use { g =>
@@ -832,7 +859,10 @@ trait MetricRegistrySuite[State] extends RegistrySuite[State] { self: CatsEffect
               buckets
             )
 
-            val create = reg.createAndRegisterDoubleHistogram(prefix, name, help, commonLabels, buckets)
+            val create =
+              reg.createAndRegisterDoubleHistogram(prefix, name, help, commonLabels, IndexedSeq.empty, buckets) {
+                (_: Unit) => IndexedSeq.empty
+              }
 
             IO.deferred[Unit].flatMap { wait =>
               create.use { h =>
@@ -871,10 +901,11 @@ trait MetricRegistrySuite[State] extends RegistrySuite[State] { self: CatsEffect
                 name,
                 help,
                 commonLabels,
+                IndexedSeq.empty,
                 quantiles,
                 age._1 + 1.second,
                 age._2
-              )
+              )((_: Unit) => IndexedSeq.empty)
 
             IO.deferred[Unit].flatMap { wait =>
               create.use { s =>


### PR DESCRIPTION

## 💻 How to review this PR?

This PR was created with the idea of being reviewed commit by commit. Each commit contains an incremental change that makes it easier to review. Also some of the commits contain additional information in their description to help understand why the change was made.

<details><summary><b>I also recommend checking "Hide whitespace" when reviewing this PR!</b></summary></br>


![](https://i0.wp.com/user-images.githubusercontent.com/2503052/137387087-91cc8458-9e11-44a9-8da0-f48251ec452c.gif?ssl=1)

</details>

## 🚀 What's included in this PR?

This PR merges the "labelled" and "no-labelled" metric classes. This can be done in an almost source-compatible way since we can represent a non-metric labelled as a labelled one with no labels and `Unit` as the label type.

We'll need to add a Scala Steward artifact migration for changes like `Counter[F, A]` to `Counter[F, A, Unit]`