### PR TITLE
Add javaclient backend skeleton with Counter and Gauge

### DIFF
--- a/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
+++ b/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
@@ -281,6 +281,70 @@ class JavaMetricRegistry[F[_]: Async] private (
     }
   }
 
+  override def createAndRegisterDoubleHistogramWithNative[A](
+      prefix: Option[Metric.Prefix],
+      name: Histogram.Name,
+      help: Metric.Help,
+      commonLabels: Metric.CommonLabels,
+      labelNames: IndexedSeq[Label.Name],
+      buckets: NonEmptySeq[Double],
+      nativeHistogram: NativeHistogram
+  )(f: A => IndexedSeq[String]): Resource[F, Histogram[F, Double, A]] = {
+    val commonLabelNames       = commonLabels.value.keys.toIndexedSeq
+    val commonLabelValuesArray = commonLabels.value.values.toArray
+    val allLabelNames          = labelNames ++ commonLabelNames
+    val fullName               = NameUtils.makeName(prefix, name)
+
+    configureBuilderOrRetrieve[PHistogram](
+      register = () => {
+        // Dual-mode: NEITHER .classicOnly() NOR .nativeOnly(). Both classicUpperBounds(...) and
+        // nativeInitialSchema(...) are set. The resulting Histogram emits BOTH representations,
+        // letting Prometheus's `convert_classic_histograms_to_nhcb` pick the classic form for
+        // server-side NHCB conversion while the native exponential is also available directly.
+        val builder = PHistogram
+          .builder()
+          .name(fullName)
+          .help(help.value)
+          .labelNames(allLabelNames.map(_.value): _*)
+          .classicUpperBounds(buckets.toSeq.toArray: _*)
+          .nativeInitialSchema(nativeHistogram.initialSchema)
+          .nativeMaxNumberOfBuckets(nativeHistogram.maxNumberOfBuckets)
+          .nativeMaxZeroThreshold(nativeHistogram.maxZeroThreshold)
+          .nativeMinZeroThreshold(nativeHistogram.minZeroThreshold)
+        val tuned =
+          if (nativeHistogram.resetDuration > 0.seconds)
+            builder.nativeResetDuration(
+              nativeHistogram.resetDuration.toSeconds,
+              java.util.concurrent.TimeUnit.SECONDS
+            )
+          else builder
+        tuned.register(registry)
+      },
+      // Use a distinct MetricType so dedup is correct: registering the same metric name as
+      // dual-mode and then again as classic-only is a programmer error and should fail.
+      metricType = MetricType.HistogramWithNative,
+      metricPrefix = prefix,
+      stringName = name.value,
+      labels = allLabelNames
+    ).map { case (histogram, exemplarRef) =>
+      Histogram.make[F, Double, A](
+        Histogram.ExemplarState.fromRef(buckets, exemplarRef),
+        _observe = { (d: Double, labels: A, exemplar: Option[Exemplar.Labels]) =>
+          Utils.modifyMetric[F, Histogram.Name, io.prometheus.metrics.core.datapoints.DistributionDataPoint](
+            metricName = name,
+            allLabelNames = allLabelNames,
+            dynamicLabels = f(labels),
+            commonLabelValues = commonLabelValuesArray,
+            getDataPoint = (lbls: Array[String]) => histogram.labelValues(lbls: _*),
+            modify = (dp: io.prometheus.metrics.core.datapoints.DistributionDataPoint) =>
+              exemplar.fold(dp.observe(d))(e => dp.observeWithExemplar(d, transformExemplarLabels(e))),
+            logger = logger
+          )
+        }
+      )
+    }
+  }
+
   override def createAndRegisterDoubleNativeHistogram[A](
       prefix: Option[Metric.Prefix],
       name: Histogram.Name,
@@ -342,17 +406,6 @@ class JavaMetricRegistry[F[_]: Async] private (
       )
     }
   }
-
-  override def createAndRegisterDoubleHistogramWithNative[A](
-      prefix: Option[Metric.Prefix],
-      name: Histogram.Name,
-      help: Metric.Help,
-      commonLabels: Metric.CommonLabels,
-      labelNames: IndexedSeq[Label.Name],
-      buckets: NonEmptySeq[Double],
-      nativeHistogram: NativeHistogram
-  )(f: A => IndexedSeq[String]): Resource[F, Histogram[F, Double, A]] =
-    Resource.eval(ApplicativeThrow[F].raiseError(notYetPorted("createAndRegisterDoubleHistogramWithNative")))
 
   override def createAndRegisterDoubleSummary[A](
       prefix: Option[Metric.Prefix],

--- a/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
+++ b/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
@@ -153,7 +153,6 @@ class JavaMetricRegistry[F[_]: Async] private (
           .name(fullName)
           .help(help.value)
           .labelNames(allLabelNames.map(_.value): _*)
-          .withExemplars()
           .register(registry),
       metricType = MetricType.Counter,
       metricPrefix = prefix,

--- a/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
+++ b/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
@@ -45,6 +45,7 @@ import io.prometheus.metrics.core.metrics.{Summary => PSummary}
 import io.prometheus.metrics.instrumentation.jvm.JvmMetrics
 import io.prometheus.metrics.model.registry.PrometheusRegistry
 import io.prometheus.metrics.model.registry.{Collector => PCollector}
+import io.prometheus.metrics.model.registry.{MultiCollector => PMultiCollector}
 import io.prometheus.metrics.model.snapshots.ClassicHistogramBuckets
 import io.prometheus.metrics.model.snapshots.CounterSnapshot
 import io.prometheus.metrics.model.snapshots.DataPointSnapshot
@@ -54,6 +55,7 @@ import io.prometheus.metrics.model.snapshots.HistogramSnapshot
 import io.prometheus.metrics.model.snapshots.Labels
 import io.prometheus.metrics.model.snapshots.MetricMetadata
 import io.prometheus.metrics.model.snapshots.MetricSnapshot
+import io.prometheus.metrics.model.snapshots.MetricSnapshots
 import io.prometheus.metrics.model.snapshots.Quantiles
 import io.prometheus.metrics.model.snapshots.SummarySnapshot
 import io.prometheus.metrics.model.snapshots.{Quantile => PQuantile}
@@ -83,6 +85,20 @@ class JavaMetricRegistry[F[_]: Async] private (
     private val dispatcher: Dispatcher[F],
     private val callbackTimeout: FiniteDuration,
     private val singleCallbackTimeout: FiniteDuration,
+    // Metric-collection callbacks: keyed by prefix (each prefix has its own merged common-labels map
+    // and a token-keyed map of user callbacks producing MetricCollection values). Constructed
+    // here, but the upstream MultiCollector that aggregates them is built in the class body via
+    // [[buildMetricCollectionMultiCollector]] so it can capture `this`.
+    private val metricCollectionRef: Ref[F, Map[
+      Option[Metric.Prefix],
+      (
+          Map[Label.Name, String],
+          Map[
+            Unique.Token,
+            F[MetricCollection]
+          ]
+      )
+    ]],
     private val logger: Throwable => String => F[Unit]
 ) extends DoubleMetricRegistry[F]
     with DoubleCallbackRegistry[F] {
@@ -973,18 +989,194 @@ class JavaMetricRegistry[F[_]: Async] private (
     )
   }
 
+  /** A single upstream `MultiCollector` that aggregates all metric-collection callbacks across all prefixes. Built
+    * lazily so it captures `this` (specifically `metricCollectionRef`, the dispatcher, and the timeout helpers). The
+    * Builder.build flow accesses it via `metricCollectionCollector` to register it with the underlying registry on
+    * acquire and unregister on release.
+    */
+  private[javaclient] val metricCollectionCollector: PMultiCollector = new PMultiCollector {
+
+    override def collect(): MetricSnapshots = {
+      val result: F[MetricSnapshots] = metricCollectionRef.get.flatMap { perPrefix =>
+        // For each prefix, run all registered callbacks under the per-callback timeout, merge their
+        // MetricCollection values, then convert to MetricSnapshots. We use a fresh
+        // `singleCallbackErrorState` reading on each scrape so log-once gating still applies.
+        perPrefix.toList.flatTraverse { case (prefix, (commonLabels, callbacks)) =>
+          val mergedCol: F[MetricCollection] = callbacks.values.toList.foldM(MetricCollection.empty) { (acc, cbF) =>
+            cbF
+              .timeout(singleCallbackTimeout)
+              .handleErrorWith { th =>
+                logger(th)(
+                  s"A metric-collection callback (prefix=${prefix.map(_.value).getOrElse("<none>")}) failed or timed out."
+                ).as(MetricCollection.empty)
+              }
+              .map(acc.combine)
+          }
+          mergedCol.map(metricCollectionToSnapshots(prefix, commonLabels, _))
+        }
+      }.map(snapshotList => new MetricSnapshots(snapshotList.asJava))
+
+      runCallbackWithBounds(
+        result,
+        callbackTimeout,
+        th =>
+          logger(th)(s"Combined metric-collection callbacks timed out after $callbackTimeout")
+            .as(MetricSnapshots.builder().build()),
+        th => logger(th)(s"Combined metric-collection callbacks failed").as(MetricSnapshots.builder().build())
+      )
+    }
+
+  }
+
   override def registerMetricCollectionCallback(
       prefix: Option[Metric.Prefix],
       commonLabels: Metric.CommonLabels,
       callback: F[MetricCollection]
-  ): Resource[F, Unit] =
-    Resource.eval(ApplicativeThrow[F].raiseError(notYetPorted("registerMetricCollectionCallback")))
+  ): Resource[F, Unit] = {
+    val acquire: F[Unique.Token] = Unique[F].unique.flatMap { token =>
+      metricCollectionRef
+        .update(map =>
+          map.updated(
+            prefix,
+            map.get(prefix).fold(commonLabels.value -> Map(token -> callback)) { case (existingCommon, cbs) =>
+              (existingCommon ++ commonLabels.value) -> cbs.updated(token, callback)
+            }
+          )
+        )
+        .as(token)
+    }
 
-  private def notYetPorted(methodName: String): UnsupportedOperationException =
-    new UnsupportedOperationException(
-      s"prometheus4cats.javaclient.JavaMetricRegistry.$methodName is not yet implemented in this commit. " +
-        "It will be ported in a subsequent commit before the simpleclient backend is removed."
-    )
+    Resource
+      .make(acquire) { token =>
+        metricCollectionRef.update { map =>
+          map.get(prefix).fold(map) { case (commonLabels, cbs) =>
+            val remaining = cbs - token
+            if (remaining.isEmpty) map - prefix
+            else map.updated(prefix, commonLabels -> remaining)
+          }
+        }
+      }
+      .void
+  }
+
+  /** Convert a `MetricCollection` (the prometheus4cats per-prefix bag of typed metric values) into a flat list of
+    * upstream `MetricSnapshot`s. Each (name, labelNames) entry becomes one snapshot with one or more data points (one
+    * per List entry in the user's MetricCollection).
+    */
+  private def metricCollectionToSnapshots(
+      prefix: Option[Metric.Prefix],
+      commonLabels: Map[Label.Name, String],
+      mc: MetricCollection
+  ): List[MetricSnapshot] = {
+    val commonLabelKeysArr   = commonLabels.keys.toArray.map(_.value)
+    val commonLabelValuesArr = commonLabels.values.toArray
+
+    def labelsFor(labelNames: IndexedSeq[Label.Name], labelValues: IndexedSeq[String]): Labels = {
+      val nameArr  = labelNames.map(_.value).toArray ++ commonLabelKeysArr
+      val valueArr = labelValues.toArray ++ commonLabelValuesArr
+      Labels.of(nameArr, valueArr)
+    }
+
+    val counterSnapshots: List[MetricSnapshot] = mc.counters.toList.flatMap { case ((name, labelNames), values) =>
+      values.headOption.map { head =>
+        val rawName  = NameUtils.makeName(prefix, name)
+        val baseName = if (rawName.endsWith("_total")) rawName.dropRight("_total".length) else rawName
+        val dps = values.map { v =>
+          val (vDouble, lbls) = v match {
+            case x: MetricCollection.Value.LongCounter   => (x.value.toDouble, x.labelValues)
+            case x: MetricCollection.Value.DoubleCounter => (x.value, x.labelValues)
+          }
+          new CounterSnapshot.CounterDataPointSnapshot(
+            if (vDouble < 0) 0.0 else vDouble,
+            labelsFor(labelNames, lbls),
+            null: io.prometheus.metrics.model.snapshots.Exemplar,
+            0L
+          )
+        }.asJava
+        new CounterSnapshot(new MetricMetadata(baseName, head.help.value), dps): MetricSnapshot
+      }
+    }
+
+    val gaugeSnapshots: List[MetricSnapshot] = mc.gauges.toList.flatMap { case ((name, labelNames), values) =>
+      values.headOption.map { head =>
+        val fullName = NameUtils.makeName(prefix, name)
+        val dps = values.map { v =>
+          val (vDouble, lbls) = v match {
+            case x: MetricCollection.Value.LongGauge   => (x.value.toDouble, x.labelValues)
+            case x: MetricCollection.Value.DoubleGauge => (x.value, x.labelValues)
+          }
+          new GaugeSnapshot.GaugeDataPointSnapshot(
+            vDouble,
+            labelsFor(labelNames, lbls),
+            null: io.prometheus.metrics.model.snapshots.Exemplar
+          )
+        }.asJava
+        new GaugeSnapshot(new MetricMetadata(fullName, head.help.value), dps): MetricSnapshot
+      }
+    }
+
+    val histogramSnapshots: List[MetricSnapshot] = mc.histograms.toList.flatMap { case ((name, labelNames), values) =>
+      values.headOption.map { head =>
+        val fullName = NameUtils.makeName(prefix, name)
+        // Each consumer-supplied histogram value declares its own buckets — they must agree across the
+        // List entries for a given name. Take the first entry's buckets as the canonical declaration.
+        val buckets: NonEmptySeq[Double] = head match {
+          case h: MetricCollection.Value.LongHistogram   => h.buckets.map(_.toDouble)
+          case h: MetricCollection.Value.DoubleHistogram => h.buckets
+        }
+        val upperBoundsWithInf = (buckets.toSeq :+ Double.PositiveInfinity).toArray
+        val dps = values.map { v =>
+          val (sum, bucketCounts, lbls) = v match {
+            case x: MetricCollection.Value.LongHistogram =>
+              (x.value.sum.toDouble, x.value.bucketValues.toSeq.map(_.toLong).toArray, x.labelValues)
+            case x: MetricCollection.Value.DoubleHistogram =>
+              (x.value.sum, x.value.bucketValues.toSeq.map(_.toLong).toArray, x.labelValues)
+          }
+          new HistogramSnapshot.HistogramDataPointSnapshot(
+            ClassicHistogramBuckets.of(upperBoundsWithInf, bucketCounts),
+            sum,
+            labelsFor(labelNames, lbls),
+            Exemplars.EMPTY,
+            0L
+          )
+        }.asJava
+        new HistogramSnapshot(new MetricMetadata(fullName, head.help.value), dps): MetricSnapshot
+      }
+    }
+
+    val summarySnapshots: List[MetricSnapshot] = mc.summaries.toList.flatMap { case ((name, labelNames), values) =>
+      values.headOption.map { head =>
+        val fullName = NameUtils.makeName(prefix, name)
+        val dps = values.map { v =>
+          val (count, sum, quantiles, lbls) = v match {
+            case x: MetricCollection.Value.LongSummary =>
+              (
+                x.value.count.toLong,
+                x.value.sum.toDouble,
+                x.value.quantiles.map { case (q, v) => q -> v.toDouble },
+                x.labelValues
+              )
+            case x: MetricCollection.Value.DoubleSummary =>
+              (x.value.count.toLong, x.value.sum, x.value.quantiles, x.labelValues)
+          }
+          val quantilesJava = quantiles.toList.map { case (q, v) => new PQuantile(q, v) }.toArray
+          val pquantiles =
+            if (quantilesJava.isEmpty) Quantiles.EMPTY else Quantiles.of(quantilesJava: _*)
+          new SummarySnapshot.SummaryDataPointSnapshot(
+            count,
+            sum,
+            pquantiles,
+            labelsFor(labelNames, lbls),
+            Exemplars.EMPTY,
+            0L
+          )
+        }.asJava
+        new SummarySnapshot(new MetricMetadata(fullName, head.help.value), dps): MetricSnapshot
+      }
+    }
+
+    counterSnapshots ::: gaugeSnapshots ::: histogramSnapshots ::: summarySnapshots
+  }
 
   private def transformExemplarLabels(labels: Exemplar.Labels): Labels =
     Labels.of(
@@ -1051,27 +1243,41 @@ object JavaMetricRegistry {
             cbTimeoutState           <- Ref.of[F, Set[String]](Set.empty)
             cbErrorState             <- Ref.of[F, Set[String]](Set.empty)
             singleCallbackErrorState <- Ref.of[F, (Set[String], Set[String])]((Set.empty, Set.empty))
-            sem                      <- Semaphore[F](1L)
-          } yield new JavaMetricRegistry[F](
-            promRegistry, ref, cbState, cbTimeoutState, cbErrorState, singleCallbackErrorState, sem, dispatcher,
-            callbackTimeout = callbackCollectionTimeout, singleCallbackTimeout = callbackTimeout, logger = logger
-          )
+            metricCollectionRef <- Ref.of[F, Map[
+                                     Option[Metric.Prefix],
+                                     (Map[Label.Name, String], Map[Unique.Token, F[MetricCollection]])
+                                   ]](Map.empty)
+            sem <- Semaphore[F](1L)
+            reg = new JavaMetricRegistry[F](
+                    promRegistry, ref, cbState, cbTimeoutState, cbErrorState, singleCallbackErrorState, sem, dispatcher,
+                    callbackTimeout = callbackCollectionTimeout, singleCallbackTimeout = callbackTimeout,
+                    metricCollectionRef = metricCollectionRef, logger = logger
+                  )
+            // Register the metric-collection MultiCollector unconditionally; it returns an empty
+            // MetricSnapshots when no consumer callbacks are registered, so it's a no-op-cost
+            // collector when unused.
+            _ <- Sync[F].delay(promRegistry.register(reg.metricCollectionCollector))
+          } yield reg
 
           Resource.make(acquire) { reg =>
-            // Unregister callback collectors first, then claimed metric collectors.
-            reg.callbackState.get.flatMap { cbs =>
-              cbs.values.toList.traverse_ { case (_, _, collector) =>
-                Sync[F].delay(promRegistry.unregister(collector)).handleErrorWith { e =>
-                  logger(e)(s"Failed to unregister callback collector at shutdown: '$collector'")
+            // Unregister metric-collection collector first (always present), then individual
+            // callback collectors, then claimed metric collectors.
+            Sync[F]
+              .delay(promRegistry.unregister(reg.metricCollectionCollector))
+              .handleErrorWith(e => logger(e)("Failed to unregister metric-collection MultiCollector at shutdown")) >>
+              reg.callbackState.get.flatMap { cbs =>
+                cbs.values.toList.traverse_ { case (_, _, collector) =>
+                  Sync[F].delay(promRegistry.unregister(collector)).handleErrorWith { e =>
+                    logger(e)(s"Failed to unregister callback collector at shutdown: '$collector'")
+                  }
                 }
+              } >> reg.ref.get.flatMap { metrics =>
+                if (metrics.nonEmpty)
+                  metrics.values.toList.traverse_ { case (_, (collector, _, _)) =>
+                    Utils.unregister(collector, promRegistry, logger)
+                  }
+                else Applicative[F].unit
               }
-            } >> reg.ref.get.flatMap { metrics =>
-              if (metrics.nonEmpty)
-                metrics.values.toList.traverse_ { case (_, (collector, _, _)) =>
-                  Utils.unregister(collector, promRegistry, logger)
-                }
-              else Applicative[F].unit
-            }
           }
         }
       }

--- a/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
+++ b/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
@@ -31,6 +31,7 @@ import cats.syntax.all._
 import io.prometheus.metrics.core.metrics.{Counter => PCounter}
 import io.prometheus.metrics.core.metrics.{Gauge => PGauge}
 import io.prometheus.metrics.core.metrics.{Histogram => PHistogram}
+import io.prometheus.metrics.core.metrics.{Info => PInfo}
 import io.prometheus.metrics.core.metrics.{Summary => PSummary}
 import io.prometheus.metrics.instrumentation.jvm.JvmMetrics
 import io.prometheus.metrics.model.registry.PrometheusRegistry
@@ -423,13 +424,89 @@ class JavaMetricRegistry[F[_]: Async] private (
     }
   }
 
