### PR TITLE
Get rid of `Sized` from APIs

### DIFF
--- a/core/src/main/scala-2/prometheus4cats/internal/ShapelessPolyfill.scala
+++ b/core/src/main/scala-2/prometheus4cats/internal/ShapelessPolyfill.scala
@@ -36,8 +36,4 @@ private[prometheus4cats] trait ShapelessPolyfill {
 
   val Succ = shapeless.Succ
 
-  type Sized[+Repr, L <: Nat] = shapeless.Sized[Repr, L]
-
-  val Sized = shapeless.Sized
-
 }

--- a/core/src/main/scala-3/prometheus4cats/internal/ShapelessPolyfill.scala
+++ b/core/src/main/scala-3/prometheus4cats/internal/ShapelessPolyfill.scala
@@ -21,10 +21,6 @@ import scala.quoted.*
 
 private[prometheus4cats] trait ShapelessPolyfill {
 
-  type Represented[R] = R match {
-    case IndexedSeq[a] => a
-  }
-
   type Nat = Int
 
   object Nat {
@@ -50,24 +46,6 @@ private[prometheus4cats] trait ShapelessPolyfill {
   object GT {
     given gt1[B <: Nat]: GT[S[B], Nat._0] = new GT[S[B], Nat._0] {}
     given gt2[A <: Nat, B <: Nat](using GT[A, B]): GT[S[A], S[B]] = new GT[S[A], S[B]] {}
-  }
-
-  type TupleSized[R, A, N <: Int] <: Tuple = N match {
-    case 0 => EmptyTuple
-    case S[n] => A *: TupleSized[R, A, n]
-  }
-
-  extension [R, A, N <: Int](s: TupleSized[R, A, N]) {
-    def unsized: IndexedSeq[A] =
-      s.productIterator.toIndexedSeq.asInstanceOf[IndexedSeq[A]]
-    def :+(a: A): TupleSized[R, A, N + 1] =
-      (s :* a).asInstanceOf[TupleSized[R, A, N + 1]]
-  }
-
-  type Sized[Repr, L <: Nat] = TupleSized[Repr, Represented[Repr], L]
-
-  object Sized {
-    def apply[A](a1: A): Sized[IndexedSeq[A], 1] = Tuple1(a1)
   }
 
 }

--- a/core/src/main/scala/prometheus4cats/internal/summary/SummaryDsl.scala
+++ b/core/src/main/scala/prometheus4cats/internal/summary/SummaryDsl.scala
@@ -62,9 +62,7 @@ object SummaryDsl {
         labelNames: Label.Name*
     ): BuildStep[F, Summary[F, A, Map[Label.Name, String]]]
 
-    def labels[B, N <: Nat](labelNames: Sized[IndexedSeq[Label.Name], N])(
-        f: B => Sized[IndexedSeq[String], N]
-    ): LabelsBuildStep[F, A, B, N, Summary]
+    def labels[B](labels: (Label.Name, B => String)*): LabelsBuildStep[F, A, B, Summary]
   }
 
   private val defaultQuantiles: Seq[Summary.QuantileDefinition] = Seq.empty

--- a/core/src/test/scala/test/MetricsFactoryDslTest.scala
+++ b/core/src/test/scala/test/MetricsFactoryDslTest.scala
@@ -49,7 +49,7 @@ object MetricsFactoryDslTest {
   doubleLabelledGaugeBuilder.asCurrentTimeRecorder(_.toUnit(TimeUnit.NANOSECONDS))
   doubleLabelledGaugeBuilder.asOutcomeRecorder.build
 
-  val doubleLabelsGaugeBuilder = doubleGaugeBuilder.labels(Sized(Label.Name("test")))((s: String) => Sized(s)).build
+  val doubleLabelsGaugeBuilder = doubleGaugeBuilder.labels(Label.Name("test") -> ((s: String) => s)).build
 
   val longGaugeBuilder = gaugeBuilder.ofLong.help("help")
   longGaugeBuilder.build

--- a/docs/interface/dsl.md
+++ b/docs/interface/dsl.md
@@ -115,8 +115,9 @@ val classLabelledCounter = factory
   .counter("counter_total")
   .ofDouble
   .help("Describe what this metric does")
-  .labels(Sized(Label.Name("label1"), Label.Name("label2")))((x: MyMultiClass) =>
-    Sized(x.value1, x.value2.toString)
+  .labels[MyMultiClass](
+    Label.Name("label1") -> (_.value1),
+    Label.Name("label2") -> (_.value2.toString)
   )
 
 classLabelledCounter.build.evalMap(_.inc(2.0, MyMultiClass("label_value", 42)))


### PR DESCRIPTION
## 🚀 What's included in this PR?

This PR removes the need to use `Sized` to check at compile time the size of parameters in the `labels` method. This is done by changing the method's signature from:

```scala
def labels[B, N <: Nat](labelNames: Sized[IndexedSeq[Label.Name], N])(
   f: B => Sized[IndexedSeq[String], N]
): LabelsBuildStep[F, A, B, N, L]
```

to...

```scala
def labels[B](labels: (Label.Name, B => String)*): LabelsBuildStep[F, A, B, L]
```