### PR TITLE
Allow using `labels` the same way we use `label`

### DIFF
--- a/core/src/main/scala/prometheus4cats/internal/summary/SummaryDsl.scala
+++ b/core/src/main/scala/prometheus4cats/internal/summary/SummaryDsl.scala
@@ -62,7 +62,7 @@ object SummaryDsl {
         labelNames: Label.Name*
     ): BuildStep[F, Summary[F, A, Map[Label.Name, String]]]
 
-    def labels[B](labels: (Label.Name, B => String)*): LabelsBuildStep[F, A, B, Summary]
+    def labels[B](labels: (Label.Name, B => String)*): LabelledMetricDsl[F, A, B, Summary]
   }
 
   private val defaultQuantiles: Seq[Summary.QuantileDefinition] = Seq.empty

--- a/core/src/test/scala/test/MetricsFactoryDslTest.scala
+++ b/core/src/test/scala/test/MetricsFactoryDslTest.scala
@@ -49,7 +49,8 @@ object MetricsFactoryDslTest {
   doubleLabelledGaugeBuilder.asCurrentTimeRecorder(_.toUnit(TimeUnit.NANOSECONDS))
   doubleLabelledGaugeBuilder.asOutcomeRecorder.build
 
-  val doubleLabelsGaugeBuilder = doubleGaugeBuilder.labels(Label.Name("test") -> ((s: String) => s)).build
+  val doubleLabelsGaugeBuilder =
+    doubleGaugeBuilder.labels(Label.Name("test") -> ((s: String) => s)).label[String]("other_label").build
 
   val longGaugeBuilder = gaugeBuilder.ofLong.help("help")
   longGaugeBuilder.build
@@ -77,10 +78,9 @@ object MetricsFactoryDslTest {
   longCounterBuilder.build
   longCounterBuilder
     .label[String]("label1")
-    .label[Int]("label2")
-    .label[BigInteger]("label3", _.toString)
+    .labels[(Int, BigInteger)](("label2", _._1.toString()), ("label3", _._2.toString()))
     .build
-    .map(_.inc(("dsfsf", 1, BigInteger.ONE)))
+    .map(_.inc(("dsfsf", (1, BigInteger.ONE))))
   longCounterBuilder.unsafeLabels(Label.Name("label1"), Label.Name("label2")).build
 
   val histogramBuilder = factory.histogram("test2")


### PR DESCRIPTION
## 🚀 What's included in this PR?

This PR allows using `labels` interchangeably whenever we can use `label`, for both normal and "callback" DSLs. That means we can do this:

```scala
case class MyClass(a: String, b: Int)

factory
  .counter("test_total")
  .ofLong
  .help("some help")
  .label[String]("label1")
  .labels[MyClass](("a", _.a), ("b", _.b.toString()))
  .label[Int]("other_label")
  .build // Counter[F, Long, (String, MyClass, Int)]
```