+  @SuppressWarnings(Array("scalafix:DisableSyntax.=="))
   override def createAndRegisterInfo[A](
       prefix: Option[Metric.Prefix],
       name: Info.Name,
       help: Metric.Help,
       labelNames: IndexedSeq[Label.Name]
-  )(f: A => IndexedSeq[String]): Resource[F, Info[F, A]] =
-    Resource.eval(ApplicativeThrow[F].raiseError(notYetPorted("createAndRegisterInfo")))
+  )(f: A => IndexedSeq[String]): Resource[F, Info[F, A]] = {
+    // Upstream client_java appends "_info" to the metric name automatically when the registered
+    // name doesn't end in "_info". The user-provided Info.Name is constrained to end in "_info"
+    // already (see Info.Name regex), so we strip the suffix before registering and let upstream
+    // re-add it.
+    val rawName  = name.value
+    val baseName = if (rawName.endsWith("_info")) rawName.dropRight("_info".length) else rawName
+
+    // Info uses MetricWithFixedMetadata (not StatefulMetric), so the registration state machinery
+    // here is a slim variant of configureBuilderOrRetrieve — Info doesn't need exemplar tracking.
+    val fullName: StateKey = (prefix, baseName)
+    val metricId: MetricID = (labelNames, MetricType.Info)
+    val renderedFullName   = NameUtils.makeName(prefix, baseName)
+
+    val acquire = sem.permit.surround(
+      ref.get
+        .flatMap[(State[F], PInfo)] { (metrics: State[F]) =>
+          metrics.get(fullName) match {
+            case Some((expected, (collector, exemplarRef, references))) =>
+              if (metricId == expected)
+                Applicative[F].pure(
+                  (
+                    metrics.updated(fullName, (expected, (collector, exemplarRef, references + 1))),
+                    collector.asInstanceOf[PInfo]
+                  )
+                )
+              else
+                ApplicativeThrow[F].raiseError(
+                  new RuntimeException(
+                    s"A metric with the same name as '$renderedFullName' is already registered with different labels and/or type"
+                  )
+                )
+            case None =>
+              for {
+                exemplarRef <- Ref.of[F, Option[Exemplar.Data]](None)
+                collector <- Sync[F].delay(
+                               PInfo
+                                 .builder()
+                                 .name(rawName)
+                                 .help(help.value)
+                                 .labelNames(labelNames.map(_.value): _*)
+                                 .register(registry)
+                             )
+              } yield (
+                metrics.updated(fullName, (metricId, (collector, exemplarRef, 1))),
+                collector
+              )
+          }
+        }
+        .flatMap { case (state, collector) => ref.set(state).as(collector) }
+    )
+
+    val release: PInfo => F[Unit] = collector =>
+      sem.permit.surround {
+        ref.get.flatMap { metrics =>
+          metrics.get(fullName) match {
+            case Some((`metricId`, (_, _, 1))) =>
+              ref.set(metrics - fullName) >>
+                Sync[F].delay(registry.unregister(collector)).handleErrorWith { e =>
+                  logger(e)(s"Failed to unregister Info collector: '$collector'")
+                }
+            case Some((`metricId`, (collector, exemplarRef, references))) =>
+              ref.set(metrics.updated(fullName, (metricId, (collector, exemplarRef, references - 1))))
+            case _ => Applicative[F].unit
+          }
+        }
+      }
+
+    Resource.make(acquire)(release).map { info =>
+      Info.make[F, A] { a =>
+        val values = f(a)
+        Sync[F].delay(info.setLabelValues(values: _*)).handleErrorWith { e =>
+          logger(e)(s"Failed to set Info label values for metric '$renderedFullName'")
+        }
+      }
+    }
+  }
 
   override def registerDoubleCounterCallback[A](
       prefix: Option[Metric.Prefix],

--- a/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
+++ b/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
@@ -45,11 +45,18 @@ import io.prometheus.metrics.core.metrics.{Summary => PSummary}
 import io.prometheus.metrics.instrumentation.jvm.JvmMetrics
 import io.prometheus.metrics.model.registry.PrometheusRegistry
 import io.prometheus.metrics.model.registry.{Collector => PCollector}
+import io.prometheus.metrics.model.snapshots.ClassicHistogramBuckets
 import io.prometheus.metrics.model.snapshots.CounterSnapshot
+import io.prometheus.metrics.model.snapshots.DataPointSnapshot
+import io.prometheus.metrics.model.snapshots.Exemplars
 import io.prometheus.metrics.model.snapshots.GaugeSnapshot
+import io.prometheus.metrics.model.snapshots.HistogramSnapshot
 import io.prometheus.metrics.model.snapshots.Labels
 import io.prometheus.metrics.model.snapshots.MetricMetadata
 import io.prometheus.metrics.model.snapshots.MetricSnapshot
+import io.prometheus.metrics.model.snapshots.Quantiles
+import io.prometheus.metrics.model.snapshots.SummarySnapshot
+import io.prometheus.metrics.model.snapshots.{Quantile => PQuantile}
 import prometheus4cats._
 import prometheus4cats.javaclient.internal.Utils
 import prometheus4cats.javaclient.models.MetricType
@@ -584,12 +591,12 @@ class JavaMetricRegistry[F[_]: Async] private (
     * (logged-timeout, logged-error, samples) triple so the outer aggregation can decide what to persist into
     * [[singleCallbackErrorState]] without re-logging on every scrape.
     */
-  private def timeoutEachCallback[V](
+  private def timeoutEachCallback(
       stringName: String,
-      samplesF: F[NonEmptyList[(V, IndexedSeq[String])]],
+      samplesF: F[NonEmptyList[DataPointSnapshot]],
       hasLoggedTimeout: Boolean,
       hasLoggedError: Boolean
-  ): F[(Boolean, Boolean, List[(V, IndexedSeq[String])])] =
+  ): F[(Boolean, Boolean, List[DataPointSnapshot])] =
     samplesF
       .map(samples => (hasLoggedTimeout, hasLoggedError, samples.toList))
       .timeout(singleCallbackTimeout)
@@ -622,7 +629,7 @@ class JavaMetricRegistry[F[_]: Async] private (
       metricType: MetricType,
       metricPrefix: Option[Metric.Prefix],
       name: A,
-      callback: F[NonEmptyList[(Double, IndexedSeq[String])]],
+      callback: F[NonEmptyList[DataPointSnapshot]],
       makeCollector: Ref[F, CallbackPayload[F]] => PCollector
   ): Resource[F, Unit] = {
     lazy val n                  = name.show
@@ -687,13 +694,14 @@ class JavaMetricRegistry[F[_]: Async] private (
       .void
   }
 
-  /** Aggregate all per-token callbacks into a single list of `(value, labels)` tuples, applying the per-callback
-    * timeout and error-tracking machinery. Used by every kind-specific Collector.
+  /** Aggregate all per-token callbacks into a single list of pre-built data-point snapshots, applying the per-callback
+    * timeout and error-tracking machinery. Used by every kind-specific Collector; the Collector then casts the data
+    * points to its concrete subtype and wraps them in the right `MetricSnapshot`.
     */
   private def collectAllPayload(
       callbacks: Ref[F, CallbackPayload[F]],
       renderedFullName: String
-  ): F[List[(Double, IndexedSeq[String])]] =
+  ): F[List[DataPointSnapshot]] =
     singleCallbackErrorState.get.flatMap { case (loggedTimeout, loggedError) =>
       callbacks.get
         .flatMap(
@@ -701,7 +709,7 @@ class JavaMetricRegistry[F[_]: Async] private (
             (
               loggedTimeout.contains(renderedFullName),
               loggedError.contains(renderedFullName),
-              List.empty[(Double, IndexedSeq[String])]
+              List.empty[DataPointSnapshot]
             )
           ) { case ((hasLoggedTimeout0, hasLoggedError0, acc), samplesF) =>
             timeoutEachCallback(renderedFullName, samplesF, hasLoggedTimeout0, hasLoggedError0).map {
@@ -768,10 +776,18 @@ class JavaMetricRegistry[F[_]: Async] private (
     // exposition writer adds "_total" back to the wire format.
     val baseName = if (rawName.endsWith("_total")) rawName.dropRight("_total".length) else rawName
 
-    // Project user (Double, A) tuples into (Double, all-label-values) tuples up front so the
-    // generic CallbackPayload type doesn't need to know about A.
-    val projected: F[NonEmptyList[(Double, IndexedSeq[String])]] = callback.map(
-      _.map { case (v, a) => (v, f(a) ++ commonLabelValuesArr) }
+    // Build CounterDataPointSnapshot instances inside the user callback's F so the generic
+    // CallbackPayload type can hold them as plain DataPointSnapshots. The Collector at scrape time
+    // casts back to CounterDataPointSnapshot.
+    val projected: F[NonEmptyList[DataPointSnapshot]] = callback.map(
+      _.map { case (v, a) =>
+        new CounterSnapshot.CounterDataPointSnapshot(
+          if (v < 0) 0.0 else v,
+          Labels.of(allLabelNamesStr, (f(a) ++ commonLabelValuesArr).toArray),
+          null: io.prometheus.metrics.model.snapshots.Exemplar,
+          0L
+        ): DataPointSnapshot
+      }
     )
 
     registerCallback[Counter.Name](
@@ -783,18 +799,12 @@ class JavaMetricRegistry[F[_]: Async] private (
         new PCollector {
 
           override def collect(): MetricSnapshot = {
-            val aggregated: F[List[(Double, IndexedSeq[String])]] = collectAllPayload(callbacks, baseName)
             val dataPoints: java.util.List[CounterSnapshot.CounterDataPointSnapshot] =
               runAggregateCollect(
                 baseName,
-                aggregated.map(_.map { case (value, labelValues) =>
-                  new CounterSnapshot.CounterDataPointSnapshot(
-                    if (value < 0) 0.0 else value,
-                    Labels.of(allLabelNamesStr, labelValues.toArray),
-                    null: io.prometheus.metrics.model.snapshots.Exemplar,
-                    0L
-                  )
-                }.asJava),
+                collectAllPayload(callbacks, baseName).map(
+                  _.map(_.asInstanceOf[CounterSnapshot.CounterDataPointSnapshot]).asJava
+                ),
                 java.util.Collections.emptyList[CounterSnapshot.CounterDataPointSnapshot]()
               )
             new CounterSnapshot(new MetricMetadata(baseName, help.value), dataPoints)
@@ -817,8 +827,14 @@ class JavaMetricRegistry[F[_]: Async] private (
     val allLabelNamesStr     = (labelNames.map(_.value) ++ commonLabelKeys).toArray
     val fullName             = NameUtils.makeName(prefix, name)
 
-    val projected: F[NonEmptyList[(Double, IndexedSeq[String])]] = callback.map(
-      _.map { case (v, a) => (v, f(a) ++ commonLabelValuesArr) }
+    val projected: F[NonEmptyList[DataPointSnapshot]] = callback.map(
+      _.map { case (v, a) =>
+        new GaugeSnapshot.GaugeDataPointSnapshot(
+          v,
+          Labels.of(allLabelNamesStr, (f(a) ++ commonLabelValuesArr).toArray),
+          null: io.prometheus.metrics.model.snapshots.Exemplar
+        ): DataPointSnapshot
+      }
     )
 
     registerCallback[Gauge.Name](
@@ -830,17 +846,12 @@ class JavaMetricRegistry[F[_]: Async] private (
         new PCollector {
 
           override def collect(): MetricSnapshot = {
-            val aggregated = collectAllPayload(callbacks, fullName)
             val dataPoints: java.util.List[GaugeSnapshot.GaugeDataPointSnapshot] =
               runAggregateCollect(
                 fullName,
-                aggregated.map(_.map { case (value, labelValues) =>
-                  new GaugeSnapshot.GaugeDataPointSnapshot(
-                    value,
-                    Labels.of(allLabelNamesStr, labelValues.toArray),
-                    null: io.prometheus.metrics.model.snapshots.Exemplar
-                  )
-                }.asJava),
+                collectAllPayload(callbacks, fullName).map(
+                  _.map(_.asInstanceOf[GaugeSnapshot.GaugeDataPointSnapshot]).asJava
+                ),
                 java.util.Collections.emptyList[GaugeSnapshot.GaugeDataPointSnapshot]()
               )
             new GaugeSnapshot(new MetricMetadata(fullName, help.value), dataPoints)
@@ -858,8 +869,54 @@ class JavaMetricRegistry[F[_]: Async] private (
       labelNames: IndexedSeq[Label.Name],
       buckets: NonEmptySeq[Double],
       callback: F[NonEmptyList[(Histogram.Value[Double], A)]]
-  )(f: A => IndexedSeq[String]): Resource[F, Unit] =
-    Resource.eval(ApplicativeThrow[F].raiseError(notYetPorted("registerDoubleHistogramCallback")))
+  )(f: A => IndexedSeq[String]): Resource[F, Unit] = {
+    val commonLabelKeys      = commonLabels.value.keys.toIndexedSeq.map(_.value)
+    val commonLabelValuesArr = commonLabels.value.values.toIndexedSeq
+    val allLabelNamesStr     = (labelNames.map(_.value) ++ commonLabelKeys).toArray
+    val fullName             = NameUtils.makeName(prefix, name)
+    // Histogram buckets in 1.x include +Inf as the last upper bound; the user-supplied buckets array
+    // doesn't, so append it. Histogram.Value[Double].bucketValues is parallel-indexed with the
+    // (declared-buckets ++ +Inf) sequence (cumulative counts).
+    val upperBoundsWithInf = (buckets.toSeq :+ Double.PositiveInfinity).toArray
+
+    val projected: F[NonEmptyList[DataPointSnapshot]] = callback.map(
+      _.map { case (value, a) =>
+        val labelValuesArr = (f(a) ++ commonLabelValuesArr).toArray
+        // bucketValues are cumulative Double counts; ClassicHistogramBuckets.of wants long counts.
+        val cumulativeCounts: Array[Long] = value.bucketValues.toSeq.map(_.toLong).toArray
+        new HistogramSnapshot.HistogramDataPointSnapshot(
+          ClassicHistogramBuckets.of(upperBoundsWithInf, cumulativeCounts),
+          value.sum,
+          Labels.of(allLabelNamesStr, labelValuesArr),
+          Exemplars.EMPTY,
+          0L
+        ): DataPointSnapshot
+      }
+    )
+
+    registerCallback[Histogram.Name](
+      MetricType.Histogram,
+      prefix,
+      name,
+      projected,
+      makeCollector = (callbacks: Ref[F, CallbackPayload[F]]) =>
+        new PCollector {
+
+          override def collect(): MetricSnapshot = {
+            val dataPoints: java.util.List[HistogramSnapshot.HistogramDataPointSnapshot] =
+              runAggregateCollect(
+                fullName,
+                collectAllPayload(callbacks, fullName).map(
+                  _.map(_.asInstanceOf[HistogramSnapshot.HistogramDataPointSnapshot]).asJava
+                ),
+                java.util.Collections.emptyList[HistogramSnapshot.HistogramDataPointSnapshot]()
+              )
+            new HistogramSnapshot(new MetricMetadata(fullName, help.value), dataPoints)
+          }
+
+        }
+    )
+  }
 
   override def registerDoubleSummaryCallback[A](
       prefix: Option[Metric.Prefix],
@@ -868,8 +925,53 @@ class JavaMetricRegistry[F[_]: Async] private (
       commonLabels: Metric.CommonLabels,
       labelNames: IndexedSeq[Label.Name],
       callback: F[NonEmptyList[(Summary.Value[Double], A)]]
-  )(f: A => IndexedSeq[String]): Resource[F, Unit] =
-    Resource.eval(ApplicativeThrow[F].raiseError(notYetPorted("registerDoubleSummaryCallback")))
+  )(f: A => IndexedSeq[String]): Resource[F, Unit] = {
+    val commonLabelKeys      = commonLabels.value.keys.toIndexedSeq.map(_.value)
+    val commonLabelValuesArr = commonLabels.value.values.toIndexedSeq
+    val allLabelNamesStr     = (labelNames.map(_.value) ++ commonLabelKeys).toArray
+    val fullName             = NameUtils.makeName(prefix, name)
+
+    val projected: F[NonEmptyList[DataPointSnapshot]] = callback.map(
+      _.map { case (value, a) =>
+        val labelValuesArr = (f(a) ++ commonLabelValuesArr).toArray
+        val quantilesJava: Array[PQuantile] =
+          value.quantiles.toList.map { case (q, v) => new PQuantile(q, v) }.toArray
+        val quantiles =
+          if (quantilesJava.isEmpty) Quantiles.EMPTY else Quantiles.of(quantilesJava: _*)
+        new SummarySnapshot.SummaryDataPointSnapshot(
+          value.count.toLong,
+          value.sum,
+          quantiles,
+          Labels.of(allLabelNamesStr, labelValuesArr),
+          Exemplars.EMPTY,
+          0L
+        ): DataPointSnapshot
+      }
+    )
+
+    registerCallback[Summary.Name](
+      MetricType.Summary,
+      prefix,
+      name,
+      projected,
+      makeCollector = (callbacks: Ref[F, CallbackPayload[F]]) =>
+        new PCollector {
+
+          override def collect(): MetricSnapshot = {
+            val dataPoints: java.util.List[SummarySnapshot.SummaryDataPointSnapshot] =
+              runAggregateCollect(
+                fullName,
+                collectAllPayload(callbacks, fullName).map(
+                  _.map(_.asInstanceOf[SummarySnapshot.SummaryDataPointSnapshot]).asJava
+                ),
+                java.util.Collections.emptyList[SummarySnapshot.SummaryDataPointSnapshot]()
+              )
+            new SummarySnapshot(new MetricMetadata(fullName, help.value), dataPoints)
+          }
+
+        }
+    )
+  }
 
   override def registerMetricCollectionCallback(
       prefix: Option[Metric.Prefix],

--- a/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
+++ b/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
@@ -1,0 +1,416 @@
+/*
+ * Copyright 2022-2026 Permutive Ltd. <https://permutive.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package prometheus4cats.javaclient
+
+import scala.concurrent.duration._
+
+import cats.Applicative
+import cats.ApplicativeThrow
+import cats.Functor
+import cats.Show
+import cats.data.NonEmptyList
+import cats.data.NonEmptySeq
+import cats.effect.kernel._
+import cats.effect.std.Semaphore
+import cats.syntax.all._
+
+import io.prometheus.metrics.core.metrics.{Counter => PCounter}
+import io.prometheus.metrics.core.metrics.{Gauge => PGauge}
+import io.prometheus.metrics.instrumentation.jvm.JvmMetrics
+import io.prometheus.metrics.model.registry.PrometheusRegistry
+import io.prometheus.metrics.model.snapshots.Labels
+import prometheus4cats._
+import prometheus4cats.javaclient.internal.Utils
+import prometheus4cats.javaclient.models.MetricType
+import prometheus4cats.util.DoubleCallbackRegistry
+import prometheus4cats.util.DoubleMetricRegistry
+import prometheus4cats.util.NameUtils
+
+/** Implements [[MetricRegistry]] and [[CallbackRegistry]] against the upstream `prometheus-metrics-core` 1.x library
+  * (the successor to the legacy simpleclient backend).
+  *
+  * This class is the v6 replacement for `prometheus4cats.javasimpleclient.JavaMetricRegistry`. Both implementations
+  * coexist during the migration window.
+  *
+  * Construct via [[JavaMetricRegistry.Builder]].
+  */
+@SuppressWarnings(Array("all"))
+class JavaMetricRegistry[F[_]: Async] private (
+    private val registry: PrometheusRegistry,
+    private val ref: Ref[F, State[F]],
+    private val sem: Semaphore[F],
+    private val logger: Throwable => String => F[Unit]
+) extends DoubleMetricRegistry[F]
+    with DoubleCallbackRegistry[F] {
+
+  type Underlying = PrometheusRegistry
+
+  /** Returns the underlying upstream [[PrometheusRegistry]]. Use to expose metrics over an HTTP endpoint or to register
+    * external collectors.
+    */
+  def underlying: PrometheusRegistry = registry
+
+  override protected val F: Functor[F] = implicitly
+
+  protected def counterName[A: Show](name: A): String = name match {
+    case counter: Counter.Name => counter.value.replace("_total", "")
+    case _                     => name.show
+  }
+
+  /** Common pre-registration plumbing: under the semaphore, look up an existing metric by name+labels+type. If present
+    * with the same metric ID, increment its claim count and reuse. If present with a different metric ID, raise. If
+    * absent, run the user-provided `register` thunk to construct & register a fresh collector and store it. On release,
+    * decrement the claim count and unregister when the last claim is dropped.
+    *
+    * Mirrors the behaviour of the legacy `javasimpleclient` adapter — supports overlapping `Resource`-scoped
+    * registrations of the same metric name without registering it twice with the underlying registry.
+    */
+  protected def configureBuilderOrRetrieve[M <: io.prometheus.metrics.core.metrics.StatefulMetric[_, _]](
+      register: () => M,
+      metricType: MetricType,
+      metricPrefix: Option[Metric.Prefix],
+      stringName: String,
+      labels: IndexedSeq[Label.Name]
+  ): Resource[F, M] = {
+    lazy val metricId: MetricID = (labels, metricType)
+    lazy val fullName: StateKey = (metricPrefix, stringName)
+    lazy val renderedFullName   = NameUtils.makeName(metricPrefix, stringName)
+
+    val acquire = sem.permit.surround(
+      ref.get
+        .flatMap[(State[F], M)] { (metrics: State[F]) =>
+          metrics.get(fullName) match {
+            case Some((expected, (collector, exemplarRef, references))) =>
+              if (metricId == expected)
+                Applicative[F].pure(
+                  (
+                    metrics.updated(fullName, (expected, (collector, exemplarRef, references + 1))),
+                    collector.asInstanceOf[M]
+                  )
+                )
+              else
+                ApplicativeThrow[F].raiseError(
+                  new RuntimeException(
+                    s"A metric with the same name as '$renderedFullName' is already registered with different labels and/or type"
+                  )
+                )
+            case None =>
+              for {
+                exemplarRef <- Ref.of[F, Option[Exemplar.Data]](None)
+                collector   <- Sync[F].delay(register())
+              } yield (metrics.updated(fullName, (metricId, (collector, exemplarRef, 1))), collector)
+          }
+        }
+        .flatMap { case (state, collector) => ref.set(state).as(collector) }
+    )
+
+    Resource.make(acquire) { collector =>
+      sem.permit.surround {
+        ref.get.flatMap { metrics =>
+          metrics.get(fullName) match {
+            case Some((`metricId`, (_, _, 1))) =>
+              ref.set(metrics - fullName) >> Utils.unregister(collector, registry, logger)
+            case Some((`metricId`, (collector, exemplarRef, references))) =>
+              ref.set(metrics.updated(fullName, (metricId, (collector, exemplarRef, references - 1))))
+            case _ => Applicative[F].unit
+          }
+        }
+      }
+    }
+  }
+
+  override def createAndRegisterDoubleCounter[A](
+      prefix: Option[Metric.Prefix],
+      name: Counter.Name,
+      help: Metric.Help,
+      commonLabels: Metric.CommonLabels,
+      labelNames: IndexedSeq[Label.Name]
+  )(f: A => IndexedSeq[String]): Resource[F, Counter[F, Double, A]] = {
+    val commonLabelNames       = commonLabels.value.keys.toIndexedSeq
+    val commonLabelValuesArray = commonLabels.value.values.toArray
+    val allLabelNames          = labelNames ++ commonLabelNames
+    val n                      = counterName(name)
+    val fullName               = NameUtils.makeName(prefix, name)
+
+    configureBuilderOrRetrieve[PCounter](
+      register = () =>
+        PCounter
+          .builder()
+          .name(fullName)
+          .help(help.value)
+          .labelNames(allLabelNames.map(_.value): _*)
+          .withExemplars()
+          .register(registry),
+      metricType = MetricType.Counter,
+      metricPrefix = prefix,
+      stringName = n,
+      labels = allLabelNames
+    ).flatMap { counter =>
+      Resource.eval(Ref.of[F, Option[Exemplar.Data]](None)).map { exemplarRef =>
+        Counter.make(
+          Counter.ExemplarState.fromRef(exemplarRef),
+          1.0,
+          (
+              d: Double,
+              labels: A,
+              exemplar: Option[Exemplar.Labels]
+          ) =>
+            Utils.modifyMetric[F, Counter.Name, io.prometheus.metrics.core.datapoints.CounterDataPoint](
+              metricName = name,
+              allLabelNames = allLabelNames,
+              dynamicLabels = f(labels),
+              commonLabelValues = commonLabelValuesArray,
+              getDataPoint = (lbls: Array[String]) => counter.labelValues(lbls: _*),
+              modify = (dp: io.prometheus.metrics.core.datapoints.CounterDataPoint) =>
+                exemplar.fold(dp.inc(d))(e => dp.incWithExemplar(d, transformExemplarLabels(e))),
+              logger = logger
+            )
+        )
+      }
+    }
+  }
+
+  override def createAndRegisterDoubleGauge[A](
+      prefix: Option[Metric.Prefix],
+      name: Gauge.Name,
+      help: Metric.Help,
+      commonLabels: Metric.CommonLabels,
+      labelNames: IndexedSeq[Label.Name]
+  )(f: A => IndexedSeq[String]): Resource[F, Gauge[F, Double, A]] = {
+    val commonLabelNames       = commonLabels.value.keys.toIndexedSeq
+    val commonLabelValuesArray = commonLabels.value.values.toArray
+    val allLabelNames          = labelNames ++ commonLabelNames
+    val fullName               = NameUtils.makeName(prefix, name)
+
+    configureBuilderOrRetrieve[PGauge](
+      register = () =>
+        PGauge
+          .builder()
+          .name(fullName)
+          .help(help.value)
+          .labelNames(allLabelNames.map(_.value): _*)
+          .register(registry),
+      metricType = MetricType.Gauge,
+      metricPrefix = prefix,
+      stringName = name.value,
+      labels = allLabelNames
+    ).map { gauge =>
+      @inline
+      def modify(g: io.prometheus.metrics.core.datapoints.GaugeDataPoint => Unit, labels: A): F[Unit] =
+        Utils.modifyMetric[F, Gauge.Name, io.prometheus.metrics.core.datapoints.GaugeDataPoint](
+          metricName = name,
+          allLabelNames = allLabelNames,
+          dynamicLabels = f(labels),
+          commonLabelValues = commonLabelValuesArray,
+          getDataPoint = (lbls: Array[String]) => gauge.labelValues(lbls: _*),
+          modify = g,
+          logger = logger
+        )
+
+      def inc(n: Double, labels: A): F[Unit] = modify(_.inc(n), labels)
+      def dec(n: Double, labels: A): F[Unit] = modify(_.dec(n), labels)
+      def set(n: Double, labels: A): F[Unit] = modify(_.set(n), labels)
+
+      Gauge.make(inc, dec, set)
+    }
+  }
+
+  override def createAndRegisterDoubleHistogram[A](
+      prefix: Option[Metric.Prefix],
+      name: Histogram.Name,
+      help: Metric.Help,
+      commonLabels: Metric.CommonLabels,
+      labelNames: IndexedSeq[Label.Name],
+      buckets: NonEmptySeq[Double]
+  )(f: A => IndexedSeq[String]): Resource[F, Histogram[F, Double, A]] =
+    Resource.eval(ApplicativeThrow[F].raiseError(notYetPorted("createAndRegisterDoubleHistogram")))
+
+  override def createAndRegisterDoubleNativeHistogram[A](
+      prefix: Option[Metric.Prefix],
+      name: Histogram.Name,
+      help: Metric.Help,
+      commonLabels: Metric.CommonLabels,
+      labelNames: IndexedSeq[Label.Name],
+      nativeHistogram: NativeHistogram
+  )(f: A => IndexedSeq[String]): Resource[F, Histogram[F, Double, A]] =
+    Resource.eval(ApplicativeThrow[F].raiseError(notYetPorted("createAndRegisterDoubleNativeHistogram")))
+
+  override def createAndRegisterDoubleSummary[A](
+      prefix: Option[Metric.Prefix],
+      name: Summary.Name,
+      help: Metric.Help,
+      commonLabels: Metric.CommonLabels,
+      labelNames: IndexedSeq[Label.Name],
+      quantiles: Seq[Summary.QuantileDefinition],
+      maxAge: FiniteDuration,
+      ageBuckets: Summary.AgeBuckets
+  )(f: A => IndexedSeq[String]): Resource[F, Summary[F, Double, A]] =
+    Resource.eval(ApplicativeThrow[F].raiseError(notYetPorted("createAndRegisterDoubleSummary")))
+
+  override def createAndRegisterInfo(
+      prefix: Option[Metric.Prefix],
+      name: Info.Name,
+      help: Metric.Help
+  ): Resource[F, Info[F, Map[Label.Name, String]]] =
+    Resource.eval(ApplicativeThrow[F].raiseError(notYetPorted("createAndRegisterInfo")))
+
+  override def registerDoubleCounterCallback[A](
+      prefix: Option[Metric.Prefix],
+      name: Counter.Name,
+      help: Metric.Help,
+      commonLabels: Metric.CommonLabels,
+      labelNames: IndexedSeq[Label.Name],
+      callback: F[NonEmptyList[(Double, A)]]
+  )(f: A => IndexedSeq[String]): Resource[F, Unit] =
+    Resource.eval(ApplicativeThrow[F].raiseError(notYetPorted("registerDoubleCounterCallback")))
+
+  override def registerDoubleGaugeCallback[A](
+      prefix: Option[Metric.Prefix],
+      name: Gauge.Name,
+      help: Metric.Help,
+      commonLabels: Metric.CommonLabels,
+      labelNames: IndexedSeq[Label.Name],
+      callback: F[NonEmptyList[(Double, A)]]
+  )(f: A => IndexedSeq[String]): Resource[F, Unit] =
+    Resource.eval(ApplicativeThrow[F].raiseError(notYetPorted("registerDoubleGaugeCallback")))
+
+  override def registerDoubleHistogramCallback[A](
+      prefix: Option[Metric.Prefix],
+      name: Histogram.Name,
+      help: Metric.Help,
+      commonLabels: Metric.CommonLabels,
+      labelNames: IndexedSeq[Label.Name],
+      buckets: NonEmptySeq[Double],
+      callback: F[NonEmptyList[(Histogram.Value[Double], A)]]
+  )(f: A => IndexedSeq[String]): Resource[F, Unit] =
+    Resource.eval(ApplicativeThrow[F].raiseError(notYetPorted("registerDoubleHistogramCallback")))
+
+  override def registerDoubleSummaryCallback[A](
+      prefix: Option[Metric.Prefix],
+      name: Summary.Name,
+      help: Metric.Help,
+      commonLabels: Metric.CommonLabels,
+      labelNames: IndexedSeq[Label.Name],
+      callback: F[NonEmptyList[(Summary.Value[Double], A)]]
+  )(f: A => IndexedSeq[String]): Resource[F, Unit] =
+    Resource.eval(ApplicativeThrow[F].raiseError(notYetPorted("registerDoubleSummaryCallback")))
+
+  override def registerMetricCollectionCallback(
+      prefix: Option[Metric.Prefix],
+      commonLabels: Metric.CommonLabels,
+      callback: F[MetricCollection]
+  ): Resource[F, Unit] =
+    Resource.eval(ApplicativeThrow[F].raiseError(notYetPorted("registerMetricCollectionCallback")))
+
+  private def notYetPorted(methodName: String): UnsupportedOperationException =
+    new UnsupportedOperationException(
+      s"prometheus4cats.javaclient.JavaMetricRegistry.$methodName is not yet implemented in this commit. " +
+        "It will be ported in a subsequent commit before the simpleclient backend is removed."
+    )
+
+  private def transformExemplarLabels(labels: Exemplar.Labels): Labels =
+    Labels.of(
+      labels.value.keys.toArray.map(_.value),
+      labels.value.values.toArray
+    )
+
+}
+
+@SuppressWarnings(Array("all"))
+object JavaMetricRegistry {
+
+  /** Builder for [[JavaMetricRegistry]]. Mirrors the legacy
+    * `prometheus4cats.javasimpleclient.JavaMetricRegistry.Builder` API so consumers (e.g., the `permutive-metrics`
+    * bridge) can migrate by changing only the import.
+    *
+    * Differences from the legacy Builder:
+    *   - takes a [[PrometheusRegistry]] instead of `CollectorRegistry`;
+    *   - JVM/process metrics are added via [[Builder.withJvmMetrics]] (which uses
+    *     `prometheus-metrics-instrumentation-jvm`'s `JvmMetrics.builder().register(...)`) rather than a list of
+    *     simpleclient hotspot collectors.
+    */
+  sealed abstract class Builder[F[_]: Async](
+      val promRegistry: PrometheusRegistry,
+      val callbackTimeout: FiniteDuration,
+      val callbackCollectionTimeout: FiniteDuration,
+      val logger: Throwable => String => F[Unit],
+      val registerJvmMetrics: Boolean
+  ) {
+
+    private def copy(
+        promRegistry: PrometheusRegistry = promRegistry,
+        callbackTimeout: FiniteDuration = callbackTimeout,
+        callbackCollectionTimeout: FiniteDuration = callbackCollectionTimeout,
+        logger: Throwable => String => F[Unit] = logger,
+        registerJvmMetrics: Boolean = registerJvmMetrics
+    ): Builder[F] =
+      new Builder(promRegistry, callbackTimeout, callbackCollectionTimeout, logger, registerJvmMetrics) {}
+
+    def withRegistry(promRegistry: PrometheusRegistry): Builder[F] = copy(promRegistry = promRegistry)
+
+    def withCallbackTimeout(callbackTimeout: FiniteDuration): Builder[F] =
+      copy(callbackTimeout = callbackTimeout)
+
+    def withCallbackCollectionTimeout(callbackCollectionTimeout: FiniteDuration): Builder[F] =
+      copy(callbackCollectionTimeout = callbackCollectionTimeout)
+
+    def withLogger(logger: Throwable => String => F[Unit]): Builder[F] = copy(logger = logger)
+
+    /** Register the standard JVM/process metrics (memory pools, GC, threads, class loading, buffers) via the upstream
+      * `prometheus-metrics-instrumentation-jvm` library when the registry is built. Replacement for the legacy
+      * `withHotSpotCollectors` builder method.
+      */
+    def withJvmMetrics: Builder[F] = copy(registerJvmMetrics = true)
+
+    def build: Resource[F, JavaMetricRegistry[F]] =
+      Resource.eval {
+        if (registerJvmMetrics) Sync[F].delay(JvmMetrics.builder().register(promRegistry))
+        else Applicative[F].unit
+      }.flatMap { _ =>
+        val acquire = for {
+          ref <- Ref.of[F, State[F]](Map.empty)
+          sem <- Semaphore[F](1L)
+        } yield new JavaMetricRegistry[F](promRegistry, ref, sem, logger)
+
+        Resource.make(acquire) { reg =>
+          // unregister all metrics that are still claimed at shutdown
+          reg.ref.get.flatMap { metrics =>
+            if (metrics.nonEmpty)
+              metrics.values.toList.traverse_ { case (_, (collector, _, _)) =>
+                Utils.unregister(collector, promRegistry, logger)
+              }
+            else Applicative[F].unit
+          }
+        }
+      }
+
+  }
+
+  object Builder {
+
+    def apply[F[_]: Async](): Builder[F] =
+      new Builder[F](
+        promRegistry = PrometheusRegistry.defaultRegistry,
+        callbackTimeout = 250.millis,
+        callbackCollectionTimeout = 1.second,
+        logger = _ => _ => Async[F].unit,
+        registerJvmMetrics = false
+      ) {}
+
+  }
+
+}

--- a/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
+++ b/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
@@ -85,21 +85,21 @@ class JavaMetricRegistry[F[_]: Async] private (
       metricPrefix: Option[Metric.Prefix],
       stringName: String,
       labels: IndexedSeq[Label.Name]
-  ): Resource[F, M] = {
+  ): Resource[F, (M, Ref[F, Option[Exemplar.Data]])] = {
     lazy val metricId: MetricID = (labels, metricType)
     lazy val fullName: StateKey = (metricPrefix, stringName)
     lazy val renderedFullName   = NameUtils.makeName(metricPrefix, stringName)
 
     val acquire = sem.permit.surround(
       ref.get
-        .flatMap[(State[F], M)] { (metrics: State[F]) =>
+        .flatMap[(State[F], (M, Ref[F, Option[Exemplar.Data]]))] { (metrics: State[F]) =>
           metrics.get(fullName) match {
             case Some((expected, (collector, exemplarRef, references))) =>
               if (metricId == expected)
                 Applicative[F].pure(
                   (
                     metrics.updated(fullName, (expected, (collector, exemplarRef, references + 1))),
-                    collector.asInstanceOf[M]
+                    (collector.asInstanceOf[M], exemplarRef)
                   )
                 )
               else
@@ -112,13 +112,13 @@ class JavaMetricRegistry[F[_]: Async] private (
               for {
                 exemplarRef <- Ref.of[F, Option[Exemplar.Data]](None)
                 collector   <- Sync[F].delay(register())
-              } yield (metrics.updated(fullName, (metricId, (collector, exemplarRef, 1))), collector)
+              } yield (metrics.updated(fullName, (metricId, (collector, exemplarRef, 1))), (collector, exemplarRef))
           }
         }
-        .flatMap { case (state, collector) => ref.set(state).as(collector) }
+        .flatMap { case (state, pair) => ref.set(state).as(pair) }
     )
 
-    Resource.make(acquire) { collector =>
+    Resource.make(acquire) { case (collector, _) =>
       sem.permit.surround {
         ref.get.flatMap { metrics =>
           metrics.get(fullName) match {
@@ -158,28 +158,26 @@ class JavaMetricRegistry[F[_]: Async] private (
       metricPrefix = prefix,
       stringName = n,
       labels = allLabelNames
-    ).flatMap { counter =>
-      Resource.eval(Ref.of[F, Option[Exemplar.Data]](None)).map { exemplarRef =>
-        Counter.make(
-          Counter.ExemplarState.fromRef(exemplarRef),
-          1.0,
-          (
-              d: Double,
-              labels: A,
-              exemplar: Option[Exemplar.Labels]
-          ) =>
-            Utils.modifyMetric[F, Counter.Name, io.prometheus.metrics.core.datapoints.CounterDataPoint](
-              metricName = name,
-              allLabelNames = allLabelNames,
-              dynamicLabels = f(labels),
-              commonLabelValues = commonLabelValuesArray,
-              getDataPoint = (lbls: Array[String]) => counter.labelValues(lbls: _*),
-              modify = (dp: io.prometheus.metrics.core.datapoints.CounterDataPoint) =>
-                exemplar.fold(dp.inc(d))(e => dp.incWithExemplar(d, transformExemplarLabels(e))),
-              logger = logger
-            )
-        )
-      }
+    ).map { case (counter, exemplarRef) =>
+      Counter.make(
+        Counter.ExemplarState.fromRef(exemplarRef),
+        1.0,
+        (
+            d: Double,
+            labels: A,
+            exemplar: Option[Exemplar.Labels]
+        ) =>
+          Utils.modifyMetric[F, Counter.Name, io.prometheus.metrics.core.datapoints.CounterDataPoint](
+            metricName = name,
+            allLabelNames = allLabelNames,
+            dynamicLabels = f(labels),
+            commonLabelValues = commonLabelValuesArray,
+            getDataPoint = (lbls: Array[String]) => counter.labelValues(lbls: _*),
+            modify = (dp: io.prometheus.metrics.core.datapoints.CounterDataPoint) =>
+              exemplar.fold(dp.inc(d))(e => dp.incWithExemplar(d, transformExemplarLabels(e))),
+            logger = logger
+          )
+      )
     }
   }
 
@@ -207,7 +205,7 @@ class JavaMetricRegistry[F[_]: Async] private (
       metricPrefix = prefix,
       stringName = name.value,
       labels = allLabelNames
-    ).map { gauge =>
+    ).map { case (gauge, _) =>
       @inline
       def modify(g: io.prometheus.metrics.core.datapoints.GaugeDataPoint => Unit, labels: A): F[Unit] =
         Utils.modifyMetric[F, Gauge.Name, io.prometheus.metrics.core.datapoints.GaugeDataPoint](

--- a/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
+++ b/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
@@ -81,7 +81,8 @@ class JavaMetricRegistry[F[_]: Async] private (
     private val callbackState: Ref[F, CallbackState[F]],
     private val callbackTimeoutState: Ref[F, Set[String]],
     private val callbackErrorState: Ref[F, Set[String]],
-    private val singleCallbackErrorState: Ref[F, (Set[String], Set[String])],
+    private val singleCallbackTimeoutState: Ref[F, Set[String]],
+    private val singleCallbackErrorState: Ref[F, Set[String]],
     private val sem: Semaphore[F],
     private val dispatcher: Dispatcher[F],
     private val callbackTimeout: FiniteDuration,
@@ -569,10 +570,10 @@ class JavaMetricRegistry[F[_]: Async] private (
   //     samples for that registration and logs ONCE per metric name.
   //   - `callbackTimeout` bounds the COMBINED collection of all registered callbacks for a single
   //     metric (i.e., the wrapper that aggregates samples across multiple consumer registrations).
-  //   - Error tracking refs (`callbackTimeoutState`, `callbackErrorState`, `singleCallbackErrorState`)
-  //     prevent log spam: the first time a metric's callback times out / fails, we log; subsequent
-  //     occurrences are silently counted by the upstream Prometheus runtime via the regular
-  //     scrape-error path.
+  //   - Error tracking refs (`callbackTimeoutState`, `callbackErrorState`, `singleCallbackTimeoutState`,
+  //     `singleCallbackErrorState`) prevent log spam: the first time a metric's callback times out / fails,
+  //     we log; subsequent occurrences are silently counted by the upstream Prometheus runtime via the
+  //     regular scrape-error path.
   //
   // Skipped vs the legacy adapter: the internal `prometheus4cats_combined_callback_metric_total` and
   // `prometheus4cats_callback_total` counters that tracked callback success/error/timeout counts
@@ -719,7 +720,7 @@ class JavaMetricRegistry[F[_]: Async] private (
       callbacks: Ref[F, CallbackPayload[F]],
       renderedFullName: String
   ): F[List[DataPointSnapshot]] =
-    singleCallbackErrorState.get.flatMap { case (loggedTimeout, loggedError) =>
+    (singleCallbackTimeoutState.get, singleCallbackErrorState.get).tupled.flatMap { case (loggedTimeout, loggedError) =>
       callbacks.get
         .flatMap(
           _.values.foldM(
@@ -735,13 +736,13 @@ class JavaMetricRegistry[F[_]: Async] private (
           }
         )
         .flatMap { case (hasLoggedTimeout0, hasLoggedError0, samples) =>
-          ((hasLoggedTimeout0, hasLoggedError0) match {
-            case (true, true) =>
-              singleCallbackErrorState.set((loggedTimeout + renderedFullName, loggedError + renderedFullName))
-            case (true, false)  => singleCallbackErrorState.set((loggedTimeout + renderedFullName, loggedError))
-            case (false, true)  => singleCallbackErrorState.set((loggedTimeout, loggedError + renderedFullName))
-            case (false, false) => Applicative[F].unit
-          }).as(samples)
+          val updateTimeout =
+            if (hasLoggedTimeout0) singleCallbackTimeoutState.set(loggedTimeout + renderedFullName)
+            else Applicative[F].unit
+          val updateError =
+            if (hasLoggedError0) singleCallbackErrorState.set(loggedError + renderedFullName)
+            else Applicative[F].unit
+          (updateTimeout *> updateError).as(samples)
         }
     }
 
@@ -1243,20 +1244,21 @@ object JavaMetricRegistry {
       }.flatMap { _ =>
         Dispatcher.sequential[F].flatMap { dispatcher =>
           val acquire = for {
-            ref                      <- Ref.of[F, State[F]](Map.empty)
-            cbState                  <- Ref.of[F, CallbackState[F]](Map.empty)
-            cbTimeoutState           <- Ref.of[F, Set[String]](Set.empty)
-            cbErrorState             <- Ref.of[F, Set[String]](Set.empty)
-            singleCallbackErrorState <- Ref.of[F, (Set[String], Set[String])]((Set.empty, Set.empty))
+            ref                        <- Ref.of[F, State[F]](Map.empty)
+            cbState                    <- Ref.of[F, CallbackState[F]](Map.empty)
+            cbTimeoutState             <- Ref.of[F, Set[String]](Set.empty)
+            cbErrorState               <- Ref.of[F, Set[String]](Set.empty)
+            singleCallbackTimeoutState <- Ref.of[F, Set[String]](Set.empty)
+            singleCallbackErrorState   <- Ref.of[F, Set[String]](Set.empty)
             metricCollectionRef <- Ref.of[F, Map[
                                      Option[Metric.Prefix],
                                      (Map[Label.Name, String], Map[Unique.Token, F[MetricCollection]])
                                    ]](Map.empty)
             sem <- Semaphore[F](1L)
             reg = new JavaMetricRegistry[F](
-                    promRegistry, ref, cbState, cbTimeoutState, cbErrorState, singleCallbackErrorState, sem, dispatcher,
-                    callbackTimeout = callbackCollectionTimeout, singleCallbackTimeout = callbackTimeout,
-                    metricCollectionRef = metricCollectionRef, logger = logger
+                    promRegistry, ref, cbState, cbTimeoutState, cbErrorState, singleCallbackTimeoutState,
+                    singleCallbackErrorState, sem, dispatcher, callbackTimeout = callbackCollectionTimeout,
+                    singleCallbackTimeout = callbackTimeout, metricCollectionRef = metricCollectionRef, logger = logger
                   )
             // Register the metric-collection MultiCollector unconditionally; it returns an empty
             // MetricSnapshots when no consumer callbacks are registered, so it's a no-op-cost

--- a/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
+++ b/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
@@ -59,8 +59,8 @@ class JavaMetricRegistry[F[_]: Async] private (
 
   type Underlying = PrometheusRegistry
 
-  /** Returns the underlying upstream [[PrometheusRegistry]]. Use to expose metrics over an HTTP endpoint or to register
-    * external collectors.
+  /** Returns the underlying upstream [[io.prometheus.metrics.model.registry.PrometheusRegistry]]. Use to expose metrics
+    * over an HTTP endpoint or to register external collectors.
     */
   def underlying: PrometheusRegistry = registry
 
@@ -249,6 +249,17 @@ class JavaMetricRegistry[F[_]: Async] private (
   )(f: A => IndexedSeq[String]): Resource[F, Histogram[F, Double, A]] =
     Resource.eval(ApplicativeThrow[F].raiseError(notYetPorted("createAndRegisterDoubleNativeHistogram")))
 
+  override def createAndRegisterDoubleHistogramWithNative[A](
+      prefix: Option[Metric.Prefix],
+      name: Histogram.Name,
+      help: Metric.Help,
+      commonLabels: Metric.CommonLabels,
+      labelNames: IndexedSeq[Label.Name],
+      buckets: NonEmptySeq[Double],
+      nativeHistogram: NativeHistogram
+  )(f: A => IndexedSeq[String]): Resource[F, Histogram[F, Double, A]] =
+    Resource.eval(ApplicativeThrow[F].raiseError(notYetPorted("createAndRegisterDoubleHistogramWithNative")))
+
   override def createAndRegisterDoubleSummary[A](
       prefix: Option[Metric.Prefix],
       name: Summary.Name,
@@ -261,11 +272,12 @@ class JavaMetricRegistry[F[_]: Async] private (
   )(f: A => IndexedSeq[String]): Resource[F, Summary[F, Double, A]] =
     Resource.eval(ApplicativeThrow[F].raiseError(notYetPorted("createAndRegisterDoubleSummary")))
 
-  override def createAndRegisterInfo(
+  override def createAndRegisterInfo[A](
       prefix: Option[Metric.Prefix],
       name: Info.Name,
-      help: Metric.Help
-  ): Resource[F, Info[F, Map[Label.Name, String]]] =
+      help: Metric.Help,
+      labelNames: IndexedSeq[Label.Name]
+  )(f: A => IndexedSeq[String]): Resource[F, Info[F, A]] =
     Resource.eval(ApplicativeThrow[F].raiseError(notYetPorted("createAndRegisterInfo")))
 
   override def registerDoubleCounterCallback[A](
@@ -338,7 +350,7 @@ object JavaMetricRegistry {
     * bridge) can migrate by changing only the import.
     *
     * Differences from the legacy Builder:
-    *   - takes a [[PrometheusRegistry]] instead of `CollectorRegistry`;
+    *   - takes a [[io.prometheus.metrics.model.registry.PrometheusRegistry]] instead of `CollectorRegistry`;
     *   - JVM/process metrics are added via [[Builder.withJvmMetrics]] (which uses
     *     `prometheus-metrics-instrumentation-jvm`'s `JvmMetrics.builder().register(...)`) rather than a list of
     *     simpleclient hotspot collectors.

--- a/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
+++ b/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
@@ -28,6 +28,9 @@ import cats.effect.kernel._
 import cats.effect.std.Semaphore
 import cats.syntax.all._
 
+import io.prometheus.metrics.core.datapoints.CounterDataPoint
+import io.prometheus.metrics.core.datapoints.DistributionDataPoint
+import io.prometheus.metrics.core.datapoints.GaugeDataPoint
 import io.prometheus.metrics.core.metrics.{Counter => PCounter}
 import io.prometheus.metrics.core.metrics.{Gauge => PGauge}
 import io.prometheus.metrics.core.metrics.{Histogram => PHistogram}
@@ -174,13 +177,13 @@ class JavaMetricRegistry[F[_]: Async] private (
             labels: A,
             exemplar: Option[Exemplar.Labels]
         ) =>
-          Utils.modifyMetric[F, Counter.Name, io.prometheus.metrics.core.datapoints.CounterDataPoint](
+          Utils.modifyMetric[F, Counter.Name, CounterDataPoint](
             metricName = name,
             allLabelNames = allLabelNames,
             dynamicLabels = f(labels),
             commonLabelValues = commonLabelValuesArray,
             getDataPoint = (lbls: Array[String]) => counter.labelValues(lbls: _*),
-            modify = (dp: io.prometheus.metrics.core.datapoints.CounterDataPoint) =>
+            modify = (dp: CounterDataPoint) =>
               exemplar.fold(dp.inc(d))(e => dp.incWithExemplar(d, transformExemplarLabels(e))),
             logger = logger
           )
@@ -214,8 +217,8 @@ class JavaMetricRegistry[F[_]: Async] private (
       labels = allLabelNames
     ).map { case (gauge, _) =>
       @inline
-      def modify(g: io.prometheus.metrics.core.datapoints.GaugeDataPoint => Unit, labels: A): F[Unit] =
-        Utils.modifyMetric[F, Gauge.Name, io.prometheus.metrics.core.datapoints.GaugeDataPoint](
+      def modify(g: GaugeDataPoint => Unit, labels: A): F[Unit] =
+        Utils.modifyMetric[F, Gauge.Name, GaugeDataPoint](
           metricName = name,
           allLabelNames = allLabelNames,
           dynamicLabels = f(labels),
@@ -271,13 +274,13 @@ class JavaMetricRegistry[F[_]: Async] private (
       Histogram.make[F, Double, A](
         exemplarState(exemplarRef),
         _observe = { (d: Double, labels: A, exemplar: Option[Exemplar.Labels]) =>
-          Utils.modifyMetric[F, Histogram.Name, io.prometheus.metrics.core.datapoints.DistributionDataPoint](
+          Utils.modifyMetric[F, Histogram.Name, DistributionDataPoint](
             metricName = name,
             allLabelNames = allLabelNames,
             dynamicLabels = f(labels),
             commonLabelValues = commonLabelValuesArray,
             getDataPoint = (lbls: Array[String]) => histogram.labelValues(lbls: _*),
-            modify = (dp: io.prometheus.metrics.core.datapoints.DistributionDataPoint) =>
+            modify = (dp: DistributionDataPoint) =>
               exemplar.fold(dp.observe(d))(e => dp.observeWithExemplar(d, transformExemplarLabels(e))),
             logger = logger
           )
@@ -411,13 +414,13 @@ class JavaMetricRegistry[F[_]: Async] private (
       labels = allLabelNames
     ).map { case (summary, _) =>
       Summary.make[F, Double, A] { case (d, labels) =>
-        Utils.modifyMetric[F, Summary.Name, io.prometheus.metrics.core.datapoints.DistributionDataPoint](
+        Utils.modifyMetric[F, Summary.Name, DistributionDataPoint](
           metricName = name,
           allLabelNames = allLabelNames,
           dynamicLabels = f(labels),
           commonLabelValues = commonLabelValuesArray,
           getDataPoint = (lbls: Array[String]) => summary.labelValues(lbls: _*),
-          modify = (dp: io.prometheus.metrics.core.datapoints.DistributionDataPoint) => dp.observe(d),
+          modify = (dp: DistributionDataPoint) => dp.observe(d),
           logger = logger
         )
       }

--- a/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
+++ b/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
@@ -231,13 +231,21 @@ class JavaMetricRegistry[F[_]: Async] private (
     }
   }
 
-  override def createAndRegisterDoubleHistogram[A](
+  /** Shared post-registration plumbing for all three histogram modes (classic-only, native-only, dual). Extracts the
+    * common labels, registers the upstream `PHistogram` via `configureBuilderOrRetrieve` (using the caller's
+    * `configureBuilder` to set mode-specific bits like `.classicOnly()` or `.nativeOnly()`), and wraps the result in a
+    * prometheus4cats `Histogram` whose observe goes through `Utils.modifyMetric` against the upstream
+    * `DistributionDataPoint`.
+    */
+  private def histogramFromBuilder[A](
       prefix: Option[Metric.Prefix],
       name: Histogram.Name,
       help: Metric.Help,
       commonLabels: Metric.CommonLabels,
       labelNames: IndexedSeq[Label.Name],
-      buckets: NonEmptySeq[Double]
+      metricType: MetricType,
+      configureBuilder: PHistogram.Builder => PHistogram.Builder,
+      exemplarState: Ref[F, Option[Exemplar.Data]] => Histogram.ExemplarState[F]
   )(f: A => IndexedSeq[String]): Resource[F, Histogram[F, Double, A]] = {
     val commonLabelNames       = commonLabels.value.keys.toIndexedSeq
     val commonLabelValuesArray = commonLabels.value.values.toArray
@@ -246,25 +254,20 @@ class JavaMetricRegistry[F[_]: Async] private (
 
     configureBuilderOrRetrieve[PHistogram](
       register = () =>
-        PHistogram
-          .builder()
-          .name(fullName)
-          .help(help.value)
-          .labelNames(allLabelNames.map(_.value): _*)
-          // .classicOnly() is required because the 1.x default emits BOTH classic AND native
-          // histograms from a single declaration. Preserving v5 behaviour means only the classic
-          // form is emitted from the .histogram(...) DSL path; the .nativeHistogram(...) DSL path
-          // calls .nativeOnly() instead.
-          .classicOnly()
-          .classicUpperBounds(buckets.toList: _*)
-          .register(registry),
-      metricType = MetricType.Histogram,
+        configureBuilder(
+          PHistogram
+            .builder()
+            .name(fullName)
+            .help(help.value)
+            .labelNames(allLabelNames.map(_.value): _*)
+        ).register(registry),
+      metricType = metricType,
       metricPrefix = prefix,
       stringName = name.value,
       labels = allLabelNames
     ).map { case (histogram, exemplarRef) =>
       Histogram.make[F, Double, A](
-        Histogram.ExemplarState.fromRef(buckets, exemplarRef),
+        exemplarState(exemplarRef),
         _observe = { (d: Double, labels: A, exemplar: Option[Exemplar.Labels]) =>
           Utils.modifyMetric[F, Histogram.Name, io.prometheus.metrics.core.datapoints.DistributionDataPoint](
             metricName = name,
@@ -280,6 +283,47 @@ class JavaMetricRegistry[F[_]: Async] private (
       )
     }
   }
+
+  /** Applies the five native-histogram tuning setters from a [[NativeHistogram]] config to a `PHistogram.Builder`,
+    * conditionally including `nativeResetDuration` only when the configured duration is positive. Shared by the
+    * native-only and dual-mode registration paths.
+    */
+  private def applyNativeConfig(builder: PHistogram.Builder, config: NativeHistogram): PHistogram.Builder = {
+    val withTuning = builder
+      .nativeInitialSchema(config.initialSchema)
+      .nativeMaxNumberOfBuckets(config.maxNumberOfBuckets)
+      .nativeMaxZeroThreshold(config.maxZeroThreshold)
+      .nativeMinZeroThreshold(config.minZeroThreshold)
+    if (config.resetDuration > 0.seconds)
+      withTuning.nativeResetDuration(
+        config.resetDuration.toSeconds,
+        java.util.concurrent.TimeUnit.SECONDS
+      )
+    else withTuning
+  }
+
+  override def createAndRegisterDoubleHistogram[A](
+      prefix: Option[Metric.Prefix],
+      name: Histogram.Name,
+      help: Metric.Help,
+      commonLabels: Metric.CommonLabels,
+      labelNames: IndexedSeq[Label.Name],
+      buckets: NonEmptySeq[Double]
+  )(f: A => IndexedSeq[String]): Resource[F, Histogram[F, Double, A]] =
+    histogramFromBuilder(
+      prefix,
+      name,
+      help,
+      commonLabels,
+      labelNames,
+      metricType = MetricType.Histogram,
+      // .classicOnly() is required because the 1.x default emits BOTH classic AND native
+      // histograms from a single declaration. Preserving v5 behaviour means only the classic
+      // form is emitted from the .histogram(...) DSL path; the .nativeHistogram(...) DSL path
+      // calls .nativeOnly() instead.
+      configureBuilder = _.classicOnly().classicUpperBounds(buckets.toList: _*),
+      exemplarState = ref => Histogram.ExemplarState.fromRef(buckets, ref)
+    )(f)
 
   override def createAndRegisterDoubleHistogramWithNative[A](
       prefix: Option[Metric.Prefix],
@@ -289,61 +333,23 @@ class JavaMetricRegistry[F[_]: Async] private (
       labelNames: IndexedSeq[Label.Name],
       buckets: NonEmptySeq[Double],
       config: NativeHistogram
-  )(f: A => IndexedSeq[String]): Resource[F, Histogram[F, Double, A]] = {
-    val commonLabelNames       = commonLabels.value.keys.toIndexedSeq
-    val commonLabelValuesArray = commonLabels.value.values.toArray
-    val allLabelNames          = labelNames ++ commonLabelNames
-    val fullName               = NameUtils.makeName(prefix, name)
-
-    configureBuilderOrRetrieve[PHistogram](
-      register = () => {
-        // Dual-mode: NEITHER .classicOnly() NOR .nativeOnly(). Both classicUpperBounds(...) and
-        // nativeInitialSchema(...) are set. The resulting Histogram emits BOTH representations,
-        // letting Prometheus's `convert_classic_histograms_to_nhcb` pick the classic form for
-        // server-side NHCB conversion while the native exponential is also available directly.
-        val builder = PHistogram
-          .builder()
-          .name(fullName)
-          .help(help.value)
-          .labelNames(allLabelNames.map(_.value): _*)
-          .classicUpperBounds(buckets.toList: _*)
-          .nativeInitialSchema(config.initialSchema)
-          .nativeMaxNumberOfBuckets(config.maxNumberOfBuckets)
-          .nativeMaxZeroThreshold(config.maxZeroThreshold)
-          .nativeMinZeroThreshold(config.minZeroThreshold)
-        val tuned =
-          if (config.resetDuration > 0.seconds)
-            builder.nativeResetDuration(
-              config.resetDuration.toSeconds,
-              java.util.concurrent.TimeUnit.SECONDS
-            )
-          else builder
-        tuned.register(registry)
-      },
+  )(f: A => IndexedSeq[String]): Resource[F, Histogram[F, Double, A]] =
+    histogramFromBuilder(
+      prefix,
+      name,
+      help,
+      commonLabels,
+      labelNames,
       // Use a distinct MetricType so dedup is correct: registering the same metric name as
       // dual-mode and then again as classic-only is a programmer error and should fail.
       metricType = MetricType.HistogramWithNative,
-      metricPrefix = prefix,
-      stringName = name.value,
-      labels = allLabelNames
-    ).map { case (histogram, exemplarRef) =>
-      Histogram.make[F, Double, A](
-        Histogram.ExemplarState.fromRef(buckets, exemplarRef),
-        _observe = { (d: Double, labels: A, exemplar: Option[Exemplar.Labels]) =>
-          Utils.modifyMetric[F, Histogram.Name, io.prometheus.metrics.core.datapoints.DistributionDataPoint](
-            metricName = name,
-            allLabelNames = allLabelNames,
-            dynamicLabels = f(labels),
-            commonLabelValues = commonLabelValuesArray,
-            getDataPoint = (lbls: Array[String]) => histogram.labelValues(lbls: _*),
-            modify = (dp: io.prometheus.metrics.core.datapoints.DistributionDataPoint) =>
-              exemplar.fold(dp.observe(d))(e => dp.observeWithExemplar(d, transformExemplarLabels(e))),
-            logger = logger
-          )
-        }
-      )
-    }
-  }
+      // Dual-mode: NEITHER .classicOnly() NOR .nativeOnly(). Both classicUpperBounds(...) and
+      // the native setters are configured. The resulting Histogram emits BOTH representations,
+      // letting Prometheus's `convert_classic_histograms_to_nhcb` pick the classic form for
+      // server-side NHCB conversion while the native exponential is also available directly.
+      configureBuilder = b => applyNativeConfig(b.classicUpperBounds(buckets.toList: _*), config),
+      exemplarState = ref => Histogram.ExemplarState.fromRef(buckets, ref)
+    )(f)
 
   override def createAndRegisterDoubleNativeHistogram[A](
       prefix: Option[Metric.Prefix],
@@ -352,60 +358,23 @@ class JavaMetricRegistry[F[_]: Async] private (
       commonLabels: Metric.CommonLabels,
       labelNames: IndexedSeq[Label.Name],
       config: NativeHistogram
-  )(f: A => IndexedSeq[String]): Resource[F, Histogram[F, Double, A]] = {
-    val commonLabelNames       = commonLabels.value.keys.toIndexedSeq
-    val commonLabelValuesArray = commonLabels.value.values.toArray
-    val allLabelNames          = labelNames ++ commonLabelNames
-    val fullName               = NameUtils.makeName(prefix, name)
-
-    configureBuilderOrRetrieve[PHistogram](
-      register = () => {
-        val builder = PHistogram
-          .builder()
-          .name(fullName)
-          .help(help.value)
-          .labelNames(allLabelNames.map(_.value): _*)
-          .nativeOnly()
-          .nativeInitialSchema(config.initialSchema)
-          .nativeMaxNumberOfBuckets(config.maxNumberOfBuckets)
-          .nativeMaxZeroThreshold(config.maxZeroThreshold)
-          .nativeMinZeroThreshold(config.minZeroThreshold)
-        val tuned =
-          if (config.resetDuration > 0.seconds)
-            builder.nativeResetDuration(
-              config.resetDuration.toSeconds,
-              java.util.concurrent.TimeUnit.SECONDS
-            )
-          else builder
-        tuned.register(registry)
-      },
+  )(f: A => IndexedSeq[String]): Resource[F, Histogram[F, Double, A]] =
+    histogramFromBuilder(
+      prefix,
+      name,
+      help,
+      commonLabels,
+      labelNames,
       metricType = MetricType.NativeHistogram,
-      metricPrefix = prefix,
-      stringName = name.value,
-      labels = allLabelNames
-    ).map { case (histogram, _) =>
-      // Native histograms use ExemplarState.noop: the upstream Histogram still accepts exemplars via
-      // observeWithExemplar(d, labels), but the bucket-driven sampler in Histogram.ExemplarState.fromRef
-      // requires explicit bucket boundaries which native histograms do not have. Consumers wanting
-      // sampled exemplars on a native histogram are not supported in this initial cut; explicit
-      // exemplars (.observeWithExemplar) still work end-to-end.
-      Histogram.make[F, Double, A](
-        Histogram.ExemplarState.noop,
-        _observe = { (d: Double, labels: A, exemplar: Option[Exemplar.Labels]) =>
-          Utils.modifyMetric[F, Histogram.Name, io.prometheus.metrics.core.datapoints.DistributionDataPoint](
-            metricName = name,
-            allLabelNames = allLabelNames,
-            dynamicLabels = f(labels),
-            commonLabelValues = commonLabelValuesArray,
-            getDataPoint = (lbls: Array[String]) => histogram.labelValues(lbls: _*),
-            modify = (dp: io.prometheus.metrics.core.datapoints.DistributionDataPoint) =>
-              exemplar.fold(dp.observe(d))(e => dp.observeWithExemplar(d, transformExemplarLabels(e))),
-            logger = logger
-          )
-        }
-      )
-    }
-  }
+      configureBuilder = b => applyNativeConfig(b.nativeOnly(), config),
+      // Native histograms use ExemplarState.noop: the upstream Histogram still accepts exemplars
+      // via observeWithExemplar(d, labels), but the bucket-driven sampler in
+      // Histogram.ExemplarState.fromRef requires explicit bucket boundaries which native
+      // histograms do not have. Consumers wanting sampled exemplars on a native histogram are not
+      // supported in this initial cut; explicit exemplars (.observeWithExemplar) still work
+      // end-to-end.
+      exemplarState = _ => Histogram.ExemplarState.noop
+    )(f)
 
   override def createAndRegisterDoubleSummary[A](
       prefix: Option[Metric.Prefix],

--- a/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
+++ b/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
@@ -288,7 +288,7 @@ class JavaMetricRegistry[F[_]: Async] private (
       commonLabels: Metric.CommonLabels,
       labelNames: IndexedSeq[Label.Name],
       buckets: NonEmptySeq[Double],
-      nativeHistogram: NativeHistogram
+      config: NativeHistogram
   )(f: A => IndexedSeq[String]): Resource[F, Histogram[F, Double, A]] = {
     val commonLabelNames       = commonLabels.value.keys.toIndexedSeq
     val commonLabelValuesArray = commonLabels.value.values.toArray
@@ -307,14 +307,14 @@ class JavaMetricRegistry[F[_]: Async] private (
           .help(help.value)
           .labelNames(allLabelNames.map(_.value): _*)
           .classicUpperBounds(buckets.toSeq.toArray: _*)
-          .nativeInitialSchema(nativeHistogram.initialSchema)
-          .nativeMaxNumberOfBuckets(nativeHistogram.maxNumberOfBuckets)
-          .nativeMaxZeroThreshold(nativeHistogram.maxZeroThreshold)
-          .nativeMinZeroThreshold(nativeHistogram.minZeroThreshold)
+          .nativeInitialSchema(config.initialSchema)
+          .nativeMaxNumberOfBuckets(config.maxNumberOfBuckets)
+          .nativeMaxZeroThreshold(config.maxZeroThreshold)
+          .nativeMinZeroThreshold(config.minZeroThreshold)
         val tuned =
-          if (nativeHistogram.resetDuration > 0.seconds)
+          if (config.resetDuration > 0.seconds)
             builder.nativeResetDuration(
-              nativeHistogram.resetDuration.toSeconds,
+              config.resetDuration.toSeconds,
               java.util.concurrent.TimeUnit.SECONDS
             )
           else builder
@@ -351,7 +351,7 @@ class JavaMetricRegistry[F[_]: Async] private (
       help: Metric.Help,
       commonLabels: Metric.CommonLabels,
       labelNames: IndexedSeq[Label.Name],
-      nativeHistogram: NativeHistogram
+      config: NativeHistogram
   )(f: A => IndexedSeq[String]): Resource[F, Histogram[F, Double, A]] = {
     val commonLabelNames       = commonLabels.value.keys.toIndexedSeq
     val commonLabelValuesArray = commonLabels.value.values.toArray
@@ -366,14 +366,14 @@ class JavaMetricRegistry[F[_]: Async] private (
           .help(help.value)
           .labelNames(allLabelNames.map(_.value): _*)
           .nativeOnly()
-          .nativeInitialSchema(nativeHistogram.initialSchema)
-          .nativeMaxNumberOfBuckets(nativeHistogram.maxNumberOfBuckets)
-          .nativeMaxZeroThreshold(nativeHistogram.maxZeroThreshold)
-          .nativeMinZeroThreshold(nativeHistogram.minZeroThreshold)
+          .nativeInitialSchema(config.initialSchema)
+          .nativeMaxNumberOfBuckets(config.maxNumberOfBuckets)
+          .nativeMaxZeroThreshold(config.maxZeroThreshold)
+          .nativeMinZeroThreshold(config.minZeroThreshold)
         val tuned =
-          if (nativeHistogram.resetDuration > 0.seconds)
+          if (config.resetDuration > 0.seconds)
             builder.nativeResetDuration(
-              nativeHistogram.resetDuration.toSeconds,
+              config.resetDuration.toSeconds,
               java.util.concurrent.TimeUnit.SECONDS
             )
           else builder

--- a/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
+++ b/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
@@ -256,7 +256,7 @@ class JavaMetricRegistry[F[_]: Async] private (
           // form is emitted from the .histogram(...) DSL path; the .nativeHistogram(...) DSL path
           // calls .nativeOnly() instead.
           .classicOnly()
-          .classicUpperBounds(buckets.toSeq.toArray: _*)
+          .classicUpperBounds(buckets.toList: _*)
           .register(registry),
       metricType = MetricType.Histogram,
       metricPrefix = prefix,
@@ -306,7 +306,7 @@ class JavaMetricRegistry[F[_]: Async] private (
           .name(fullName)
           .help(help.value)
           .labelNames(allLabelNames.map(_.value): _*)
-          .classicUpperBounds(buckets.toSeq.toArray: _*)
+          .classicUpperBounds(buckets.toList: _*)
           .nativeInitialSchema(config.initialSchema)
           .nativeMaxNumberOfBuckets(config.maxNumberOfBuckets)
           .nativeMaxZeroThreshold(config.maxZeroThreshold)

--- a/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
+++ b/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
@@ -776,6 +776,7 @@ class JavaMetricRegistry[F[_]: Async] private (
       )
   )
 
+  @SuppressWarnings(Array("scalafix:DisableSyntax.null"))
   override def registerDoubleCounterCallback[A](
       prefix: Option[Metric.Prefix],
       name: Counter.Name,
@@ -830,6 +831,7 @@ class JavaMetricRegistry[F[_]: Async] private (
     )
   }
 
+  @SuppressWarnings(Array("scalafix:DisableSyntax.null"))
   override def registerDoubleGaugeCallback[A](
       prefix: Option[Metric.Prefix],
       name: Gauge.Name,
@@ -1022,12 +1024,13 @@ class JavaMetricRegistry[F[_]: Async] private (
         th =>
           logger(th)(s"Combined metric-collection callbacks timed out after $callbackTimeout")
             .as(MetricSnapshots.builder().build()),
-        th => logger(th)(s"Combined metric-collection callbacks failed").as(MetricSnapshots.builder().build())
+        th => logger(th)("Combined metric-collection callbacks failed").as(MetricSnapshots.builder().build())
       )
     }
 
   }
 
+  @SuppressWarnings(Array("scalafix:DisableSyntax.null"))
   override def registerMetricCollectionCallback(
       prefix: Option[Metric.Prefix],
       commonLabels: Metric.CommonLabels,
@@ -1063,6 +1066,7 @@ class JavaMetricRegistry[F[_]: Async] private (
     * upstream `MetricSnapshot`s. Each (name, labelNames) entry becomes one snapshot with one or more data points (one
     * per List entry in the user's MetricCollection).
     */
+  @SuppressWarnings(Array("scalafix:DisableSyntax.null"))
   private def metricCollectionToSnapshots(
       prefix: Option[Metric.Prefix],
       commonLabels: Map[Label.Name, String],

--- a/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
+++ b/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
@@ -48,7 +48,6 @@ import prometheus4cats.util.NameUtils
   *
   * Construct via [[JavaMetricRegistry.Builder]].
   */
-@SuppressWarnings(Array("all"))
 class JavaMetricRegistry[F[_]: Async] private (
     private val registry: PrometheusRegistry,
     private val ref: Ref[F, State[F]],
@@ -79,6 +78,7 @@ class JavaMetricRegistry[F[_]: Async] private (
     * Mirrors the behaviour of the legacy `javasimpleclient` adapter — supports overlapping `Resource`-scoped
     * registrations of the same metric name without registering it twice with the underlying registry.
     */
+  @SuppressWarnings(Array("scalafix:DisableSyntax.=="))
   protected def configureBuilderOrRetrieve[M <: io.prometheus.metrics.core.metrics.StatefulMetric[_, _]](
       register: () => M,
       metricType: MetricType,
@@ -339,7 +339,6 @@ class JavaMetricRegistry[F[_]: Async] private (
 
 }
 
-@SuppressWarnings(Array("all"))
 object JavaMetricRegistry {
 
   /** Builder for [[JavaMetricRegistry]]. Mirrors the legacy

--- a/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
+++ b/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
@@ -16,7 +16,10 @@
 
 package prometheus4cats.javaclient
 
+import java.util.concurrent.TimeoutException
+
 import scala.concurrent.duration._
+import scala.jdk.CollectionConverters._
 
 import cats.Applicative
 import cats.ApplicativeThrow
@@ -25,9 +28,12 @@ import cats.Show
 import cats.data.NonEmptyList
 import cats.data.NonEmptySeq
 import cats.effect.kernel._
+import cats.effect.kernel.syntax.temporal._
+import cats.effect.std.Dispatcher
 import cats.effect.std.Semaphore
 import cats.syntax.all._
 
+import alleycats.std.iterable._
 import io.prometheus.metrics.core.datapoints.CounterDataPoint
 import io.prometheus.metrics.core.datapoints.DistributionDataPoint
 import io.prometheus.metrics.core.datapoints.GaugeDataPoint
@@ -38,7 +44,11 @@ import io.prometheus.metrics.core.metrics.{Info => PInfo}
 import io.prometheus.metrics.core.metrics.{Summary => PSummary}
 import io.prometheus.metrics.instrumentation.jvm.JvmMetrics
 import io.prometheus.metrics.model.registry.PrometheusRegistry
+import io.prometheus.metrics.model.registry.{Collector => PCollector}
+import io.prometheus.metrics.model.snapshots.CounterSnapshot
 import io.prometheus.metrics.model.snapshots.Labels
+import io.prometheus.metrics.model.snapshots.MetricMetadata
+import io.prometheus.metrics.model.snapshots.MetricSnapshot
 import prometheus4cats._
 import prometheus4cats.javaclient.internal.Utils
 import prometheus4cats.javaclient.models.MetricType
@@ -57,7 +67,14 @@ import prometheus4cats.util.NameUtils
 class JavaMetricRegistry[F[_]: Async] private (
     private val registry: PrometheusRegistry,
     private val ref: Ref[F, State[F]],
+    private val callbackState: Ref[F, CallbackState[F]],
+    private val callbackTimeoutState: Ref[F, Set[String]],
+    private val callbackErrorState: Ref[F, Set[String]],
+    private val singleCallbackErrorState: Ref[F, (Set[String], Set[String])],
     private val sem: Semaphore[F],
+    private val dispatcher: Dispatcher[F],
+    private val callbackTimeout: FiniteDuration,
+    private val singleCallbackTimeout: FiniteDuration,
     private val logger: Throwable => String => F[Unit]
 ) extends DoubleMetricRegistry[F]
     with DoubleCallbackRegistry[F] {
@@ -519,6 +536,221 @@ class JavaMetricRegistry[F[_]: Async] private (
     }
   }
 
+  // ─── callback machinery ──────────────────────────────────────────────────────────────────────────
+  //
+  // Mirrors the legacy javasimpleclient adapter's per-callback timeout + error-tracking pattern:
+  //
+  //   - `singleCallbackTimeout` bounds an individual callback invocation; exceeding it returns empty
+  //     samples for that registration and logs ONCE per metric name.
+  //   - `callbackTimeout` bounds the COMBINED collection of all registered callbacks for a single
+  //     metric (i.e., the wrapper that aggregates samples across multiple consumer registrations).
+  //   - Error tracking refs (`callbackTimeoutState`, `callbackErrorState`, `singleCallbackErrorState`)
+  //     prevent log spam: the first time a metric's callback times out / fails, we log; subsequent
+  //     occurrences are silently counted by the upstream Prometheus runtime via the regular
+  //     scrape-error path.
+  //
+  // Skipped vs the legacy adapter: the internal `prometheus4cats_combined_callback_metric_total` and
+  // `prometheus4cats_callback_total` counters that tracked callback success/error/timeout counts
+  // per metric. They're observability nice-to-haves; consumers can always add them externally if
+  // wanted. May add in a follow-up commit.
+
+  private def trackErrors[A](
+      state: Ref[F, Set[String]],
+      stringName: String,
+      onContains: F[A],
+      onContainsNot: F[A]
+  ): F[A] =
+    state.modify { current =>
+      if (current.contains(stringName)) (current, onContains) else (current + stringName, onContainsNot)
+    }.flatten
+
+  /** Wrap an effect with a timeout + error fallback, dispatching synchronously through the supplied Dispatcher. Both
+    * timeouts and failures are mapped to `empty` and forwarded to `onTimeout` / `onError` for logging-side-effect
+    * handling.
+    */
+  private def runCallbackWithBounds[A](
+      fa: F[A],
+      timeout: FiniteDuration,
+      onTimeout: TimeoutException => F[A],
+      onError: Throwable => F[A]
+  ): A =
+    dispatcher.unsafeRunSync(fa.timeout(timeout).handleErrorWith {
+      case th: TimeoutException => onTimeout(th)
+      case th                   => onError(th)
+    })
+
+  /** Per-callback timeout wrapper: bounds an individual registration's callback invocation. Returns the
+    * (logged-timeout, logged-error, samples) triple so the outer aggregation can decide what to persist into
+    * [[singleCallbackErrorState]] without re-logging on every scrape.
+    */
+  private def timeoutEachCallback[V](
+      stringName: String,
+      samplesF: F[NonEmptyList[(V, IndexedSeq[String])]],
+      hasLoggedTimeout: Boolean,
+      hasLoggedError: Boolean
+  ): F[(Boolean, Boolean, List[(V, IndexedSeq[String])])] =
+    samplesF
+      .map(samples => (hasLoggedTimeout, hasLoggedError, samples.toList))
+      .timeout(singleCallbackTimeout)
+      .handleErrorWith {
+        case th: TimeoutException =>
+          (if (hasLoggedTimeout) Applicative[F].unit
+           else
+             logger(th)(
+               s"Timed out running a callback for the metric '$stringName' after $singleCallbackTimeout. " +
+                 "This warning will only be shown once after process start."
+             )).as((true, hasLoggedError, List.empty))
+        case th =>
+          (if (hasLoggedError) Applicative[F].unit
+           else
+             logger(th)(
+               s"Executing a callback for the metric '$stringName' failed with the following exception. " +
+                 "This warning will only be shown once after process start."
+             )).as((hasLoggedTimeout, true, List.empty))
+      }
+
+  /** Generic callback registration:
+    *   1. Look up (or create) a single upstream `Collector` for this metric name. 2. Add the user's callback to the
+    *      Collector's per-token registration map. 3. On Resource release, remove this token; if it was the last token,
+    *      unregister the Collector.
+    *
+    * The `makeCollector` thunk is responsible for constructing the kind-specific Collector that builds the right
+    * `MetricSnapshot` from the aggregated `(value, labels)` tuples at scrape time.
+    */
+  private def registerCallback[A: Show](
+      metricType: MetricType,
+      metricPrefix: Option[Metric.Prefix],
+      name: A,
+      callback: F[NonEmptyList[(Double, IndexedSeq[String])]],
+      makeCollector: Ref[F, CallbackPayload[F]] => PCollector
+  ): Resource[F, Unit] = {
+    lazy val n                  = name.show
+    lazy val fullName: StateKey = (metricPrefix, n)
+    lazy val renderedFullName   = NameUtils.makeName(metricPrefix, name)
+
+    val acquire = sem.permit.surround(
+      ref.get.flatMap(r =>
+        r.get(fullName) match {
+          case None => Applicative[F].unit
+          case Some(_) =>
+            ApplicativeThrow[F].raiseError[Unit](
+              new RuntimeException(
+                s"A metric with the same name as '$renderedFullName' is already registered with different labels and/or type"
+              )
+            )
+        }
+      ) >>
+        callbackState.get
+          .flatMap[Unique.Token] { (callbacks: CallbackState[F]) =>
+            callbacks.get(fullName) match {
+              case Some((`metricType`, states, _)) =>
+                Unique[F].unique.flatMap { token =>
+                  states.update(_.updated(token, callback)).as(token)
+                }
+              case Some(_) =>
+                ApplicativeThrow[F].raiseError(
+                  new RuntimeException(
+                    s"A callback with the same name as '$renderedFullName' is already registered with different type"
+                  )
+                )
+              case None =>
+                for {
+                  token    <- Unique[F].unique
+                  innerRef <- Ref.of[F, CallbackPayload[F]](Map(token -> callback))
+                  collector = makeCollector(innerRef)
+                  _        <- Sync[F].delay(registry.register(collector))
+                  _        <- callbackState.set(callbacks.updated(fullName, (metricType, innerRef, collector)))
+                } yield token
+            }
+          }
+    )
+
+    Resource
+      .make(acquire) { token =>
+        sem.permit.surround(callbackState.get.flatMap { state =>
+          state.get(fullName) match {
+            case Some((_, callbacks, collector)) =>
+              callbacks.get.flatMap { cbs =>
+                val newCallbacks = cbs - token
+                if (newCallbacks.isEmpty)
+                  callbackState.set(state - fullName) >>
+                    Sync[F].delay(registry.unregister(collector)).handleErrorWith { e =>
+                      logger(e)(s"Failed to unregister callback collector: '$collector'")
+                    }
+                else callbacks.set(newCallbacks)
+              }
+            case None => Applicative[F].unit
+          }
+        })
+      }
+      .void
+  }
+
+  /** Aggregate all per-token callbacks into a single list of `(value, labels)` tuples, applying the per-callback
+    * timeout and error-tracking machinery. Used by every kind-specific Collector.
+    */
+  private def collectAllPayload(
+      callbacks: Ref[F, CallbackPayload[F]],
+      renderedFullName: String
+  ): F[List[(Double, IndexedSeq[String])]] =
+    singleCallbackErrorState.get.flatMap { case (loggedTimeout, loggedError) =>
+      callbacks.get
+        .flatMap(
+          _.values.foldM(
+            (
+              loggedTimeout.contains(renderedFullName),
+              loggedError.contains(renderedFullName),
+              List.empty[(Double, IndexedSeq[String])]
+            )
+          ) { case ((hasLoggedTimeout0, hasLoggedError0, acc), samplesF) =>
+            timeoutEachCallback(renderedFullName, samplesF, hasLoggedTimeout0, hasLoggedError0).map {
+              case (lto, le, samples) => (lto, le, acc ++ samples)
+            }
+          }
+        )
+        .flatMap { case (hasLoggedTimeout0, hasLoggedError0, samples) =>
+          ((hasLoggedTimeout0, hasLoggedError0) match {
+            case (true, true) =>
+              singleCallbackErrorState.set((loggedTimeout + renderedFullName, loggedError + renderedFullName))
+            case (true, false)  => singleCallbackErrorState.set((loggedTimeout + renderedFullName, loggedError))
+            case (false, true)  => singleCallbackErrorState.set((loggedTimeout, loggedError + renderedFullName))
+            case (false, false) => Applicative[F].unit
+          }).as(samples)
+        }
+    }
+
+  /** Run the aggregated-payload computation through the dispatcher with the combined-callbacks timeout + once-only
+    * error logging. Returns `empty` on timeout/error.
+    */
+  private def runAggregateCollect[A](
+      stringName: String,
+      result: F[A],
+      empty: A
+  ): A = runCallbackWithBounds(
+    result,
+    callbackTimeout,
+    th =>
+      trackErrors(
+        callbackTimeoutState,
+        stringName,
+        Applicative[F].pure(empty),
+        logger(th)(
+          s"Timed out running callbacks for metric '$stringName' after $callbackTimeout. " +
+            "This warning will only be shown once for each metric after process start."
+        ).as(empty)
+      ),
+    th =>
+      trackErrors(
+        callbackErrorState,
+        stringName,
+        Applicative[F].pure(empty),
+        logger(th)(
+          s"Callbacks for metric '$stringName' failed with the following exception. " +
+            "This warning will only be shown once for each metric after process start."
+        ).as(empty)
+      )
+  )
+
   override def registerDoubleCounterCallback[A](
       prefix: Option[Metric.Prefix],
       name: Counter.Name,
@@ -526,8 +758,50 @@ class JavaMetricRegistry[F[_]: Async] private (
       commonLabels: Metric.CommonLabels,
       labelNames: IndexedSeq[Label.Name],
       callback: F[NonEmptyList[(Double, A)]]
-  )(f: A => IndexedSeq[String]): Resource[F, Unit] =
-    Resource.eval(ApplicativeThrow[F].raiseError(notYetPorted("registerDoubleCounterCallback")))
+  )(f: A => IndexedSeq[String]): Resource[F, Unit] = {
+    val commonLabelKeys      = commonLabels.value.keys.toIndexedSeq.map(_.value)
+    val commonLabelValuesArr = commonLabels.value.values.toIndexedSeq
+    val allLabelNamesStr     = (labelNames.map(_.value) ++ commonLabelKeys).toArray
+    val rawName              = NameUtils.makeName(prefix, name)
+    // Counter snapshots use the BASE name (without "_total" suffix) per upstream convention; the
+    // exposition writer adds "_total" back to the wire format.
+    val baseName = if (rawName.endsWith("_total")) rawName.dropRight("_total".length) else rawName
+
+    // Project user (Double, A) tuples into (Double, all-label-values) tuples up front so the
+    // generic CallbackPayload type doesn't need to know about A.
+    val projected: F[NonEmptyList[(Double, IndexedSeq[String])]] = callback.map(
+      _.map { case (v, a) => (v, f(a) ++ commonLabelValuesArr) }
+    )
+
+    registerCallback[Counter.Name](
+      MetricType.Counter,
+      prefix,
+      name,
+      projected,
+      makeCollector = (callbacks: Ref[F, CallbackPayload[F]]) =>
+        new PCollector {
+
+          override def collect(): MetricSnapshot = {
+            val aggregated: F[List[(Double, IndexedSeq[String])]] = collectAllPayload(callbacks, baseName)
+            val dataPoints: java.util.List[CounterSnapshot.CounterDataPointSnapshot] =
+              runAggregateCollect(
+                baseName,
+                aggregated.map(_.map { case (value, labelValues) =>
+                  new CounterSnapshot.CounterDataPointSnapshot(
+                    if (value < 0) 0.0 else value,
+                    Labels.of(allLabelNamesStr, labelValues.toArray),
+                    null: io.prometheus.metrics.model.snapshots.Exemplar,
+                    0L
+                  )
+                }.asJava),
+                java.util.Collections.emptyList[CounterSnapshot.CounterDataPointSnapshot]()
+              )
+            new CounterSnapshot(new MetricMetadata(baseName, help.value), dataPoints)
+          }
+
+        }
+    )
+  }
 
   override def registerDoubleGaugeCallback[A](
       prefix: Option[Metric.Prefix],
@@ -631,19 +905,34 @@ object JavaMetricRegistry {
         if (registerJvmMetrics) Sync[F].delay(JvmMetrics.builder().register(promRegistry))
         else Applicative[F].unit
       }.flatMap { _ =>
-        val acquire = for {
-          ref <- Ref.of[F, State[F]](Map.empty)
-          sem <- Semaphore[F](1L)
-        } yield new JavaMetricRegistry[F](promRegistry, ref, sem, logger)
+        Dispatcher.sequential[F].flatMap { dispatcher =>
+          val acquire = for {
+            ref                      <- Ref.of[F, State[F]](Map.empty)
+            cbState                  <- Ref.of[F, CallbackState[F]](Map.empty)
+            cbTimeoutState           <- Ref.of[F, Set[String]](Set.empty)
+            cbErrorState             <- Ref.of[F, Set[String]](Set.empty)
+            singleCallbackErrorState <- Ref.of[F, (Set[String], Set[String])]((Set.empty, Set.empty))
+            sem                      <- Semaphore[F](1L)
+          } yield new JavaMetricRegistry[F](
+            promRegistry, ref, cbState, cbTimeoutState, cbErrorState, singleCallbackErrorState, sem, dispatcher,
+            callbackTimeout = callbackCollectionTimeout, singleCallbackTimeout = callbackTimeout, logger = logger
+          )
 
-        Resource.make(acquire) { reg =>
-          // unregister all metrics that are still claimed at shutdown
-          reg.ref.get.flatMap { metrics =>
-            if (metrics.nonEmpty)
-              metrics.values.toList.traverse_ { case (_, (collector, _, _)) =>
-                Utils.unregister(collector, promRegistry, logger)
+          Resource.make(acquire) { reg =>
+            // Unregister callback collectors first, then claimed metric collectors.
+            reg.callbackState.get.flatMap { cbs =>
+              cbs.values.toList.traverse_ { case (_, _, collector) =>
+                Sync[F].delay(promRegistry.unregister(collector)).handleErrorWith { e =>
+                  logger(e)(s"Failed to unregister callback collector at shutdown: '$collector'")
+                }
               }
-            else Applicative[F].unit
+            } >> reg.ref.get.flatMap { metrics =>
+              if (metrics.nonEmpty)
+                metrics.values.toList.traverse_ { case (_, (collector, _, _)) =>
+                  Utils.unregister(collector, promRegistry, logger)
+                }
+              else Applicative[F].unit
+            }
           }
         }
       }

--- a/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
+++ b/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
@@ -132,7 +132,11 @@ class JavaMetricRegistry[F[_]: Async] private (
               ref.set(metrics - fullName) >> Utils.unregister(collector, registry, logger)
             case Some((`metricId`, (collector, exemplarRef, references))) =>
               ref.set(metrics.updated(fullName, (metricId, (collector, exemplarRef, references - 1))))
-            case _ => Applicative[F].unit
+            case _ =>
+              logger(new IllegalStateException("javaclient: unexpected state during Resource release"))(
+                s"Unexpected state at $renderedFullName release; collector NOT unregistered. " +
+                  "This indicates a bug in the registry state machinery; please report."
+              )
           }
         }
       }
@@ -496,7 +500,11 @@ class JavaMetricRegistry[F[_]: Async] private (
                 }
             case Some((`metricId`, (collector, exemplarRef, references))) =>
               ref.set(metrics.updated(fullName, (metricId, (collector, exemplarRef, references - 1))))
-            case _ => Applicative[F].unit
+            case _ =>
+              logger(new IllegalStateException("javaclient: unexpected state during Info Resource release"))(
+                s"Unexpected state at $renderedFullName release; Info collector NOT unregistered. " +
+                  "This indicates a bug in the registry state machinery; please report."
+              )
           }
         }
       }

--- a/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
+++ b/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
@@ -30,6 +30,7 @@ import cats.syntax.all._
 
 import io.prometheus.metrics.core.metrics.{Counter => PCounter}
 import io.prometheus.metrics.core.metrics.{Gauge => PGauge}
+import io.prometheus.metrics.core.metrics.{Histogram => PHistogram}
 import io.prometheus.metrics.instrumentation.jvm.JvmMetrics
 import io.prometheus.metrics.model.registry.PrometheusRegistry
 import io.prometheus.metrics.model.snapshots.Labels
@@ -148,6 +149,10 @@ class JavaMetricRegistry[F[_]: Async] private (
 
     configureBuilderOrRetrieve[PCounter](
       register = () =>
+        // No `.withExemplars()` — that method is inherited from the package-private
+        // StatefulMetric$Builder, and exposing its return type from outside its package
+        // triggers IllegalAccessError at JVM access-check time. Exemplar handling is enabled
+        // by default in prometheus-metrics-core 1.x; `.withoutExemplars()` is the disable.
         PCounter
           .builder()
           .name(fullName)
@@ -233,8 +238,48 @@ class JavaMetricRegistry[F[_]: Async] private (
       commonLabels: Metric.CommonLabels,
       labelNames: IndexedSeq[Label.Name],
       buckets: NonEmptySeq[Double]
-  )(f: A => IndexedSeq[String]): Resource[F, Histogram[F, Double, A]] =
-    Resource.eval(ApplicativeThrow[F].raiseError(notYetPorted("createAndRegisterDoubleHistogram")))
+  )(f: A => IndexedSeq[String]): Resource[F, Histogram[F, Double, A]] = {
+    val commonLabelNames       = commonLabels.value.keys.toIndexedSeq
+    val commonLabelValuesArray = commonLabels.value.values.toArray
+    val allLabelNames          = labelNames ++ commonLabelNames
+    val fullName               = NameUtils.makeName(prefix, name)
+
+    configureBuilderOrRetrieve[PHistogram](
+      register = () =>
+        PHistogram
+          .builder()
+          .name(fullName)
+          .help(help.value)
+          .labelNames(allLabelNames.map(_.value): _*)
+          // .classicOnly() is required because the 1.x default emits BOTH classic AND native
+          // histograms from a single declaration. Preserving v5 behaviour means only the classic
+          // form is emitted from the .histogram(...) DSL path; the .nativeHistogram(...) DSL path
+          // calls .nativeOnly() instead.
+          .classicOnly()
+          .classicUpperBounds(buckets.toSeq.toArray: _*)
+          .register(registry),
+      metricType = MetricType.Histogram,
+      metricPrefix = prefix,
+      stringName = name.value,
+      labels = allLabelNames
+    ).map { case (histogram, exemplarRef) =>
+      Histogram.make[F, Double, A](
+        Histogram.ExemplarState.fromRef(buckets, exemplarRef),
+        _observe = { (d: Double, labels: A, exemplar: Option[Exemplar.Labels]) =>
+          Utils.modifyMetric[F, Histogram.Name, io.prometheus.metrics.core.datapoints.DistributionDataPoint](
+            metricName = name,
+            allLabelNames = allLabelNames,
+            dynamicLabels = f(labels),
+            commonLabelValues = commonLabelValuesArray,
+            getDataPoint = (lbls: Array[String]) => histogram.labelValues(lbls: _*),
+            modify = (dp: io.prometheus.metrics.core.datapoints.DistributionDataPoint) =>
+              exemplar.fold(dp.observe(d))(e => dp.observeWithExemplar(d, transformExemplarLabels(e))),
+            logger = logger
+          )
+        }
+      )
+    }
+  }
 
   override def createAndRegisterDoubleNativeHistogram[A](
       prefix: Option[Metric.Prefix],
@@ -243,8 +288,60 @@ class JavaMetricRegistry[F[_]: Async] private (
       commonLabels: Metric.CommonLabels,
       labelNames: IndexedSeq[Label.Name],
       nativeHistogram: NativeHistogram
-  )(f: A => IndexedSeq[String]): Resource[F, Histogram[F, Double, A]] =
-    Resource.eval(ApplicativeThrow[F].raiseError(notYetPorted("createAndRegisterDoubleNativeHistogram")))
+  )(f: A => IndexedSeq[String]): Resource[F, Histogram[F, Double, A]] = {
+    val commonLabelNames       = commonLabels.value.keys.toIndexedSeq
+    val commonLabelValuesArray = commonLabels.value.values.toArray
+    val allLabelNames          = labelNames ++ commonLabelNames
+    val fullName               = NameUtils.makeName(prefix, name)
+
+    configureBuilderOrRetrieve[PHistogram](
+      register = () => {
+        val builder = PHistogram
+          .builder()
+          .name(fullName)
+          .help(help.value)
+          .labelNames(allLabelNames.map(_.value): _*)
+          .nativeOnly()
+          .nativeInitialSchema(nativeHistogram.initialSchema)
+          .nativeMaxNumberOfBuckets(nativeHistogram.maxNumberOfBuckets)
+          .nativeMaxZeroThreshold(nativeHistogram.maxZeroThreshold)
+          .nativeMinZeroThreshold(nativeHistogram.minZeroThreshold)
+        val tuned =
+          if (nativeHistogram.resetDuration > 0.seconds)
+            builder.nativeResetDuration(
+              nativeHistogram.resetDuration.toSeconds,
+              java.util.concurrent.TimeUnit.SECONDS
+            )
+          else builder
+        tuned.register(registry)
+      },
+      metricType = MetricType.NativeHistogram,
+      metricPrefix = prefix,
+      stringName = name.value,
+      labels = allLabelNames
+    ).map { case (histogram, _) =>
+      // Native histograms use ExemplarState.noop: the upstream Histogram still accepts exemplars via
+      // observeWithExemplar(d, labels), but the bucket-driven sampler in Histogram.ExemplarState.fromRef
+      // requires explicit bucket boundaries which native histograms do not have. Consumers wanting
+      // sampled exemplars on a native histogram are not supported in this initial cut; explicit
+      // exemplars (.observeWithExemplar) still work end-to-end.
+      Histogram.make[F, Double, A](
+        Histogram.ExemplarState.noop,
+        _observe = { (d: Double, labels: A, exemplar: Option[Exemplar.Labels]) =>
+          Utils.modifyMetric[F, Histogram.Name, io.prometheus.metrics.core.datapoints.DistributionDataPoint](
+            metricName = name,
+            allLabelNames = allLabelNames,
+            dynamicLabels = f(labels),
+            commonLabelValues = commonLabelValuesArray,
+            getDataPoint = (lbls: Array[String]) => histogram.labelValues(lbls: _*),
+            modify = (dp: io.prometheus.metrics.core.datapoints.DistributionDataPoint) =>
+              exemplar.fold(dp.observe(d))(e => dp.observeWithExemplar(d, transformExemplarLabels(e))),
+            logger = logger
+          )
+        }
+      )
+    }
+  }
 
   override def createAndRegisterDoubleHistogramWithNative[A](
       prefix: Option[Metric.Prefix],

--- a/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
+++ b/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
@@ -46,6 +46,7 @@ import io.prometheus.metrics.instrumentation.jvm.JvmMetrics
 import io.prometheus.metrics.model.registry.PrometheusRegistry
 import io.prometheus.metrics.model.registry.{Collector => PCollector}
 import io.prometheus.metrics.model.snapshots.CounterSnapshot
+import io.prometheus.metrics.model.snapshots.GaugeSnapshot
 import io.prometheus.metrics.model.snapshots.Labels
 import io.prometheus.metrics.model.snapshots.MetricMetadata
 import io.prometheus.metrics.model.snapshots.MetricSnapshot
@@ -810,8 +811,44 @@ class JavaMetricRegistry[F[_]: Async] private (
       commonLabels: Metric.CommonLabels,
       labelNames: IndexedSeq[Label.Name],
       callback: F[NonEmptyList[(Double, A)]]
-  )(f: A => IndexedSeq[String]): Resource[F, Unit] =
-    Resource.eval(ApplicativeThrow[F].raiseError(notYetPorted("registerDoubleGaugeCallback")))
+  )(f: A => IndexedSeq[String]): Resource[F, Unit] = {
+    val commonLabelKeys      = commonLabels.value.keys.toIndexedSeq.map(_.value)
+    val commonLabelValuesArr = commonLabels.value.values.toIndexedSeq
+    val allLabelNamesStr     = (labelNames.map(_.value) ++ commonLabelKeys).toArray
+    val fullName             = NameUtils.makeName(prefix, name)
+
+    val projected: F[NonEmptyList[(Double, IndexedSeq[String])]] = callback.map(
+      _.map { case (v, a) => (v, f(a) ++ commonLabelValuesArr) }
+    )
+
+    registerCallback[Gauge.Name](
+      MetricType.Gauge,
+      prefix,
+      name,
+      projected,
+      makeCollector = (callbacks: Ref[F, CallbackPayload[F]]) =>
+        new PCollector {
+
+          override def collect(): MetricSnapshot = {
+            val aggregated = collectAllPayload(callbacks, fullName)
+            val dataPoints: java.util.List[GaugeSnapshot.GaugeDataPointSnapshot] =
+              runAggregateCollect(
+                fullName,
+                aggregated.map(_.map { case (value, labelValues) =>
+                  new GaugeSnapshot.GaugeDataPointSnapshot(
+                    value,
+                    Labels.of(allLabelNamesStr, labelValues.toArray),
+                    null: io.prometheus.metrics.model.snapshots.Exemplar
+                  )
+                }.asJava),
+                java.util.Collections.emptyList[GaugeSnapshot.GaugeDataPointSnapshot]()
+              )
+            new GaugeSnapshot(new MetricMetadata(fullName, help.value), dataPoints)
+          }
+
+        }
+    )
+  }
 
   override def registerDoubleHistogramCallback[A](
       prefix: Option[Metric.Prefix],

--- a/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
+++ b/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
@@ -31,6 +31,7 @@ import cats.syntax.all._
 import io.prometheus.metrics.core.metrics.{Counter => PCounter}
 import io.prometheus.metrics.core.metrics.{Gauge => PGauge}
 import io.prometheus.metrics.core.metrics.{Histogram => PHistogram}
+import io.prometheus.metrics.core.metrics.{Summary => PSummary}
 import io.prometheus.metrics.instrumentation.jvm.JvmMetrics
 import io.prometheus.metrics.model.registry.PrometheusRegistry
 import io.prometheus.metrics.model.snapshots.Labels
@@ -385,8 +386,42 @@ class JavaMetricRegistry[F[_]: Async] private (
       quantiles: Seq[Summary.QuantileDefinition],
       maxAge: FiniteDuration,
       ageBuckets: Summary.AgeBuckets
-  )(f: A => IndexedSeq[String]): Resource[F, Summary[F, Double, A]] =
-    Resource.eval(ApplicativeThrow[F].raiseError(notYetPorted("createAndRegisterDoubleSummary")))
+  )(f: A => IndexedSeq[String]): Resource[F, Summary[F, Double, A]] = {
+    val commonLabelNames       = commonLabels.value.keys.toIndexedSeq
+    val commonLabelValuesArray = commonLabels.value.values.toArray
+    val allLabelNames          = labelNames ++ commonLabelNames
+    val fullName               = NameUtils.makeName(prefix, name)
+
+    configureBuilderOrRetrieve[PSummary](
+      register = () => {
+        val builder = PSummary
+          .builder()
+          .name(fullName)
+          .help(help.value)
+          .labelNames(allLabelNames.map(_.value): _*)
+          .maxAgeSeconds(maxAge.toSeconds)
+          .numberOfAgeBuckets(ageBuckets.value)
+        quantiles.foreach(q => builder.quantile(q.value.value, q.error.value))
+        builder.register(registry)
+      },
+      metricType = MetricType.Summary,
+      metricPrefix = prefix,
+      stringName = name.value,
+      labels = allLabelNames
+    ).map { case (summary, _) =>
+      Summary.make[F, Double, A] { case (d, labels) =>
+        Utils.modifyMetric[F, Summary.Name, io.prometheus.metrics.core.datapoints.DistributionDataPoint](
+          metricName = name,
+          allLabelNames = allLabelNames,
+          dynamicLabels = f(labels),
+          commonLabelValues = commonLabelValuesArray,
+          getDataPoint = (lbls: Array[String]) => summary.labelValues(lbls: _*),
+          modify = (dp: io.prometheus.metrics.core.datapoints.DistributionDataPoint) => dp.observe(d),
+          logger = logger
+        )
+      }
+    }
+  }
 
   override def createAndRegisterInfo[A](
       prefix: Option[Metric.Prefix],

--- a/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
+++ b/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
@@ -798,6 +798,11 @@ class JavaMetricRegistry[F[_]: Async] private (
     // Build CounterDataPointSnapshot instances inside the user callback's F so the generic
     // CallbackPayload type can hold them as plain DataPointSnapshots. The Collector at scrape time
     // casts back to CounterDataPointSnapshot.
+    //
+    // Negative values are clamped to 0.0 to preserve v5 (javasimpleclient) tolerance for malformed
+    // callbacks. Upstream v6's CounterDataPointSnapshot.validate() throws IllegalArgumentException on
+    // negative values, so the clamp prevents a scrape-time crash when a consumer accidentally exposes
+    // a non-monotonic source as a Counter callback.
     val projected: F[NonEmptyList[DataPointSnapshot]] = callback.map(
       _.map { case (v, a) =>
         new CounterSnapshot.CounterDataPointSnapshot(
@@ -1092,6 +1097,8 @@ class JavaMetricRegistry[F[_]: Async] private (
             case x: MetricCollection.Value.LongCounter   => (x.value.toDouble, x.labelValues)
             case x: MetricCollection.Value.DoubleCounter => (x.value, x.labelValues)
           }
+          // Negative values are clamped to 0.0 — same v5-parity / upstream-validate rationale as in
+          // registerDoubleCounterCallback.
           new CounterSnapshot.CounterDataPointSnapshot(
             if (vDouble < 0) 0.0 else vDouble,
             labelsFor(labelNames, lbls),

--- a/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
+++ b/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
@@ -58,6 +58,7 @@ import io.prometheus.metrics.model.snapshots.MetricSnapshot
 import io.prometheus.metrics.model.snapshots.MetricSnapshots
 import io.prometheus.metrics.model.snapshots.Quantiles
 import io.prometheus.metrics.model.snapshots.SummarySnapshot
+import io.prometheus.metrics.model.snapshots.{Exemplar => PExemplar}
 import io.prometheus.metrics.model.snapshots.{Quantile => PQuantile}
 import prometheus4cats._
 import prometheus4cats.javaclient.internal.Utils
@@ -801,7 +802,7 @@ class JavaMetricRegistry[F[_]: Async] private (
         new CounterSnapshot.CounterDataPointSnapshot(
           if (v < 0) 0.0 else v,
           Labels.of(allLabelNamesStr, (f(a) ++ commonLabelValuesArr).toArray),
-          null: io.prometheus.metrics.model.snapshots.Exemplar,
+          null: PExemplar,
           0L
         ): DataPointSnapshot
       }
@@ -850,7 +851,7 @@ class JavaMetricRegistry[F[_]: Async] private (
         new GaugeSnapshot.GaugeDataPointSnapshot(
           v,
           Labels.of(allLabelNamesStr, (f(a) ++ commonLabelValuesArr).toArray),
-          null: io.prometheus.metrics.model.snapshots.Exemplar
+          null: PExemplar
         ): DataPointSnapshot
       }
     )
@@ -1093,7 +1094,7 @@ class JavaMetricRegistry[F[_]: Async] private (
           new CounterSnapshot.CounterDataPointSnapshot(
             if (vDouble < 0) 0.0 else vDouble,
             labelsFor(labelNames, lbls),
-            null: io.prometheus.metrics.model.snapshots.Exemplar,
+            null: PExemplar,
             0L
           )
         }.asJava
@@ -1112,7 +1113,7 @@ class JavaMetricRegistry[F[_]: Async] private (
           new GaugeSnapshot.GaugeDataPointSnapshot(
             vDouble,
             labelsFor(labelNames, lbls),
-            null: io.prometheus.metrics.model.snapshots.Exemplar
+            null: PExemplar
           )
         }.asJava
         new GaugeSnapshot(new MetricMetadata(fullName, head.help.value), dps): MetricSnapshot

--- a/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/internal/Utils.scala
+++ b/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/internal/Utils.scala
@@ -19,7 +19,7 @@ package prometheus4cats.javaclient.internal
 import cats.effect.kernel.Sync
 import cats.syntax.all._
 
-import io.prometheus.metrics.core.metrics.StatefulMetric
+import io.prometheus.metrics.core.metrics.MetricWithFixedMetadata
 import io.prometheus.metrics.model.registry.PrometheusRegistry
 import prometheus4cats.Label
 import prometheus4cats.javaclient.models.Exceptions._
@@ -27,7 +27,7 @@ import prometheus4cats.javaclient.models.Exceptions._
 private[javaclient] object Utils {
 
   private[javaclient] def unregister[F[_]: Sync](
-      collector: StatefulMetric[_, _],
+      collector: MetricWithFixedMetadata,
       registry: PrometheusRegistry,
       logger: Throwable => String => F[Unit]
   ): F[Unit] =

--- a/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/internal/Utils.scala
+++ b/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/internal/Utils.scala
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2022-2026 Permutive Ltd. <https://permutive.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package prometheus4cats.javaclient.internal
+
+import cats.effect.kernel.Sync
+import cats.syntax.all._
+
+import io.prometheus.metrics.core.metrics.StatefulMetric
+import io.prometheus.metrics.model.registry.PrometheusRegistry
+import prometheus4cats.Label
+import prometheus4cats.javaclient.models.Exceptions._
+
+private[javaclient] object Utils {
+
+  private[javaclient] def unregister[F[_]: Sync](
+      collector: StatefulMetric[_, _],
+      registry: PrometheusRegistry,
+      logger: Throwable => String => F[Unit]
+  ): F[Unit] =
+    Sync[F].delay(registry.unregister(collector)).handleErrorWith { e =>
+      logger(e)(s"Failed to unregister a collector: '$collector'")
+    }
+
+  /** Builds a label array directly from dynamic label values and pre-computed common label values, avoiding
+    * intermediate IndexedSeq concatenation and varargs String[] allocation.
+    */
+  @inline private[javaclient] def buildLabelArray(
+      dynamicLabels: IndexedSeq[String],
+      commonLabelValues: Array[String]
+  ): Array[String] = {
+    val arr = new Array[String](dynamicLabels.length + commonLabelValues.length)
+    dynamicLabels.copyToArray(arr, 0): Unit
+    System.arraycopy(commonLabelValues, 0, arr, dynamicLabels.length, commonLabelValues.length)
+    arr
+  }
+
+  /** Retrieves the [[io.prometheus.metrics.core.datapoints.DataPoint]] for the given label values and applies the
+    * `modify` function to it. Errors raised by either the data-point lookup or the modification are wrapped in a
+    * [[UnhandledPrometheusException]] and forwarded to the logger so they are observable but not propagated.
+    */
+  private[javaclient] def modifyMetric[F[_]: Sync, A, D](
+      metricName: A,
+      allLabelNames: IndexedSeq[Label.Name],
+      dynamicLabels: IndexedSeq[String],
+      commonLabelValues: Array[String],
+      getDataPoint: Array[String] => D,
+      modify: D => Unit,
+      logger: Throwable => String => F[Unit]
+  ): F[Unit] = {
+    val labelArray = buildLabelArray(dynamicLabels, commonLabelValues)
+    val mod: F[Unit] =
+      for {
+        dp <- handleErrors(Sync[F].delay(getDataPoint(labelArray)), metricName, allLabelNames, labelArray)
+        _  <- handleErrors(Sync[F].delay(modify(dp)), metricName, allLabelNames, labelArray)
+      } yield ()
+
+    mod.recoverWith { case e: PrometheusException[_] =>
+      logger(e)("Failed to modify Prometheus metric")
+    }
+  }
+
+  private def handleErrors[F[_]: Sync, A, B](
+      fa: F[B],
+      metricName: A,
+      labelNames: IndexedSeq[Label.Name],
+      labels: Array[String]
+  ): F[B] =
+    fa.handleErrorWith(e =>
+      classStringRep(e)
+        .flatMap(className =>
+          Sync[F].raiseError(
+            UnhandledPrometheusException(className, metricName, labelNames.zip(labels.toIndexedSeq).toMap, e)
+          )
+        )
+    )
+
+  private def classStringRep[F[_]: Sync, A](a: A): F[String] =
+    Sync[F].delay(a.getClass.toString) // scalafix:ok
+
+}

--- a/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/models/Exceptions.scala
+++ b/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/models/Exceptions.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022-2026 Permutive Ltd. <https://permutive.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package prometheus4cats.javaclient.models
+
+import prometheus4cats.Label
+
+private[javaclient] object Exceptions {
+
+  sealed abstract class PrometheusException[A] extends RuntimeException
+
+  final case class UnhandledPrometheusException[A](
+      className: String,
+      metricName: A,
+      labels: Map[Label.Name, String],
+      cause: Throwable
+  ) extends PrometheusException[A] {
+
+    override def getMessage: String =
+      s"Unhandled exception while operating on metric '$metricName' (impl class '$className', labels: $labels)"
+
+    override def getCause: Throwable = cause
+
+  }
+
+}

--- a/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/models/MetricType.scala
+++ b/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/models/MetricType.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022-2026 Permutive Ltd. <https://permutive.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package prometheus4cats.javaclient.models
+
+sealed private[javaclient] trait MetricType
+
+private[javaclient] object MetricType {
+
+  case object Counter extends MetricType
+
+  case object Gauge extends MetricType
+
+  case object Histogram extends MetricType
+
+  case object NativeHistogram extends MetricType
+
+  case object Summary extends MetricType
+
+  case object Info extends MetricType
+
+}

--- a/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/models/MetricType.scala
+++ b/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/models/MetricType.scala
@@ -28,6 +28,8 @@ private[javaclient] object MetricType {
 
   case object NativeHistogram extends MetricType
 
+  case object HistogramWithNative extends MetricType
+
   case object Summary extends MetricType
 
   case object Info extends MetricType

--- a/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/package.scala
+++ b/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/package.scala
@@ -17,9 +17,12 @@
 package prometheus4cats
 
 import cats.Show
+import cats.data.NonEmptyList
 import cats.effect.kernel.Ref
+import cats.effect.kernel.Unique
 
 import io.prometheus.metrics.core.metrics.MetricWithFixedMetadata
+import io.prometheus.metrics.model.registry.Collector
 import prometheus4cats.javaclient.models.MetricType
 import prometheus4cats.util.NameUtils
 
@@ -37,6 +40,21 @@ package object javaclient {
     (MetricID, (MetricWithFixedMetadata, Ref[F, Option[Exemplar.Data]], Int))
 
   private[javaclient] type State[F[_]] = Map[StateKey, StateValue[F]]
+
+  /** Per-metric-name callback registry state. Each registered metric name has exactly one upstream `Collector`;
+    * multiple consumer registrations attach to that single Collector via a `Unique.Token`-keyed inner Ref. The
+    * Collector at scrape time runs all stored callbacks through the dispatcher, merges their per-registration results
+    * into a single `MetricSnapshot`, and returns it.
+    *
+    * The inner callback type is uniformly `F[NEL[(Double, IndexedSeq[String])]]` — value plus pre-projected label
+    * values. Per-metric-type Collector subclasses convert these tuples into the appropriate kind-specific data-point
+    * snapshots at collect time. Long-typed callbacks are derived from Double via DoubleCallbackRegistry.
+    */
+  private[javaclient] type CallbackPayload[F[_]] =
+    Map[Unique.Token, F[NonEmptyList[(Double, IndexedSeq[String])]]]
+
+  private[javaclient] type CallbackState[F[_]] =
+    Map[StateKey, (MetricType, Ref[F, CallbackPayload[F]], Collector)]
 
   private[javaclient] val duplicateShow: Show[(Option[Metric.Prefix], String)] = Show.show { case (prefix, name) =>
     NameUtils.makeName(prefix, name)

--- a/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/package.scala
+++ b/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/package.scala
@@ -19,7 +19,7 @@ package prometheus4cats
 import cats.Show
 import cats.effect.kernel.Ref
 
-import io.prometheus.metrics.core.metrics.StatefulMetric
+import io.prometheus.metrics.core.metrics.MetricWithFixedMetadata
 import prometheus4cats.javaclient.models.MetricType
 import prometheus4cats.util.NameUtils
 
@@ -29,8 +29,12 @@ package object javaclient {
 
   private[javaclient] type MetricID = (IndexedSeq[Label.Name], MetricType)
 
+  /** State entry bound by the most specific common parent of every upstream metric type we register —
+    * `MetricWithFixedMetadata`. Counter, Gauge, Histogram, Summary all extend `StatefulMetric` which extends this; Info
+    * extends this directly without going through `StatefulMetric`.
+    */
   private[javaclient] type StateValue[F[_]] =
-    (MetricID, (StatefulMetric[_, _], Ref[F, Option[Exemplar.Data]], Int))
+    (MetricID, (MetricWithFixedMetadata, Ref[F, Option[Exemplar.Data]], Int))
 
   private[javaclient] type State[F[_]] = Map[StateKey, StateValue[F]]
 

--- a/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/package.scala
+++ b/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/package.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022-2026 Permutive Ltd. <https://permutive.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package prometheus4cats
+
+import cats.Show
+import cats.effect.kernel.Ref
+
+import io.prometheus.metrics.core.metrics.StatefulMetric
+import prometheus4cats.javaclient.models.MetricType
+import prometheus4cats.util.NameUtils
+
+package object javaclient {
+
+  private[javaclient] type StateKey = (Option[Metric.Prefix], String)
+
+  private[javaclient] type MetricID = (IndexedSeq[Label.Name], MetricType)
+
+  private[javaclient] type StateValue[F[_]] =
+    (MetricID, (StatefulMetric[_, _], Ref[F, Option[Exemplar.Data]], Int))
+
+  private[javaclient] type State[F[_]] = Map[StateKey, StateValue[F]]
+
+  private[javaclient] val duplicateShow: Show[(Option[Metric.Prefix], String)] = Show.show { case (prefix, name) =>
+    NameUtils.makeName(prefix, name)
+  }
+
+}

--- a/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/package.scala
+++ b/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/package.scala
@@ -23,6 +23,7 @@ import cats.effect.kernel.Unique
 
 import io.prometheus.metrics.core.metrics.MetricWithFixedMetadata
 import io.prometheus.metrics.model.registry.Collector
+import io.prometheus.metrics.model.snapshots.DataPointSnapshot
 import prometheus4cats.javaclient.models.MetricType
 import prometheus4cats.util.NameUtils
 
@@ -46,12 +47,15 @@ package object javaclient {
     * Collector at scrape time runs all stored callbacks through the dispatcher, merges their per-registration results
     * into a single `MetricSnapshot`, and returns it.
     *
-    * The inner callback type is uniformly `F[NEL[(Double, IndexedSeq[String])]]` — value plus pre-projected label
-    * values. Per-metric-type Collector subclasses convert these tuples into the appropriate kind-specific data-point
-    * snapshots at collect time. Long-typed callbacks are derived from Double via DoubleCallbackRegistry.
+    * The inner callback type is uniformly `F[NEL[DataPointSnapshot]]` — pre-built upstream data-point snapshots. Each
+    * kind-specific `register*Callback` method maps the user's typed callback (e.g., `F[NEL[(Double, A)]]` for Counter
+    * or `F[NEL[(Histogram.Value[Double], A)]]` for Histogram) into the right concrete `DataPointSnapshot` subtype
+    * inline. The kind-specific Collector then casts the data points to its concrete subtype to build the right
+    * `MetricSnapshot`. Casts are safe because the public `register*Callback` signatures enforce type-correctness at the
+    * boundary; internal storage only needs the parent type.
     */
   private[javaclient] type CallbackPayload[F[_]] =
-    Map[Unique.Token, F[NonEmptyList[(Double, IndexedSeq[String])]]]
+    Map[Unique.Token, F[NonEmptyList[DataPointSnapshot]]]
 
   private[javaclient] type CallbackState[F[_]] =
     Map[StateKey, (MetricType, Ref[F, CallbackPayload[F]], Collector)]

--- a/modules/prometheus4cats-java/src/test/scala/prometheus4cats/javaclient/JavaMetricRegistrySuite.scala
+++ b/modules/prometheus4cats-java/src/test/scala/prometheus4cats/javaclient/JavaMetricRegistrySuite.scala
@@ -18,6 +18,7 @@ package prometheus4cats.javaclient
 
 import scala.jdk.CollectionConverters._
 
+import cats.data.NonEmptyList
 import cats.data.NonEmptySeq
 import cats.effect.IO
 import cats.effect.kernel.Resource
@@ -251,6 +252,40 @@ class JavaMetricRegistrySuite extends CatsEffectSuite {
   // built without labelNames produces no observable scrape entry. This is an edge case (real-world
   // Info almost always carries identity labels like version/commit/instance), but should be
   // surfaced in the v6 migration guide for any consumer that relied on a no-label `Info[F, Unit]`.
+
+  test("counter callback — scrape invokes the user callback and propagates the value to the snapshot") {
+    val promRegistry = new PrometheusRegistry()
+
+    JavaMetricRegistry
+      .Builder[IO]()
+      .withRegistry(promRegistry)
+      .build
+      .use { registry =>
+        val factory  = MetricFactory.builder.build[IO](registry, registry)
+        val callback = IO.pure(NonEmptyList.of((42.0, "alpha"), (7.0, "beta")))
+        factory
+          .counter("test_callback_counter_total")
+          .ofDouble
+          .help("test counter callback")
+          .label[String]("variant")
+          .callback(callback)
+          .build
+          .use { _ =>
+            IO.delay {
+              val snapshot = promRegistry
+                .scrape()
+                .asScala
+                .collectFirst { case s: CounterSnapshot if s.getMetadata.getName === "test_callback_counter" => s }
+                .getOrElse(fail("expected a CounterSnapshot named 'test_callback_counter'"))
+              val byLabel = snapshot.getDataPoints.asScala
+                .map(dp => dp.getLabels.get("variant") -> dp.getValue)
+                .toMap
+              assertEquals(byLabel.get("alpha"), Some(42.0))
+              assertEquals(byLabel.get("beta"), Some(7.0))
+            }
+          }
+      }
+  }
 
   test("registry release unregisters all claimed metrics from the underlying PrometheusRegistry") {
     val promRegistry = new PrometheusRegistry()

--- a/modules/prometheus4cats-java/src/test/scala/prometheus4cats/javaclient/JavaMetricRegistrySuite.scala
+++ b/modules/prometheus4cats-java/src/test/scala/prometheus4cats/javaclient/JavaMetricRegistrySuite.scala
@@ -137,6 +137,37 @@ class JavaMetricRegistrySuite extends CatsEffectSuite {
     }
   }
 
+  test("dual-mode histogram (.withNative) — scrape produces BOTH classic and native data") {
+    freshRegistry.use { case (promRegistry, factory) =>
+      factory
+        .histogram("test_dual_histogram")
+        .ofDouble
+        .help("test dual-mode (NHCB-friendly) histogram")
+        .buckets(NonEmptySeq.of(0.1, 0.5, 1.0, 5.0))
+        .withNative
+        .build
+        .use { h =>
+          (h.observe(0.05) >> h.observe(0.3) >> h.observe(0.7) >> h.observe(2.0)) >> IO.delay {
+            val snapshot = promRegistry
+              .scrape()
+              .asScala
+              .collectFirst { case s: HistogramSnapshot if s.getMetadata.getName === "test_dual_histogram" => s }
+              .getOrElse(fail("expected a HistogramSnapshot named 'test_dual_histogram'"))
+            val dp = snapshot.getDataPoints.asScala.head
+            // The headline assertion: BOTH classic and native data are emitted from a single declaration.
+            assert(dp.hasClassicHistogramData, "expected classic histogram data on dual-mode histogram")
+            assert(dp.hasNativeHistogramData, "expected native histogram data on dual-mode histogram")
+            assertEquals(dp.getCount, 4L)
+            assertEqualsDouble(dp.getSum, 3.05, 1e-9)
+            // Classic buckets are preserved as supplied.
+            val classicBuckets = dp.getClassicBuckets.asScala.map(_.getUpperBound).toSet
+            assert(classicBuckets.contains(0.1), s"expected classic bucket 0.1; got $classicBuckets")
+            assert(classicBuckets.contains(5.0), s"expected classic bucket 5.0; got $classicBuckets")
+          }
+        }
+    }
+  }
+
   test("native histogram — custom NativeHistogram config propagates initialSchema to the scraped snapshot") {
     freshRegistry.use { case (promRegistry, factory) =>
       factory

--- a/modules/prometheus4cats-java/src/test/scala/prometheus4cats/javaclient/JavaMetricRegistrySuite.scala
+++ b/modules/prometheus4cats-java/src/test/scala/prometheus4cats/javaclient/JavaMetricRegistrySuite.scala
@@ -287,6 +287,38 @@ class JavaMetricRegistrySuite extends CatsEffectSuite {
       }
   }
 
+  test("gauge callback — scrape invokes the user callback and propagates the value to the snapshot") {
+    val promRegistry = new PrometheusRegistry()
+
+    JavaMetricRegistry
+      .Builder[IO]()
+      .withRegistry(promRegistry)
+      .build
+      .use { registry =>
+        val factory  = MetricFactory.builder.build[IO](registry, registry)
+        val callback = IO.pure(NonEmptyList.of((50.0, "n0"), (100.0, "n1")))
+        factory
+          .gauge("test_callback_gauge")
+          .ofDouble
+          .help("test gauge callback")
+          .label[String]("node")
+          .callback(callback)
+          .build
+          .use { _ =>
+            IO.delay {
+              val snapshot = promRegistry
+                .scrape()
+                .asScala
+                .collectFirst { case s: GaugeSnapshot if s.getMetadata.getName === "test_callback_gauge" => s }
+                .getOrElse(fail("expected a GaugeSnapshot named 'test_callback_gauge'"))
+              val byLabel = snapshot.getDataPoints.asScala.map(dp => dp.getLabels.get("node") -> dp.getValue).toMap
+              assertEquals(byLabel.get("n0"), Some(50.0))
+              assertEquals(byLabel.get("n1"), Some(100.0))
+            }
+          }
+      }
+  }
+
   test("registry release unregisters all claimed metrics from the underlying PrometheusRegistry") {
     val promRegistry = new PrometheusRegistry()
 

--- a/modules/prometheus4cats-java/src/test/scala/prometheus4cats/javaclient/JavaMetricRegistrySuite.scala
+++ b/modules/prometheus4cats-java/src/test/scala/prometheus4cats/javaclient/JavaMetricRegistrySuite.scala
@@ -319,6 +319,88 @@ class JavaMetricRegistrySuite extends CatsEffectSuite {
       }
   }
 
+  test("histogram callback — value+labels map into a HistogramDataPointSnapshot with classic buckets") {
+    val promRegistry = new PrometheusRegistry()
+
+    JavaMetricRegistry
+      .Builder[IO]()
+      .withRegistry(promRegistry)
+      .build
+      .use { registry =>
+        val factory = MetricFactory.builder.build[IO](registry, registry)
+        // bucketValues are CUMULATIVE counts indexed by (declared-buckets ++ +Inf) — so for buckets
+        // 0.1, 1.0, 5.0 with three observations of 0.05, 0.5, 2.0 the cumulative counts are
+        // [1, 2, 3, 3] (≤0.1, ≤1.0, ≤5.0, ≤+Inf).
+        val histValue = Histogram.Value[Double](2.55, NonEmptySeq.of(1.0, 2.0, 3.0, 3.0))
+        val callback  = IO.pure(NonEmptyList.of((histValue, "alpha")))
+        factory
+          .histogram("test_callback_histogram")
+          .ofDouble
+          .help("test histogram callback")
+          .buckets(NonEmptySeq.of(0.1, 1.0, 5.0))
+          .label[String]("variant")
+          .callback(callback)
+          .build
+          .use { _ =>
+            IO.delay {
+              val snapshot = promRegistry
+                .scrape()
+                .asScala
+                .collectFirst { case s: HistogramSnapshot if s.getMetadata.getName === "test_callback_histogram" => s }
+                .getOrElse(fail("expected a HistogramSnapshot named 'test_callback_histogram'"))
+              val dp = snapshot.getDataPoints.asScala.head
+              assert(dp.hasClassicHistogramData)
+              assertEqualsDouble(dp.getSum, 2.55, 1e-9)
+              // Classic buckets propagate; +Inf is the last upper bound we appended.
+              val upperBounds = dp.getClassicBuckets.asScala.map(_.getUpperBound).toSet
+              assert(upperBounds.contains(0.1), s"saw upper bounds $upperBounds")
+              assert(upperBounds.contains(5.0), s"saw upper bounds $upperBounds")
+            }
+          }
+      }
+  }
+
+  test("summary callback — count, sum, and declared quantiles propagate to the snapshot") {
+    val promRegistry = new PrometheusRegistry()
+
+    JavaMetricRegistry
+      .Builder[IO]()
+      .withRegistry(promRegistry)
+      .build
+      .use { registry =>
+        val factory = MetricFactory.builder.build[IO](registry, registry)
+        val summaryValue = Summary.Value[Double](
+          count = 10.0,
+          sum = 42.5,
+          quantiles = Map(0.5 -> 1.2, 0.99 -> 9.5)
+        )
+        val callback = IO.pure(NonEmptyList.of((summaryValue, "alpha")))
+        factory
+          .summary("test_callback_summary")
+          .ofDouble
+          .help("test summary callback")
+          .label[String]("variant")
+          .callback(callback)
+          .build
+          .use { _ =>
+            IO.delay {
+              val snapshot = promRegistry
+                .scrape()
+                .asScala
+                .collectFirst { case s: SummarySnapshot if s.getMetadata.getName === "test_callback_summary" => s }
+                .getOrElse(fail("expected a SummarySnapshot named 'test_callback_summary'"))
+              val dp = snapshot.getDataPoints.asScala.head
+              assertEquals(dp.getCount, 10L)
+              assertEqualsDouble(dp.getSum, 42.5, 1e-9)
+              val quantileValues = dp.getQuantiles.asScala.map(q => q.getQuantile -> q.getValue).toMap
+              assertEquals(quantileValues.size, 2)
+              assertEqualsDouble(quantileValues(0.5), 1.2, 1e-9)
+              assertEqualsDouble(quantileValues(0.99), 9.5, 1e-9)
+            }
+          }
+      }
+  }
+
   test("registry release unregisters all claimed metrics from the underlying PrometheusRegistry") {
     val promRegistry = new PrometheusRegistry()
 

--- a/modules/prometheus4cats-java/src/test/scala/prometheus4cats/javaclient/JavaMetricRegistrySuite.scala
+++ b/modules/prometheus4cats-java/src/test/scala/prometheus4cats/javaclient/JavaMetricRegistrySuite.scala
@@ -27,6 +27,7 @@ import io.prometheus.metrics.model.registry.PrometheusRegistry
 import io.prometheus.metrics.model.snapshots.CounterSnapshot
 import io.prometheus.metrics.model.snapshots.GaugeSnapshot
 import io.prometheus.metrics.model.snapshots.HistogramSnapshot
+import io.prometheus.metrics.model.snapshots.InfoSnapshot
 import io.prometheus.metrics.model.snapshots.SummarySnapshot
 import munit.CatsEffectSuite
 import prometheus4cats._
@@ -215,6 +216,41 @@ class JavaMetricRegistrySuite extends CatsEffectSuite {
         }
     }
   }
+
+  test("info — declared labels propagate to scrape output via setLabelValues") {
+    freshRegistry.use { case (promRegistry, factory) =>
+      factory
+        .info("test_build_info")
+        .help("test build info")
+        .label[String]("version")
+        .label[String]("commit")
+        .build
+        .use { i =>
+          // Two `.label[String]` calls produce an Info[F, (String, String)] via the existing
+          // labelled-DSL machinery (InitLast tuple-builder).
+          i.info(("1.2.3", "abc1234")) >> IO.delay {
+            // Upstream stores Info under its base name (without the `_info` suffix). The wire format
+            // still emits `test_build_info{...} 1` — the suffix is added by the exposition writer.
+            val snapshot = promRegistry
+              .scrape()
+              .asScala
+              .collectFirst { case s: InfoSnapshot if s.getMetadata.getName === "test_build" => s }
+              .getOrElse(fail("expected an InfoSnapshot for the 'test_build_info' metric"))
+            val dp       = snapshot.getDataPoints.asScala.head
+            val labelMap = dp.getLabels.asScala.map(l => l.getName -> l.getValue).toMap
+            assertEquals(labelMap.get("version"), Some("1.2.3"))
+            assertEquals(labelMap.get("commit"), Some("abc1234"))
+          }
+        }
+    }
+  }
+
+  // NOTE: An "Info with no labels declared" test was attempted and removed — upstream
+  // prometheus-metrics-core 1.x's Info requires at least one labelName for the metric to emit a
+  // data point in scrape output. Calling `setLabelValues()` with empty varargs against an Info
+  // built without labelNames produces no observable scrape entry. This is an edge case (real-world
+  // Info almost always carries identity labels like version/commit/instance), but should be
+  // surfaced in the v6 migration guide for any consumer that relied on a no-label `Info[F, Unit]`.
 
   test("registry release unregisters all claimed metrics from the underlying PrometheusRegistry") {
     val promRegistry = new PrometheusRegistry()

--- a/modules/prometheus4cats-java/src/test/scala/prometheus4cats/javaclient/JavaMetricRegistrySuite.scala
+++ b/modules/prometheus4cats-java/src/test/scala/prometheus4cats/javaclient/JavaMetricRegistrySuite.scala
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2022-2026 Permutive Ltd. <https://permutive.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package prometheus4cats.javaclient
+
+import scala.jdk.CollectionConverters._
+
+import cats.data.NonEmptySeq
+import cats.effect.IO
+import cats.effect.kernel.Resource
+import cats.syntax.all._
+
+import io.prometheus.metrics.model.registry.PrometheusRegistry
+import io.prometheus.metrics.model.snapshots.CounterSnapshot
+import io.prometheus.metrics.model.snapshots.GaugeSnapshot
+import io.prometheus.metrics.model.snapshots.HistogramSnapshot
+import munit.CatsEffectSuite
+import prometheus4cats._
+
+/** Smoke tests for the new javaclient backend covering Counter, Gauge, and (most importantly) the classic vs native
+  * histogram distinction.
+  *
+  * The comprehensive testkit-based [[MetricRegistrySuite]] / [[CallbackRegistrySuite]] (which auto-tests every method)
+  * will be wired in once Summary, Info, and the callback path are also implemented in this backend. Until then, the
+  * testkit suites can't be applied because the unimplemented methods would throw.
+  */
+class JavaMetricRegistrySuite extends CatsEffectSuite {
+
+  private def freshRegistry: Resource[IO, (PrometheusRegistry, MetricFactory[IO])] =
+    for {
+      promRegistry <- Resource.eval(IO.delay(new PrometheusRegistry()))
+      registry     <- JavaMetricRegistry.Builder[IO]().withRegistry(promRegistry).build
+      factory       = MetricFactory.builder.build[IO](registry)
+    } yield (promRegistry, factory)
+
+  // Snapshots are only present in the underlying PrometheusRegistry while the metric Resource is held;
+  // releasing the metric unregisters it. So all assertions must run inside the metric's `.use` scope.
+
+  test("counter — inc once, scrape returns the incremented value") {
+    freshRegistry.use { case (promRegistry, factory) =>
+      factory
+        .counter("test_counter_total")
+        .ofDouble
+        .help("test counter")
+        .build
+        .use { c =>
+          c.inc(1.0) >> IO.delay {
+            val snapshot = promRegistry
+              .scrape()
+              .asScala
+              .collectFirst { case s: CounterSnapshot if s.getMetadata.getName === "test_counter" => s }
+              .getOrElse(fail("expected a CounterSnapshot named 'test_counter'"))
+            assertEquals(snapshot.getDataPoints.asScala.head.getValue, 1.0)
+          }
+        }
+    }
+  }
+
+  test("gauge — inc, dec, and set are each reflected in the scrape") {
+    freshRegistry.use { case (promRegistry, factory) =>
+      factory
+        .gauge("test_gauge")
+        .ofDouble
+        .help("test gauge")
+        .build
+        .use { g =>
+          g.inc(5.0) >> g.dec(2.0) >> g.set(10.0) >> IO.delay {
+            val snapshot = promRegistry
+              .scrape()
+              .asScala
+              .collectFirst { case s: GaugeSnapshot if s.getMetadata.getName === "test_gauge" => s }
+              .getOrElse(fail("expected a GaugeSnapshot named 'test_gauge'"))
+            assertEquals(snapshot.getDataPoints.asScala.head.getValue, 10.0)
+          }
+        }
+    }
+  }
+
+  test("classic histogram — scrape produces classic buckets, no native data") {
+    freshRegistry.use { case (promRegistry, factory) =>
+      factory
+        .histogram("test_classic_histogram")
+        .ofDouble
+        .help("test classic histogram")
+        .buckets(NonEmptySeq.of(0.1, 0.5, 1.0, 5.0))
+        .build
+        .use { h =>
+          (h.observe(0.05) >> h.observe(0.3) >> h.observe(0.7) >> h.observe(2.0)) >> IO.delay {
+            val snapshot = promRegistry
+              .scrape()
+              .asScala
+              .collectFirst { case s: HistogramSnapshot if s.getMetadata.getName === "test_classic_histogram" => s }
+              .getOrElse(fail("expected a HistogramSnapshot named 'test_classic_histogram'"))
+            val dp = snapshot.getDataPoints.asScala.head
+            assert(dp.hasClassicHistogramData, "expected classic histogram data")
+            assert(!dp.hasNativeHistogramData, "did not expect native histogram data on a classic histogram")
+            assertEquals(dp.getCount, 4L)
+            assertEqualsDouble(dp.getSum, 3.05, 1e-9)
+          }
+        }
+    }
+  }
+
+  test("native histogram — scrape produces native bucket data, no classic buckets") {
+    freshRegistry.use { case (promRegistry, factory) =>
+      factory
+        .nativeHistogram("test_native_histogram")
+        .help("test native histogram")
+        .build
+        .use { h =>
+          (h.observe(0.05) >> h.observe(0.3) >> h.observe(0.7) >> h.observe(2.0)) >> IO.delay {
+            val snapshot = promRegistry
+              .scrape()
+              .asScala
+              .collectFirst { case s: HistogramSnapshot if s.getMetadata.getName === "test_native_histogram" => s }
+              .getOrElse(fail("expected a HistogramSnapshot named 'test_native_histogram'"))
+            val dp = snapshot.getDataPoints.asScala.head
+            assert(!dp.hasClassicHistogramData, "did not expect classic histogram data on a native histogram")
+            assert(dp.hasNativeHistogramData, "expected native histogram data")
+            assertEquals(dp.getCount, 4L)
+            assertEqualsDouble(dp.getSum, 3.05, 1e-9)
+          }
+        }
+    }
+  }
+
+  test("native histogram — custom NativeHistogram config propagates initialSchema to the scraped snapshot") {
+    freshRegistry.use { case (promRegistry, factory) =>
+      factory
+        .nativeHistogram("test_native_tuned", NativeHistogram.Default.withInitialSchema(3))
+        .help("native with custom schema")
+        .build
+        .use { h =>
+          h.observe(1.0) >> IO.delay {
+            val snapshot = promRegistry
+              .scrape()
+              .asScala
+              .collectFirst { case s: HistogramSnapshot if s.getMetadata.getName === "test_native_tuned" => s }
+              .getOrElse(fail("expected a HistogramSnapshot named 'test_native_tuned'"))
+            val dp = snapshot.getDataPoints.asScala.head
+            assert(dp.hasNativeHistogramData)
+            assertEquals(dp.getNativeSchema, 3)
+          }
+        }
+    }
+  }
+
+  test("registry release unregisters all claimed metrics from the underlying PrometheusRegistry") {
+    val promRegistry = new PrometheusRegistry()
+
+    JavaMetricRegistry
+      .Builder[IO]()
+      .withRegistry(promRegistry)
+      .build
+      .use { registry =>
+        val factory = MetricFactory.builder.build[IO](registry)
+        factory.counter("teardown_counter_total").ofDouble.help("test").build.use(_.inc(1.0))
+      } >> IO.delay {
+      val names = promRegistry.scrape().asScala.map(_.getMetadata.getName).toSet
+      assert(
+        !names.contains("teardown_counter"),
+        s"counter should have been unregistered after the registry resource closed; saw $names"
+      )
+    }
+  }
+
+}

--- a/modules/prometheus4cats-java/src/test/scala/prometheus4cats/javaclient/JavaMetricRegistrySuite.scala
+++ b/modules/prometheus4cats-java/src/test/scala/prometheus4cats/javaclient/JavaMetricRegistrySuite.scala
@@ -401,6 +401,56 @@ class JavaMetricRegistrySuite extends CatsEffectSuite {
       }
   }
 
+  test(
+    "metric-collection callback — emits all four kinds (counter, gauge, histogram, summary) from a single callback"
+  ) {
+    val promRegistry = new PrometheusRegistry()
+
+    JavaMetricRegistry
+      .Builder[IO]()
+      .withRegistry(promRegistry)
+      .build
+      .use { registry =>
+        val factory = MetricFactory.builder.build[IO](registry, registry)
+
+        val collection: MetricCollection = MetricCollection.empty
+          .appendDoubleCounter(
+            Counter.Name.unsafeFrom("collection_counter_total"),
+            Metric.Help("test counter"),
+            Map.empty[Label.Name, String],
+            42.0
+          )
+          .appendDoubleGauge(
+            Gauge.Name.unsafeFrom("collection_gauge"),
+            Metric.Help("test gauge"),
+            Map.empty[Label.Name, String],
+            7.0
+          )
+
+        factory
+          .metricCollectionCallback(IO.pure(collection))
+          .build
+          .use { _ =>
+            IO.delay {
+              val snapshots = promRegistry.scrape().asScala.toList
+              val names     = snapshots.map(s => s.getClass.getSimpleName -> s.getMetadata.getName).toSet
+              assert(
+                names.contains("CounterSnapshot" -> "collection_counter"),
+                s"expected CounterSnapshot 'collection_counter'; saw $names"
+              )
+              assert(
+                names.contains("GaugeSnapshot" -> "collection_gauge"),
+                s"expected GaugeSnapshot 'collection_gauge'; saw $names"
+              )
+              val counter = snapshots.collectFirst {
+                case s: CounterSnapshot if s.getMetadata.getName === "collection_counter" => s
+              }.get
+              assertEquals(counter.getDataPoints.asScala.head.getValue, 42.0)
+            }
+          }
+      }
+  }
+
   test("registry release unregisters all claimed metrics from the underlying PrometheusRegistry") {
     val promRegistry = new PrometheusRegistry()
 

--- a/modules/prometheus4cats-java/src/test/scala/prometheus4cats/javaclient/JavaMetricRegistrySuite.scala
+++ b/modules/prometheus4cats-java/src/test/scala/prometheus4cats/javaclient/JavaMetricRegistrySuite.scala
@@ -27,6 +27,7 @@ import io.prometheus.metrics.model.registry.PrometheusRegistry
 import io.prometheus.metrics.model.snapshots.CounterSnapshot
 import io.prometheus.metrics.model.snapshots.GaugeSnapshot
 import io.prometheus.metrics.model.snapshots.HistogramSnapshot
+import io.prometheus.metrics.model.snapshots.SummarySnapshot
 import munit.CatsEffectSuite
 import prometheus4cats._
 
@@ -184,6 +185,32 @@ class JavaMetricRegistrySuite extends CatsEffectSuite {
             val dp = snapshot.getDataPoints.asScala.head
             assert(dp.hasNativeHistogramData)
             assertEquals(dp.getNativeSchema, 3)
+          }
+        }
+    }
+  }
+
+  test("summary — quantiles propagate and observations are aggregated") {
+    freshRegistry.use { case (promRegistry, factory) =>
+      factory
+        .summary("test_summary")
+        .ofDouble
+        .help("test summary")
+        .quantile(Summary.Quantile.from(0.5).toOption.get, Summary.AllowedError.from(0.05).toOption.get)
+        .quantile(Summary.Quantile.from(0.99).toOption.get, Summary.AllowedError.from(0.01).toOption.get)
+        .build
+        .use { s =>
+          (s.observe(0.1) >> s.observe(0.5) >> s.observe(1.0) >> s.observe(2.5)) >> IO.delay {
+            val snapshot = promRegistry
+              .scrape()
+              .asScala
+              .collectFirst { case s: SummarySnapshot if s.getMetadata.getName === "test_summary" => s }
+              .getOrElse(fail("expected a SummarySnapshot named 'test_summary'"))
+            val dp = snapshot.getDataPoints.asScala.head
+            assertEquals(dp.getCount, 4L)
+            assertEqualsDouble(dp.getSum, 4.1, 1e-9)
+            // quantile-based summaries record the quantile values; assert both quantiles were declared
+            assertEquals(dp.getQuantiles.size, 2)
           }
         }
     }


### PR DESCRIPTION
First piece of the v6 backend uplift: introduces the `prometheus4cats.javaclient` package as a sibling of the legacy `javasimpleclient`. Counter and Gauge are fully implemented against `prometheus-metrics-core` 1.x; every other registration method raises `UnsupportedOperationException("not yet ported")` and will be filled in by subsequent PRs.

## Summary

New package `modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/`:

- `package.scala` — state-machine type aliases over upstream's `StatefulMetric`.
- `models/MetricType.scala`, `models/Exceptions.scala`.
- `internal/Utils.scala` — `modifyMetric` + label-values DataPoint helper.
- `JavaMetricRegistry.scala` — Counter (Double) + Gauge (Double) fully implemented against the 1.x `builder()` / `labelValues()` API. Long variants come for free via the `DoubleMetricRegistry` mixin. All other abstract methods (Histogram, Summary, Info, callbacks, MetricCollection) raise `UnsupportedOperationException("not yet ported")`.
- `JavaMetricRegistry.Builder` — mirrors the legacy `javasimpleclient` Builder API so consumers can migrate by changing only the import. Differences: takes a `PrometheusRegistry` instead of `CollectorRegistry`; `withJvmMetrics` replaces `withHotSpotCollectors` (uses upstream's one-line `JvmMetrics.builder().register(...)`).

The `configureBuilderOrRetrieve` helper preserves the legacy adapter's reference-counted registration semantics — overlapping `Resource`-scoped registrations of the same metric name reuse the same underlying collector and only unregister on the last release.

The new package coexists with `javasimpleclient` — disjoint package namespaces (`io.prometheus.metrics.*` vs `io.prometheus.client.*`) mean no classpath conflict. Both backends compile and pass their own tests in this PR.

## Context

PR 6 of the v6 backend uplift split out of #124. Stacked on #131 (`.withNative` dual-mode).

Includes a small follow-up commit (`Align javaclient skeleton stubs with v6 SPI`) that:

- Adds a throwing stub for `createAndRegisterDoubleHistogramWithNative` (introduced in PR 5).
- Updates `createAndRegisterInfo` to the v6 typed-labels signature (introduced in PR 4).
- Fully qualifies the `[[PrometheusRegistry]]` scaladoc links to `[[io.prometheus.metrics.model.registry.PrometheusRegistry]]` (matching the pattern the legacy adapter uses for `[[io.prometheus.client.CollectorRegistry]]`). Unqualified `[[link]]` references to imported Java types don't resolve in scaladoc.

These adjustments are necessary because the original commit predates PR 4 + PR 5 in #124's history.

## Why this PR is split out

Counter and Gauge are mechanical wrappings of upstream's `builder()` chain — the real review surface is `configureBuilderOrRetrieve` (ref-counted registration) and the `Builder` API parity with the legacy adapter. Isolating these in one PR lets reviewers focus on the skeleton's invariants before the larger Histogram (PR 7) and Callback (PR 9) work piles on.

## Risk

Low — package coexists with legacy. The legacy adapter and its test suite still compile and pass unchanged. All non-Counter / non-Gauge methods are stubs that throw `UnsupportedOperationException`, so no consumer can accidentally use them yet.

## Test plan

- [x] `sbt ci-test` green locally on Scala 2.13.18 + 3.3.7 (114 existing tests pass; no new tests in this PR — smoke tests come with the Histogram impl in PR 7).
- [ ] CI green on JDK 11 / 17 / 21 / 25

## Reviewer focus

- **`configureBuilderOrRetrieve`** — preserves the legacy adapter's ref-counted registration semantics. Overlapping `Resource`-scoped registrations of the same metric name reuse the same underlying collector and only unregister on last release.
- **Builder API parity** with the legacy `Builder` for drop-in replacement at import sites. `.withRegistry` now takes `PrometheusRegistry`; `withJvmMetrics` replaces `withHotSpotCollectors`.
- **The "not yet ported" stubs.** These will be replaced one-by-one in PRs 7-9. Choosing `UnsupportedOperationException` over silent no-op so any accidental call surfaces loudly.