### PR TITLE
Allow using `labels` with any type having a `Show` instance

### DIFF
--- a/core/src/main/scala/prometheus4cats/Label.scala
+++ b/core/src/main/scala/prometheus4cats/Label.scala
@@ -42,10 +42,14 @@ object Label {
 
   final class Value private (val value: String) extends AnyVal
 
-  object Value {
+  object Value extends ValueLowPriority0 {
 
-    implicit def fromShow[A: Show](a: A): Value = new Value(a.show)
+    implicit def fromString(a: String): Value = new Value(a)
 
+  }
+
+  trait ValueLowPriority0 {
+    implicit def fromShow[A: Show](a: A): Value = Value.fromString(a.show)
   }
 
 }

--- a/core/src/main/scala/prometheus4cats/Label.scala
+++ b/core/src/main/scala/prometheus4cats/Label.scala
@@ -16,6 +16,9 @@
 
 package prometheus4cats
 
+import cats.Show
+import cats.syntax.all._
+
 import prometheus4cats.internal.LabelNameFromStringLiteral
 import prometheus4cats.internal.Refined
 import prometheus4cats.internal.Refined.Regex
@@ -34,6 +37,14 @@ object Label {
       with LabelNameFromStringLiteral {
     // prevents macro compilation problems with the status label
     private[prometheus4cats] val outcomeStatus = new Name("outcome_status")
+
+  }
+
+  final class Value private (val value: String) extends AnyVal
+
+  object Value {
+
+    implicit def fromShow[A: Show](a: A): Value = new Value(a.show)
 
   }
 

--- a/core/src/main/scala/prometheus4cats/Label.scala
+++ b/core/src/main/scala/prometheus4cats/Label.scala
@@ -44,12 +44,21 @@ object Label {
 
   object Value extends ValueLowPriority0 {
 
-    implicit def fromString(a: String): Value = new Value(a)
+    def apply(a: String) = new Value(a)
+    implicit def fromString(a: String): Value = apply(a)
 
   }
 
   trait ValueLowPriority0 {
-    implicit def fromShow[A: Show](a: A): Value = Value.fromString(a.show)
+    implicit def fromShow[A: Show](a: A): Value = Value(a.show)
+  }
+
+  trait Encoder[A] {
+    def toLabels: IndexedSeq[(Label.Name, A => Label.Value)]
+  }
+
+  object Encoder {
+    def apply[A: Encoder]: Encoder[A] = implicitly
   }
 
 }

--- a/core/src/main/scala/prometheus4cats/internal/package.scala
+++ b/core/src/main/scala/prometheus4cats/internal/package.scala
@@ -22,6 +22,7 @@ import cats.syntax.all._
 import cats.{Contravariant, FlatMap, Functor, Show}
 import prometheus4cats.OutcomeRecorder.Status
 import prometheus4cats._
+import prometheus4cats.internal.InitLast.Aux
 
 import scala.concurrent.duration.FiniteDuration
 
@@ -237,6 +238,8 @@ class MetricDsl[F[_], A, L[_[_], _, _]] private[prometheus4cats] (
     new LabelledMetricDsl(makeMetric, labelNames, b => labelValues.map(_(b).value))
   }
 
+  def labelsFrom[B](implicit encoder: Label.Encoder[B]): LabelledMetricDsl[F, A, B, L] = labels(encoder.toLabels: _*)
+
 }
 
 object MetricDsl {
@@ -271,6 +274,9 @@ object MetricDsl {
 
       new LabelledMetricDsl.WithCallbacks(makeMetric, makeCallback, labelNames, b => labelValues.map(_(b).value))
     }
+
+    override def labelsFrom[B](implicit encoder: Label.Encoder[B]): LabelledMetricDsl.WithCallbacks[F, A, A0, B, L] =
+      labels(encoder.toLabels: _*)
 
     override def label[B]: FirstLabelApply.WithCallbacks[F, A, A0, B, L] =
       new FirstLabelApply.WithCallbacks[F, A, A0, B, L] {
@@ -458,6 +464,18 @@ class LabelledMetricDsl[F[_], A, T, L[_[_], _, _]] private[internal] (
 
     }
 
+  def labelsFrom[B]: LabelsFromApply[F, A, T, B, L] = new LabelsFromApply[F, A, T, B, L] {
+    override def apply[C](implicit encoder: Label.Encoder[B], initLast: Aux[T, B, C]): LabelledMetricDsl[F, A, C, L] = {
+      val labels = encoder.toLabels
+
+      new LabelledMetricDsl(
+        makeMetric,
+        labelNames ++ labels.map(_._1),
+        c => f(initLast.init(c)) ++ labels.map(_._2(initLast.last(c)).value)
+      )
+    }
+  }
+
   override def contramapLabels[B](f0: B => T): LabelledMetricDsl[F, A, B, L] = new LabelledMetricDsl(
     makeMetric,
     labelNames,
@@ -507,6 +525,23 @@ object LabelledMetricDsl {
           c => f(initLast.init(c)) ++ labels.map(_._2(initLast.last(c)).value)
         )
 
+      }
+
+    override def labelsFrom[B]: LabelsFromApply.WithCallbacks[F, A, A0, T, B, L] =
+      new LabelsFromApply.WithCallbacks[F, A, A0, T, B, L] {
+        override def apply[C](implicit
+            encoder: Label.Encoder[B],
+            initLast: Aux[T, B, C]
+        ): LabelledMetricDsl.WithCallbacks[F, A, A0, C, L] = {
+          val labels = encoder.toLabels
+
+          new LabelledMetricDsl.WithCallbacks(
+            makeMetric,
+            makeCallback,
+            labelNames ++ labels.map(_._1),
+            c => f(initLast.init(c)) ++ labels.map(_._2(initLast.last(c)).value)
+          )
+        }
       }
 
     override def contramapLabels[B](f0: B => T): WithCallbacks[F, A, A0, B, L] =
@@ -595,6 +630,25 @@ object LabelsApply {
   abstract class WithCallbacks[F[_], A, A0, T, B, L[_[_], _, _]] extends LabelsApply[F, A, T, B, L] {
 
     def apply[C](labels: (Label.Name, B => Label.Value)*)(implicit
+        initLast: InitLast.Aux[T, B, C]
+    ): LabelledMetricDsl.WithCallbacks[F, A, A0, C, L]
+
+  }
+
+}
+
+abstract class LabelsFromApply[F[_], A, T, B, L[_[_], _, _]] {
+
+  def apply[C](implicit encoder: Label.Encoder[B], initLast: InitLast.Aux[T, B, C]): LabelledMetricDsl[F, A, C, L]
+
+}
+
+object LabelsFromApply {
+
+  abstract class WithCallbacks[F[_], A, A0, T, B, L[_[_], _, _]] extends LabelsFromApply[F, A, T, B, L] {
+
+    override def apply[C](implicit
+        encoder: Label.Encoder[B],
         initLast: InitLast.Aux[T, B, C]
     ): LabelledMetricDsl.WithCallbacks[F, A, A0, C, L]
 

--- a/core/src/main/scala/prometheus4cats/internal/summary/SummaryDsl.scala
+++ b/core/src/main/scala/prometheus4cats/internal/summary/SummaryDsl.scala
@@ -62,7 +62,7 @@ object SummaryDsl {
         labelNames: Label.Name*
     ): BuildStep[F, Summary[F, A, Map[Label.Name, String]]]
 
-    def labels[B](labels: (Label.Name, B => String)*): LabelledMetricDsl[F, A, B, Summary]
+    def labels[B](labels: (Label.Name, B => Label.Value)*): LabelledMetricDsl[F, A, B, Summary]
   }
 
   private val defaultQuantiles: Seq[Summary.QuantileDefinition] = Seq.empty

--- a/core/src/main/scala/prometheus4cats/internal/summary/SummaryDsl.scala
+++ b/core/src/main/scala/prometheus4cats/internal/summary/SummaryDsl.scala
@@ -63,6 +63,8 @@ object SummaryDsl {
     ): BuildStep[F, Summary[F, A, Map[Label.Name, String]]]
 
     def labels[B](labels: (Label.Name, B => Label.Value)*): LabelledMetricDsl[F, A, B, Summary]
+
+    def labelsFrom[B](implicit encoder: Label.Encoder[B]): LabelledMetricDsl[F, A, B, Summary]
   }
 
   private val defaultQuantiles: Seq[Summary.QuantileDefinition] = Seq.empty

--- a/core/src/test/scala/test/MetricsFactoryDslTest.scala
+++ b/core/src/test/scala/test/MetricsFactoryDslTest.scala
@@ -50,7 +50,7 @@ object MetricsFactoryDslTest {
   doubleLabelledGaugeBuilder.asOutcomeRecorder.build
 
   val doubleLabelsGaugeBuilder =
-    doubleGaugeBuilder.labels(Label.Name("test") -> ((s: String) => s)).label[String]("other_label").build
+    doubleGaugeBuilder.labels[String](Label.Name("test") -> (s => s)).label[String]("other_label").build
 
   val longGaugeBuilder = gaugeBuilder.ofLong.help("help")
   longGaugeBuilder.build

--- a/core/src/test/scala/test/MetricsFactoryDslTest.scala
+++ b/core/src/test/scala/test/MetricsFactoryDslTest.scala
@@ -78,7 +78,7 @@ object MetricsFactoryDslTest {
   longCounterBuilder.build
   longCounterBuilder
     .label[String]("label1")
-    .labels[(Int, BigInteger)](("label2", _._1.toString()), ("label3", _._2.toString()))
+    .labels[(Int, BigInteger)](("label2", _._1), ("label3", _._2.toString()))
     .build
     .map(_.inc(("dsfsf", (1, BigInteger.ONE))))
   longCounterBuilder.unsafeLabels(Label.Name("label1"), Label.Name("label2")).build

--- a/core/src/test/scala/test/MetricsFactoryDslTest.scala
+++ b/core/src/test/scala/test/MetricsFactoryDslTest.scala
@@ -74,13 +74,25 @@ object MetricsFactoryDslTest {
   doubleLabelledCounterBuilder.contramap[Int](_.toDouble).build
   doubleLabelledCounterBuilder.asOutcomeRecorder.build
 
+  case class LabelsClass(a: String, b: Long)
+  object LabelsClass {
+    implicit val encoder: Label.Encoder[LabelsClass] = new Label.Encoder[LabelsClass] {
+      override val toLabels: IndexedSeq[(Label.Name, LabelsClass => Label.Value)] =
+        IndexedSeq(
+          Label.Name("a") -> ((lc: LabelsClass) => Label.Value(lc.a)),
+          Label.Name("b") -> ((lc: LabelsClass) => Label.Value.fromShow(lc.b))
+        )
+    }
+  }
+
   val longCounterBuilder = counterBuilder.ofLong.help("help")
   longCounterBuilder.build
   longCounterBuilder
+    .labelsFrom[LabelsClass]
     .label[String]("label1")
     .labels[(Int, BigInteger)](("label2", _._1), ("label3", _._2.toString()))
     .build
-    .map(_.inc(("dsfsf", (1, BigInteger.ONE))))
+    .map(_.inc((LabelsClass("sdfds", 22), "dsfsf", (1, BigInteger.ONE))))
   longCounterBuilder.unsafeLabels(Label.Name("label1"), Label.Name("label2")).build
 
   val histogramBuilder = factory.histogram("test2")


### PR DESCRIPTION
This allows doing:

```diff
case class MyClass(a: Long, b: Int)

factory
  .counter("test_total")
  .ofLong
  .help("some help")
+ .labels[MyClass](("a", _.a), ("b", _.b))
- .labels[MyClass](("a", _.a.toString()), ("b", _.b.toString()))
  .build
````