### PR TITLE
Change exemplar sampler to return `Exemplar.Data`

### DIFF
--- a/core/src/main/scala/prometheus4cats/ExemplarSampler.scala
+++ b/core/src/main/scala/prometheus4cats/ExemplarSampler.scala
@@ -21,9 +21,9 @@ import cats.data.NonEmptySeq
 
 trait ExemplarSampler[F[_], -A] extends ExemplarSampler.Counter[F, A] with ExemplarSampler.Histogram[F, A] { self =>
   override def mapK[G[_]](fk: F ~> G): ExemplarSampler[G, A] = new ExemplarSampler[G, A] {
-    override def sample(previous: Option[Exemplar.Data]): G[Option[Exemplar.Labels]] = fk(self.sample(previous))
+    override def sample(previous: Option[Exemplar.Data]): G[Option[Exemplar.Data]] = fk(self.sample(previous))
 
-    override def sample(value: A, previous: Option[Exemplar.Data]): G[Option[Exemplar.Labels]] = fk(
+    override def sample(value: A, previous: Option[Exemplar.Data]): G[Option[Exemplar.Data]] = fk(
       self.sample(value, previous)
     )
 
@@ -31,21 +31,21 @@ trait ExemplarSampler[F[_], -A] extends ExemplarSampler.Counter[F, A] with Exemp
         value: A,
         buckets: NonEmptySeq[Double],
         previous: Option[Exemplar.Data]
-    ): G[Option[Exemplar.Labels]] = fk(self.sample(value, buckets, previous))
+    ): G[Option[Exemplar.Data]] = fk(self.sample(value, buckets, previous))
   }
 }
 
 object ExemplarSampler extends Common {
   trait Counter[F[_], -A] {
     self =>
-    def sample(previous: Option[Exemplar.Data]): F[Option[Exemplar.Labels]]
+    def sample(previous: Option[Exemplar.Data]): F[Option[Exemplar.Data]]
 
-    def sample(value: A, previous: Option[Exemplar.Data]): F[Option[Exemplar.Labels]]
+    def sample(value: A, previous: Option[Exemplar.Data]): F[Option[Exemplar.Data]]
 
     def mapK[G[_]](fk: F ~> G): Counter[G, A] = new Counter[G, A] {
-      override def sample(previous: Option[Exemplar.Data]): G[Option[Exemplar.Labels]] = fk(self.sample(previous))
+      override def sample(previous: Option[Exemplar.Data]): G[Option[Exemplar.Data]] = fk(self.sample(previous))
 
-      override def sample(value: A, previous: Option[Exemplar.Data]): G[Option[Exemplar.Labels]] = fk(
+      override def sample(value: A, previous: Option[Exemplar.Data]): G[Option[Exemplar.Data]] = fk(
         self.sample(value, previous)
       )
     }
@@ -57,14 +57,14 @@ object ExemplarSampler extends Common {
 
   trait Histogram[F[_], -A] {
     self =>
-    def sample(value: A, buckets: NonEmptySeq[Double], previous: Option[Exemplar.Data]): F[Option[Exemplar.Labels]]
+    def sample(value: A, buckets: NonEmptySeq[Double], previous: Option[Exemplar.Data]): F[Option[Exemplar.Data]]
 
     def mapK[G[_]](fk: F ~> G): Histogram[G, A] = new Histogram[G, A] {
       override def sample(
           value: A,
           buckets: NonEmptySeq[Double],
           previous: Option[Exemplar.Data]
-      ): G[Option[Exemplar.Labels]] =
+      ): G[Option[Exemplar.Data]] =
         fk(self.sample(value, buckets, previous))
     }
   }
@@ -79,16 +79,16 @@ object ExemplarSampler extends Common {
 trait Common {
   object Implicits {
     implicit def noop[F[_]: Applicative, A]: ExemplarSampler[F, A] = new ExemplarSampler[F, A] {
-      override def sample(previous: Option[Exemplar.Data]): F[Option[Exemplar.Labels]] = Applicative[F].pure(None)
+      override def sample(previous: Option[Exemplar.Data]): F[Option[Exemplar.Data]] = Applicative[F].pure(None)
 
-      override def sample(value: A, previous: Option[Exemplar.Data]): F[Option[Exemplar.Labels]] =
+      override def sample(value: A, previous: Option[Exemplar.Data]): F[Option[Exemplar.Data]] =
         Applicative[F].pure(None)
 
       override def sample(
           value: A,
           buckets: NonEmptySeq[Double],
           previous: Option[Exemplar.Data]
-      ): F[Option[Exemplar.Labels]] = Applicative[F].pure(None)
+      ): F[Option[Exemplar.Data]] = Applicative[F].pure(None)
     }
   }
 }

--- a/core/src/main/scala/prometheus4cats/OutcomeRecorder.scala
+++ b/core/src/main/scala/prometheus4cats/OutcomeRecorder.scala
@@ -17,7 +17,7 @@
 package prometheus4cats
 
 import cats.effect.kernel.syntax.monadCancel._
-import cats.effect.kernel.{Clock, MonadCancelThrow, Outcome}
+import cats.effect.kernel.{MonadCancelThrow, Outcome}
 import cats.syntax.flatMap._
 import cats.{FlatMap, Monad, Show, ~>}
 import prometheus4cats.internal.Neq
@@ -137,7 +137,7 @@ object OutcomeRecorder {
 
     final def surroundWithSampledExemplar[B](
         fb: F[B]
-    )(implicit F: MonadCancelThrow[F], clock: Clock[F], exemplarSampler: ExemplarSampler.Counter[F, A]): F[B] =
+    )(implicit F: MonadCancelThrow[F], exemplarSampler: ExemplarSampler.Counter[F, A]): F[B] =
       fb.guaranteeCase(recordWithSampledExemplar)
 
     final def surroundProvidedExemplar[C](
@@ -173,7 +173,7 @@ object OutcomeRecorder {
 
     final def recordWithSampledExemplar[B, E](
         outcome: Outcome[F, E, B]
-    )(implicit F: Monad[F], clock: Clock[F], exemplarSampler: ExemplarSampler.Counter[F, A]): F[Unit] =
+    )(implicit F: Monad[F], exemplarSampler: ExemplarSampler.Counter[F, A]): F[Unit] =
       recorder.exemplarState.surround(exemplar => recordOutcomeProvidedExemplar(outcome, exemplar, exemplar, exemplar))
 
     final def recordOutcomeProvidedExemplar[C, E](
@@ -297,7 +297,6 @@ object OutcomeRecorder {
 
     final def surroundWithSampledExemplar[C](fb: F[C], labels: A)(implicit
         F: MonadCancelThrow[F],
-        clock: Clock[F],
         exemplarSampler: ExemplarSampler.Counter[F, B]
     ): F[C] = fb.guaranteeCase(recordOutcomeWithSampledExemplar(_, labels))
 
@@ -342,7 +341,6 @@ object OutcomeRecorder {
         labels: A
     )(implicit
         F: Monad[F],
-        clock: Clock[F],
         exemplarSampler: ExemplarSampler.Counter[F, B]
     ): F[Unit] =
       recorder.exemplarState.surround(next => recordOutcomeProvidedExemplar(outcome, labels, next, next, next))
@@ -403,7 +401,6 @@ object OutcomeRecorder {
         labelsCanceled: A
     )(labelsSuccess: C => A, labelsError: Throwable => A)(implicit
         F: MonadCancelThrow[F],
-        clock: Clock[F],
         exemplarSampler: ExemplarSampler.Counter[F, B]
     ): F[C] =
       fb.guaranteeCase(
@@ -449,7 +446,6 @@ object OutcomeRecorder {
         labelsCanceled: A
     )(labelsSuccess: C => A, labelsError: E => A)(implicit
         F: Monad[F],
-        clock: Clock[F],
         exemplarSampler: ExemplarSampler.Counter[F, B]
     ): F[Unit] =
       recorder.exemplarState


### PR DESCRIPTION
The time may be checked internally in the implementation, so may as well return it and cut down on the need for another implicit