### PR TITLE
Open v6 series: add prometheus-metrics-core deps and relax version policy

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 ThisBuild / scalaVersion           := "2.13.18"
 ThisBuild / crossScalaVersions     := Seq("2.13.18", "3.3.7")
 ThisBuild / organization           := "com.permutive"
-ThisBuild / versionPolicyIntention := Compatibility.BinaryAndSourceCompatible
+ThisBuild / versionPolicyIntention := Compatibility.None
 
 addCommandAlias("ci-test", "fix --check; versionPolicyCheck; mdoc; publishLocal; +test")
 addCommandAlias("ci-docs", "github; mdoc; headerCreateAll; docusaurusPublishGhpages")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -36,17 +36,17 @@ object Dependencies {
   )
 
   lazy val `prometheus4cats-java` = Seq(
-    "org.typelevel" %% "alleycats-core"                          % "2.13.0",
-    "org.typelevel" %% "cats-effect-std"                         % "3.6.3",
+    "org.typelevel" %% "alleycats-core"  % "2.13.0",
+    "org.typelevel" %% "cats-effect-std" % "3.6.3",
     // simpleclient (0.x) — backs the legacy `prometheus4cats.javasimpleclient` adapter. Will be removed
     // once the new `prometheus4cats.javaclient` adapter on prometheus-metrics-core 1.x is complete.
-    "io.prometheus"  % "simpleclient"                            % "0.16.0",
-    "io.prometheus"  % "simpleclient_hotspot"                    % "0.16.0",
+    "io.prometheus" % "simpleclient"         % "0.16.0",
+    "io.prometheus" % "simpleclient_hotspot" % "0.16.0",
     // prometheus-metrics-core (1.x) — backs the new `prometheus4cats.javaclient` adapter. Adds native
     // histogram support. Coexists with simpleclient during migration: different package namespaces
     // (`io.prometheus.metrics.*` vs `io.prometheus.client.*`) so there's no classpath conflict.
-    "io.prometheus"  % "prometheus-metrics-core"                 % "1.6.1",
-    "io.prometheus"  % "prometheus-metrics-instrumentation-jvm"  % "1.6.1"
+    "io.prometheus" % "prometheus-metrics-core"                % "1.6.1",
+    "io.prometheus" % "prometheus-metrics-instrumentation-jvm" % "1.6.1"
   )
 
   lazy val website = Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -36,10 +36,17 @@ object Dependencies {
   )
 
   lazy val `prometheus4cats-java` = Seq(
-    "org.typelevel" %% "alleycats-core"       % "2.13.0",
-    "org.typelevel" %% "cats-effect-std"      % "3.6.3",
-    "io.prometheus"  % "simpleclient"         % "0.16.0",
-    "io.prometheus"  % "simpleclient_hotspot" % "0.16.0"
+    "org.typelevel" %% "alleycats-core"                          % "2.13.0",
+    "org.typelevel" %% "cats-effect-std"                         % "3.6.3",
+    // simpleclient (0.x) — backs the legacy `prometheus4cats.javasimpleclient` adapter. Will be removed
+    // once the new `prometheus4cats.javaclient` adapter on prometheus-metrics-core 1.x is complete.
+    "io.prometheus"  % "simpleclient"                            % "0.16.0",
+    "io.prometheus"  % "simpleclient_hotspot"                    % "0.16.0",
+    // prometheus-metrics-core (1.x) — backs the new `prometheus4cats.javaclient` adapter. Adds native
+    // histogram support. Coexists with simpleclient during migration: different package namespaces
+    // (`io.prometheus.metrics.*` vs `io.prometheus.client.*`) so there's no classpath conflict.
+    "io.prometheus"  % "prometheus-metrics-core"                 % "1.6.1",
+    "io.prometheus"  % "prometheus-metrics-instrumentation-jvm"  % "1.6.1"
   )
 
   lazy val website = Seq(


### PR DESCRIPTION
Foundation PR for the v6 backend uplift. Pure build configuration — no Scala code changes.

## Summary

- Adds `prometheus-metrics-core` 1.6.1 and `prometheus-metrics-instrumentation-jvm` 1.6.1 alongside the existing `simpleclient` 0.16.0 and `simpleclient_hotspot` 0.16.0. The two Java client lines have disjoint package namespaces (`io.prometheus.metrics.*` vs `io.prometheus.client.*`) and coexist with no classpath conflict.
- Flips `versionPolicyIntention` from `Compatibility.BinaryAndSourceCompatible` to `Compatibility.None`. Required because subsequent v6 PRs add abstract methods to `MetricRegistry`, redesign `Info`, and delete the legacy adapter — all source-incompatible.

## Context

This is the first of a seriies of split PRs replacing #124. Each PR targets `series/6.x` (this PR's base). The full split plan covers:

1. **This PR** — deps + version policy
2. `NativeHistogram` config type
3. `MetricRegistry` SPI extension for native histograms
4. `Info` redesign for build-time labels
5. `.withNative` dual-mode histogram
6-9. `javaclient` backend (skeleton → histograms → summary/info → callbacks)
10. Testkit conformance + drop legacy `javasimpleclient`
11. Migration guide + native histogram docs
12. (TBD) self-metrics scenario — pending maintainer decision

## Why this PR is split out

Allows reviewers to focus on the API design PRs (2-5) without first wading through build/version-policy noise, and isolates the moment we commit to allowing source breaks on this branch.

## Risk

None. Pure build config; both Java client lines compile side-by-side. Existing 114-test suite passes unchanged.

## Test plan

- [x] `sbt update` resolves all four Java client artifacts
- [x] `sbt compile` clean on Scala 2.13.18 + 3.3.7
- [x] `sbt test` — all 114 existing tests pass
- [ ] `versionPolicyCheck` confirmed permissive once subsequent PRs land

## Follow-up

- Once v6.0.0 is tagged, `versionPolicyIntention` flips back to `BinaryAndSourceCompatible` on `series/6.x` for the v6 maintenance line.
- `simpleclient` + `simpleclient_hotspot` dependencies and their inline comments are dropped atomically in the cutover PR (PR 10).