### PR TITLE
Implement Summary and Info in javaclient

### DIFF
--- a/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
+++ b/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
@@ -45,6 +45,7 @@ import io.prometheus.metrics.core.metrics.{Summary => PSummary}
 import io.prometheus.metrics.instrumentation.jvm.JvmMetrics
 import io.prometheus.metrics.model.registry.PrometheusRegistry
 import io.prometheus.metrics.model.registry.{Collector => PCollector}
+import io.prometheus.metrics.model.registry.{MultiCollector => PMultiCollector}
 import io.prometheus.metrics.model.snapshots.ClassicHistogramBuckets
 import io.prometheus.metrics.model.snapshots.CounterSnapshot
 import io.prometheus.metrics.model.snapshots.DataPointSnapshot
@@ -54,6 +55,7 @@ import io.prometheus.metrics.model.snapshots.HistogramSnapshot
 import io.prometheus.metrics.model.snapshots.Labels
 import io.prometheus.metrics.model.snapshots.MetricMetadata
 import io.prometheus.metrics.model.snapshots.MetricSnapshot
+import io.prometheus.metrics.model.snapshots.MetricSnapshots
 import io.prometheus.metrics.model.snapshots.Quantiles
 import io.prometheus.metrics.model.snapshots.SummarySnapshot
 import io.prometheus.metrics.model.snapshots.{Quantile => PQuantile}
@@ -83,6 +85,20 @@ class JavaMetricRegistry[F[_]: Async] private (
     private val dispatcher: Dispatcher[F],
     private val callbackTimeout: FiniteDuration,
     private val singleCallbackTimeout: FiniteDuration,
+    // Metric-collection callbacks: keyed by prefix (each prefix has its own merged common-labels map
+    // and a token-keyed map of user callbacks producing MetricCollection values). Constructed
+    // here, but the upstream MultiCollector that aggregates them is built in the class body via
+    // [[buildMetricCollectionMultiCollector]] so it can capture `this`.
+    private val metricCollectionRef: Ref[F, Map[
+      Option[Metric.Prefix],
+      (
+          Map[Label.Name, String],
+          Map[
+            Unique.Token,
+            F[MetricCollection]
+          ]
+      )
+    ]],
     private val logger: Throwable => String => F[Unit]
 ) extends DoubleMetricRegistry[F]
     with DoubleCallbackRegistry[F] {
@@ -973,18 +989,194 @@ class JavaMetricRegistry[F[_]: Async] private (
     )
   }
 
+  /** A single upstream `MultiCollector` that aggregates all metric-collection callbacks across all prefixes. Built
+    * lazily so it captures `this` (specifically `metricCollectionRef`, the dispatcher, and the timeout helpers). The
+    * Builder.build flow accesses it via `metricCollectionCollector` to register it with the underlying registry on
+    * acquire and unregister on release.
+    */
+  private[javaclient] val metricCollectionCollector: PMultiCollector = new PMultiCollector {
+
+    override def collect(): MetricSnapshots = {
+      val result: F[MetricSnapshots] = metricCollectionRef.get.flatMap { perPrefix =>
+        // For each prefix, run all registered callbacks under the per-callback timeout, merge their
+        // MetricCollection values, then convert to MetricSnapshots. We use a fresh
+        // `singleCallbackErrorState` reading on each scrape so log-once gating still applies.
+        perPrefix.toList.flatTraverse { case (prefix, (commonLabels, callbacks)) =>
+          val mergedCol: F[MetricCollection] = callbacks.values.toList.foldM(MetricCollection.empty) { (acc, cbF) =>
+            cbF
+              .timeout(singleCallbackTimeout)
+              .handleErrorWith { th =>
+                logger(th)(
+                  s"A metric-collection callback (prefix=${prefix.map(_.value).getOrElse("<none>")}) failed or timed out."
+                ).as(MetricCollection.empty)
+              }
+              .map(acc.combine)
+          }
+          mergedCol.map(metricCollectionToSnapshots(prefix, commonLabels, _))
+        }
+      }.map(snapshotList => new MetricSnapshots(snapshotList.asJava))
+
+      runCallbackWithBounds(
+        result,
+        callbackTimeout,
+        th =>
+          logger(th)(s"Combined metric-collection callbacks timed out after $callbackTimeout")
+            .as(MetricSnapshots.builder().build()),
+        th => logger(th)(s"Combined metric-collection callbacks failed").as(MetricSnapshots.builder().build())
+      )
+    }
+
+  }
+
   override def registerMetricCollectionCallback(
       prefix: Option[Metric.Prefix],
       commonLabels: Metric.CommonLabels,
       callback: F[MetricCollection]
-  ): Resource[F, Unit] =
-    Resource.eval(ApplicativeThrow[F].raiseError(notYetPorted("registerMetricCollectionCallback")))
+  ): Resource[F, Unit] = {
+    val acquire: F[Unique.Token] = Unique[F].unique.flatMap { token =>
+      metricCollectionRef
+        .update(map =>
+          map.updated(
+            prefix,
+            map.get(prefix).fold(commonLabels.value -> Map(token -> callback)) { case (existingCommon, cbs) =>
+              (existingCommon ++ commonLabels.value) -> cbs.updated(token, callback)
+            }
+          )
+        )
+        .as(token)
+    }
 
-  private def notYetPorted(methodName: String): UnsupportedOperationException =
-    new UnsupportedOperationException(
-      s"prometheus4cats.javaclient.JavaMetricRegistry.$methodName is not yet implemented in this commit. " +
-        "It will be ported in a subsequent commit before the simpleclient backend is removed."
-    )
+    Resource
+      .make(acquire) { token =>
+        metricCollectionRef.update { map =>
+          map.get(prefix).fold(map) { case (commonLabels, cbs) =>
+            val remaining = cbs - token
+            if (remaining.isEmpty) map - prefix
+            else map.updated(prefix, commonLabels -> remaining)
+          }
+        }
+      }
+      .void
+  }
+
+  /** Convert a `MetricCollection` (the prometheus4cats per-prefix bag of typed metric values) into a flat list of
+    * upstream `MetricSnapshot`s. Each (name, labelNames) entry becomes one snapshot with one or more data points (one
+    * per List entry in the user's MetricCollection).
+    */
+  private def metricCollectionToSnapshots(
+      prefix: Option[Metric.Prefix],
+      commonLabels: Map[Label.Name, String],
+      mc: MetricCollection
+  ): List[MetricSnapshot] = {
+    val commonLabelKeysArr   = commonLabels.keys.toArray.map(_.value)
+    val commonLabelValuesArr = commonLabels.values.toArray
+
+    def labelsFor(labelNames: IndexedSeq[Label.Name], labelValues: IndexedSeq[String]): Labels = {
+      val nameArr  = labelNames.map(_.value).toArray ++ commonLabelKeysArr
+      val valueArr = labelValues.toArray ++ commonLabelValuesArr
+      Labels.of(nameArr, valueArr)
+    }
+
+    val counterSnapshots: List[MetricSnapshot] = mc.counters.toList.flatMap { case ((name, labelNames), values) =>
+      values.headOption.map { head =>
+        val rawName  = NameUtils.makeName(prefix, name)
+        val baseName = if (rawName.endsWith("_total")) rawName.dropRight("_total".length) else rawName
+        val dps = values.map { v =>
+          val (vDouble, lbls) = v match {
+            case x: MetricCollection.Value.LongCounter   => (x.value.toDouble, x.labelValues)
+            case x: MetricCollection.Value.DoubleCounter => (x.value, x.labelValues)
+          }
+          new CounterSnapshot.CounterDataPointSnapshot(
+            if (vDouble < 0) 0.0 else vDouble,
+            labelsFor(labelNames, lbls),
+            null: io.prometheus.metrics.model.snapshots.Exemplar,
+            0L
+          )
+        }.asJava
+        new CounterSnapshot(new MetricMetadata(baseName, head.help.value), dps): MetricSnapshot
+      }
+    }
+
+    val gaugeSnapshots: List[MetricSnapshot] = mc.gauges.toList.flatMap { case ((name, labelNames), values) =>
+      values.headOption.map { head =>
+        val fullName = NameUtils.makeName(prefix, name)
+        val dps = values.map { v =>
+          val (vDouble, lbls) = v match {
+            case x: MetricCollection.Value.LongGauge   => (x.value.toDouble, x.labelValues)
+            case x: MetricCollection.Value.DoubleGauge => (x.value, x.labelValues)
+          }
+          new GaugeSnapshot.GaugeDataPointSnapshot(
+            vDouble,
+            labelsFor(labelNames, lbls),
+            null: io.prometheus.metrics.model.snapshots.Exemplar
+          )
+        }.asJava
+        new GaugeSnapshot(new MetricMetadata(fullName, head.help.value), dps): MetricSnapshot
+      }
+    }
+
+    val histogramSnapshots: List[MetricSnapshot] = mc.histograms.toList.flatMap { case ((name, labelNames), values) =>
+      values.headOption.map { head =>
+        val fullName = NameUtils.makeName(prefix, name)
+        // Each consumer-supplied histogram value declares its own buckets — they must agree across the
+        // List entries for a given name. Take the first entry's buckets as the canonical declaration.
+        val buckets: NonEmptySeq[Double] = head match {
+          case h: MetricCollection.Value.LongHistogram   => h.buckets.map(_.toDouble)
+          case h: MetricCollection.Value.DoubleHistogram => h.buckets
+        }
+        val upperBoundsWithInf = (buckets.toSeq :+ Double.PositiveInfinity).toArray
+        val dps = values.map { v =>
+          val (sum, bucketCounts, lbls) = v match {
+            case x: MetricCollection.Value.LongHistogram =>
+              (x.value.sum.toDouble, x.value.bucketValues.toSeq.map(_.toLong).toArray, x.labelValues)
+            case x: MetricCollection.Value.DoubleHistogram =>
+              (x.value.sum, x.value.bucketValues.toSeq.map(_.toLong).toArray, x.labelValues)
+          }
+          new HistogramSnapshot.HistogramDataPointSnapshot(
+            ClassicHistogramBuckets.of(upperBoundsWithInf, bucketCounts),
+            sum,
+            labelsFor(labelNames, lbls),
+            Exemplars.EMPTY,
+            0L
+          )
+        }.asJava
+        new HistogramSnapshot(new MetricMetadata(fullName, head.help.value), dps): MetricSnapshot
+      }
+    }
+
+    val summarySnapshots: List[MetricSnapshot] = mc.summaries.toList.flatMap { case ((name, labelNames), values) =>
+      values.headOption.map { head =>
+        val fullName = NameUtils.makeName(prefix, name)
+        val dps = values.map { v =>
+          val (count, sum, quantiles, lbls) = v match {
+            case x: MetricCollection.Value.LongSummary =>
+              (
+                x.value.count.toLong,
+                x.value.sum.toDouble,
+                x.value.quantiles.map { case (q, v) => q -> v.toDouble },
+                x.labelValues
+              )
+            case x: MetricCollection.Value.DoubleSummary =>
+              (x.value.count.toLong, x.value.sum, x.value.quantiles, x.labelValues)
+          }
+          val quantilesJava = quantiles.toList.map { case (q, v) => new PQuantile(q, v) }.toArray
+          val pquantiles =
+            if (quantilesJava.isEmpty) Quantiles.EMPTY else Quantiles.of(quantilesJava: _*)
+          new SummarySnapshot.SummaryDataPointSnapshot(
+            count,
+            sum,
+            pquantiles,
+            labelsFor(labelNames, lbls),
+            Exemplars.EMPTY,
+            0L
+          )
+        }.asJava
+        new SummarySnapshot(new MetricMetadata(fullName, head.help.value), dps): MetricSnapshot
+      }
+    }
+
+    counterSnapshots ::: gaugeSnapshots ::: histogramSnapshots ::: summarySnapshots
+  }
 
   private def transformExemplarLabels(labels: Exemplar.Labels): Labels =
     Labels.of(
@@ -1051,27 +1243,41 @@ object JavaMetricRegistry {
             cbTimeoutState           <- Ref.of[F, Set[String]](Set.empty)
             cbErrorState             <- Ref.of[F, Set[String]](Set.empty)
             singleCallbackErrorState <- Ref.of[F, (Set[String], Set[String])]((Set.empty, Set.empty))
-            sem                      <- Semaphore[F](1L)
-          } yield new JavaMetricRegistry[F](
-            promRegistry, ref, cbState, cbTimeoutState, cbErrorState, singleCallbackErrorState, sem, dispatcher,
-            callbackTimeout = callbackCollectionTimeout, singleCallbackTimeout = callbackTimeout, logger = logger
-          )
+            metricCollectionRef <- Ref.of[F, Map[
+                                     Option[Metric.Prefix],
+                                     (Map[Label.Name, String], Map[Unique.Token, F[MetricCollection]])
+                                   ]](Map.empty)
+            sem <- Semaphore[F](1L)
+            reg = new JavaMetricRegistry[F](
+                    promRegistry, ref, cbState, cbTimeoutState, cbErrorState, singleCallbackErrorState, sem, dispatcher,
+                    callbackTimeout = callbackCollectionTimeout, singleCallbackTimeout = callbackTimeout,
+                    metricCollectionRef = metricCollectionRef, logger = logger
+                  )
+            // Register the metric-collection MultiCollector unconditionally; it returns an empty
+            // MetricSnapshots when no consumer callbacks are registered, so it's a no-op-cost
+            // collector when unused.
+            _ <- Sync[F].delay(promRegistry.register(reg.metricCollectionCollector))
+          } yield reg
 
           Resource.make(acquire) { reg =>
-            // Unregister callback collectors first, then claimed metric collectors.
-            reg.callbackState.get.flatMap { cbs =>
-              cbs.values.toList.traverse_ { case (_, _, collector) =>
-                Sync[F].delay(promRegistry.unregister(collector)).handleErrorWith { e =>
-                  logger(e)(s"Failed to unregister callback collector at shutdown: '$collector'")
+            // Unregister metric-collection collector first (always present), then individual
+            // callback collectors, then claimed metric collectors.
+            Sync[F]
+              .delay(promRegistry.unregister(reg.metricCollectionCollector))
+              .handleErrorWith(e => logger(e)("Failed to unregister metric-collection MultiCollector at shutdown")) >>
+              reg.callbackState.get.flatMap { cbs =>
+                cbs.values.toList.traverse_ { case (_, _, collector) =>
+                  Sync[F].delay(promRegistry.unregister(collector)).handleErrorWith { e =>
+                    logger(e)(s"Failed to unregister callback collector at shutdown: '$collector'")
+                  }
                 }
+              } >> reg.ref.get.flatMap { metrics =>
+                if (metrics.nonEmpty)
+                  metrics.values.toList.traverse_ { case (_, (collector, _, _)) =>
+                    Utils.unregister(collector, promRegistry, logger)
+                  }
+                else Applicative[F].unit
               }
-            } >> reg.ref.get.flatMap { metrics =>
-              if (metrics.nonEmpty)
-                metrics.values.toList.traverse_ { case (_, (collector, _, _)) =>
-                  Utils.unregister(collector, promRegistry, logger)
-                }
-              else Applicative[F].unit
-            }
           }
         }
       }

--- a/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
+++ b/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
@@ -31,6 +31,7 @@ import cats.syntax.all._
 import io.prometheus.metrics.core.metrics.{Counter => PCounter}
 import io.prometheus.metrics.core.metrics.{Gauge => PGauge}
 import io.prometheus.metrics.core.metrics.{Histogram => PHistogram}
+import io.prometheus.metrics.core.metrics.{Info => PInfo}
 import io.prometheus.metrics.core.metrics.{Summary => PSummary}
 import io.prometheus.metrics.instrumentation.jvm.JvmMetrics
 import io.prometheus.metrics.model.registry.PrometheusRegistry
@@ -423,13 +424,89 @@ class JavaMetricRegistry[F[_]: Async] private (
     }
   }
 
+  @SuppressWarnings(Array("scalafix:DisableSyntax.=="))
   override def createAndRegisterInfo[A](
       prefix: Option[Metric.Prefix],
       name: Info.Name,
       help: Metric.Help,
       labelNames: IndexedSeq[Label.Name]
-  )(f: A => IndexedSeq[String]): Resource[F, Info[F, A]] =
-    Resource.eval(ApplicativeThrow[F].raiseError(notYetPorted("createAndRegisterInfo")))
+  )(f: A => IndexedSeq[String]): Resource[F, Info[F, A]] = {
+    // Upstream client_java appends "_info" to the metric name automatically when the registered
+    // name doesn't end in "_info". The user-provided Info.Name is constrained to end in "_info"
+    // already (see Info.Name regex), so we strip the suffix before registering and let upstream
+    // re-add it.
+    val rawName  = name.value
+    val baseName = if (rawName.endsWith("_info")) rawName.dropRight("_info".length) else rawName
+
+    // Info uses MetricWithFixedMetadata (not StatefulMetric), so the registration state machinery
+    // here is a slim variant of configureBuilderOrRetrieve — Info doesn't need exemplar tracking.
+    val fullName: StateKey = (prefix, baseName)
+    val metricId: MetricID = (labelNames, MetricType.Info)
+    val renderedFullName   = NameUtils.makeName(prefix, baseName)
+
+    val acquire = sem.permit.surround(
+      ref.get
+        .flatMap[(State[F], PInfo)] { (metrics: State[F]) =>
+          metrics.get(fullName) match {
+            case Some((expected, (collector, exemplarRef, references))) =>
+              if (metricId == expected)
+                Applicative[F].pure(
+                  (
+                    metrics.updated(fullName, (expected, (collector, exemplarRef, references + 1))),
+                    collector.asInstanceOf[PInfo]
+                  )
+                )
+              else
+                ApplicativeThrow[F].raiseError(
+                  new RuntimeException(
+                    s"A metric with the same name as '$renderedFullName' is already registered with different labels and/or type"
+                  )
+                )
+            case None =>
+              for {
+                exemplarRef <- Ref.of[F, Option[Exemplar.Data]](None)
+                collector <- Sync[F].delay(
+                               PInfo
+                                 .builder()
+                                 .name(rawName)
+                                 .help(help.value)
+                                 .labelNames(labelNames.map(_.value): _*)
+                                 .register(registry)
+                             )
+              } yield (
+                metrics.updated(fullName, (metricId, (collector, exemplarRef, 1))),
+                collector
+              )
+          }
+        }
+        .flatMap { case (state, collector) => ref.set(state).as(collector) }
+    )
+
+    val release: PInfo => F[Unit] = collector =>
+      sem.permit.surround {
+        ref.get.flatMap { metrics =>
+          metrics.get(fullName) match {
+            case Some((`metricId`, (_, _, 1))) =>
+              ref.set(metrics - fullName) >>
+                Sync[F].delay(registry.unregister(collector)).handleErrorWith { e =>
+                  logger(e)(s"Failed to unregister Info collector: '$collector'")
+                }
+            case Some((`metricId`, (collector, exemplarRef, references))) =>
+              ref.set(metrics.updated(fullName, (metricId, (collector, exemplarRef, references - 1))))
+            case _ => Applicative[F].unit
+          }
+        }
+      }
+
+    Resource.make(acquire)(release).map { info =>
+      Info.make[F, A] { a =>
+        val values = f(a)
+        Sync[F].delay(info.setLabelValues(values: _*)).handleErrorWith { e =>
+          logger(e)(s"Failed to set Info label values for metric '$renderedFullName'")
+        }
+      }
+    }
+  }
 
   override def registerDoubleCounterCallback[A](
       prefix: Option[Metric.Prefix],

--- a/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
+++ b/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
@@ -45,11 +45,18 @@ import io.prometheus.metrics.core.metrics.{Summary => PSummary}
 import io.prometheus.metrics.instrumentation.jvm.JvmMetrics
 import io.prometheus.metrics.model.registry.PrometheusRegistry
 import io.prometheus.metrics.model.registry.{Collector => PCollector}
+import io.prometheus.metrics.model.snapshots.ClassicHistogramBuckets
 import io.prometheus.metrics.model.snapshots.CounterSnapshot
+import io.prometheus.metrics.model.snapshots.DataPointSnapshot
+import io.prometheus.metrics.model.snapshots.Exemplars
 import io.prometheus.metrics.model.snapshots.GaugeSnapshot
+import io.prometheus.metrics.model.snapshots.HistogramSnapshot
 import io.prometheus.metrics.model.snapshots.Labels
 import io.prometheus.metrics.model.snapshots.MetricMetadata
 import io.prometheus.metrics.model.snapshots.MetricSnapshot
+import io.prometheus.metrics.model.snapshots.Quantiles
+import io.prometheus.metrics.model.snapshots.SummarySnapshot
+import io.prometheus.metrics.model.snapshots.{Quantile => PQuantile}
 import prometheus4cats._
 import prometheus4cats.javaclient.internal.Utils
 import prometheus4cats.javaclient.models.MetricType
@@ -584,12 +591,12 @@ class JavaMetricRegistry[F[_]: Async] private (
     * (logged-timeout, logged-error, samples) triple so the outer aggregation can decide what to persist into
     * [[singleCallbackErrorState]] without re-logging on every scrape.
     */
-  private def timeoutEachCallback[V](
+  private def timeoutEachCallback(
       stringName: String,
-      samplesF: F[NonEmptyList[(V, IndexedSeq[String])]],
+      samplesF: F[NonEmptyList[DataPointSnapshot]],
       hasLoggedTimeout: Boolean,
       hasLoggedError: Boolean
-  ): F[(Boolean, Boolean, List[(V, IndexedSeq[String])])] =
+  ): F[(Boolean, Boolean, List[DataPointSnapshot])] =
     samplesF
       .map(samples => (hasLoggedTimeout, hasLoggedError, samples.toList))
       .timeout(singleCallbackTimeout)
@@ -622,7 +629,7 @@ class JavaMetricRegistry[F[_]: Async] private (
       metricType: MetricType,
       metricPrefix: Option[Metric.Prefix],
       name: A,
-      callback: F[NonEmptyList[(Double, IndexedSeq[String])]],
+      callback: F[NonEmptyList[DataPointSnapshot]],
       makeCollector: Ref[F, CallbackPayload[F]] => PCollector
   ): Resource[F, Unit] = {
     lazy val n                  = name.show
@@ -687,13 +694,14 @@ class JavaMetricRegistry[F[_]: Async] private (
       .void
   }
 
-  /** Aggregate all per-token callbacks into a single list of `(value, labels)` tuples, applying the per-callback
-    * timeout and error-tracking machinery. Used by every kind-specific Collector.
+  /** Aggregate all per-token callbacks into a single list of pre-built data-point snapshots, applying the per-callback
+    * timeout and error-tracking machinery. Used by every kind-specific Collector; the Collector then casts the data
+    * points to its concrete subtype and wraps them in the right `MetricSnapshot`.
     */
   private def collectAllPayload(
       callbacks: Ref[F, CallbackPayload[F]],
       renderedFullName: String
-  ): F[List[(Double, IndexedSeq[String])]] =
+  ): F[List[DataPointSnapshot]] =
     singleCallbackErrorState.get.flatMap { case (loggedTimeout, loggedError) =>
       callbacks.get
         .flatMap(
@@ -701,7 +709,7 @@ class JavaMetricRegistry[F[_]: Async] private (
             (
               loggedTimeout.contains(renderedFullName),
               loggedError.contains(renderedFullName),
-              List.empty[(Double, IndexedSeq[String])]
+              List.empty[DataPointSnapshot]
             )
           ) { case ((hasLoggedTimeout0, hasLoggedError0, acc), samplesF) =>
             timeoutEachCallback(renderedFullName, samplesF, hasLoggedTimeout0, hasLoggedError0).map {
@@ -768,10 +776,18 @@ class JavaMetricRegistry[F[_]: Async] private (
     // exposition writer adds "_total" back to the wire format.
     val baseName = if (rawName.endsWith("_total")) rawName.dropRight("_total".length) else rawName
 
-    // Project user (Double, A) tuples into (Double, all-label-values) tuples up front so the
-    // generic CallbackPayload type doesn't need to know about A.
-    val projected: F[NonEmptyList[(Double, IndexedSeq[String])]] = callback.map(
-      _.map { case (v, a) => (v, f(a) ++ commonLabelValuesArr) }
+    // Build CounterDataPointSnapshot instances inside the user callback's F so the generic
+    // CallbackPayload type can hold them as plain DataPointSnapshots. The Collector at scrape time
+    // casts back to CounterDataPointSnapshot.
+    val projected: F[NonEmptyList[DataPointSnapshot]] = callback.map(
+      _.map { case (v, a) =>
+        new CounterSnapshot.CounterDataPointSnapshot(
+          if (v < 0) 0.0 else v,
+          Labels.of(allLabelNamesStr, (f(a) ++ commonLabelValuesArr).toArray),
+          null: io.prometheus.metrics.model.snapshots.Exemplar,
+          0L
+        ): DataPointSnapshot
+      }
     )
 
     registerCallback[Counter.Name](
@@ -783,18 +799,12 @@ class JavaMetricRegistry[F[_]: Async] private (
         new PCollector {
 
           override def collect(): MetricSnapshot = {
-            val aggregated: F[List[(Double, IndexedSeq[String])]] = collectAllPayload(callbacks, baseName)
             val dataPoints: java.util.List[CounterSnapshot.CounterDataPointSnapshot] =
               runAggregateCollect(
                 baseName,
-                aggregated.map(_.map { case (value, labelValues) =>
-                  new CounterSnapshot.CounterDataPointSnapshot(
-                    if (value < 0) 0.0 else value,
-                    Labels.of(allLabelNamesStr, labelValues.toArray),
-                    null: io.prometheus.metrics.model.snapshots.Exemplar,
-                    0L
-                  )
-                }.asJava),
+                collectAllPayload(callbacks, baseName).map(
+                  _.map(_.asInstanceOf[CounterSnapshot.CounterDataPointSnapshot]).asJava
+                ),
                 java.util.Collections.emptyList[CounterSnapshot.CounterDataPointSnapshot]()
               )
             new CounterSnapshot(new MetricMetadata(baseName, help.value), dataPoints)
@@ -817,8 +827,14 @@ class JavaMetricRegistry[F[_]: Async] private (
     val allLabelNamesStr     = (labelNames.map(_.value) ++ commonLabelKeys).toArray
     val fullName             = NameUtils.makeName(prefix, name)
 
-    val projected: F[NonEmptyList[(Double, IndexedSeq[String])]] = callback.map(
-      _.map { case (v, a) => (v, f(a) ++ commonLabelValuesArr) }
+    val projected: F[NonEmptyList[DataPointSnapshot]] = callback.map(
+      _.map { case (v, a) =>
+        new GaugeSnapshot.GaugeDataPointSnapshot(
+          v,
+          Labels.of(allLabelNamesStr, (f(a) ++ commonLabelValuesArr).toArray),
+          null: io.prometheus.metrics.model.snapshots.Exemplar
+        ): DataPointSnapshot
+      }
     )
 
     registerCallback[Gauge.Name](
@@ -830,17 +846,12 @@ class JavaMetricRegistry[F[_]: Async] private (
         new PCollector {
 
           override def collect(): MetricSnapshot = {
-            val aggregated = collectAllPayload(callbacks, fullName)
             val dataPoints: java.util.List[GaugeSnapshot.GaugeDataPointSnapshot] =
               runAggregateCollect(
                 fullName,
-                aggregated.map(_.map { case (value, labelValues) =>
-                  new GaugeSnapshot.GaugeDataPointSnapshot(
-                    value,
-                    Labels.of(allLabelNamesStr, labelValues.toArray),
-                    null: io.prometheus.metrics.model.snapshots.Exemplar
-                  )
-                }.asJava),
+                collectAllPayload(callbacks, fullName).map(
+                  _.map(_.asInstanceOf[GaugeSnapshot.GaugeDataPointSnapshot]).asJava
+                ),
                 java.util.Collections.emptyList[GaugeSnapshot.GaugeDataPointSnapshot]()
               )
             new GaugeSnapshot(new MetricMetadata(fullName, help.value), dataPoints)
@@ -858,8 +869,54 @@ class JavaMetricRegistry[F[_]: Async] private (
       labelNames: IndexedSeq[Label.Name],
       buckets: NonEmptySeq[Double],
       callback: F[NonEmptyList[(Histogram.Value[Double], A)]]
-  )(f: A => IndexedSeq[String]): Resource[F, Unit] =
-    Resource.eval(ApplicativeThrow[F].raiseError(notYetPorted("registerDoubleHistogramCallback")))
+  )(f: A => IndexedSeq[String]): Resource[F, Unit] = {
+    val commonLabelKeys      = commonLabels.value.keys.toIndexedSeq.map(_.value)
+    val commonLabelValuesArr = commonLabels.value.values.toIndexedSeq
+    val allLabelNamesStr     = (labelNames.map(_.value) ++ commonLabelKeys).toArray
+    val fullName             = NameUtils.makeName(prefix, name)
+    // Histogram buckets in 1.x include +Inf as the last upper bound; the user-supplied buckets array
+    // doesn't, so append it. Histogram.Value[Double].bucketValues is parallel-indexed with the
+    // (declared-buckets ++ +Inf) sequence (cumulative counts).
+    val upperBoundsWithInf = (buckets.toSeq :+ Double.PositiveInfinity).toArray
+
+    val projected: F[NonEmptyList[DataPointSnapshot]] = callback.map(
+      _.map { case (value, a) =>
+        val labelValuesArr = (f(a) ++ commonLabelValuesArr).toArray
+        // bucketValues are cumulative Double counts; ClassicHistogramBuckets.of wants long counts.
+        val cumulativeCounts: Array[Long] = value.bucketValues.toSeq.map(_.toLong).toArray
+        new HistogramSnapshot.HistogramDataPointSnapshot(
+          ClassicHistogramBuckets.of(upperBoundsWithInf, cumulativeCounts),
+          value.sum,
+          Labels.of(allLabelNamesStr, labelValuesArr),
+          Exemplars.EMPTY,
+          0L
+        ): DataPointSnapshot
+      }
+    )
+
+    registerCallback[Histogram.Name](
+      MetricType.Histogram,
+      prefix,
+      name,
+      projected,
+      makeCollector = (callbacks: Ref[F, CallbackPayload[F]]) =>
+        new PCollector {
+
+          override def collect(): MetricSnapshot = {
+            val dataPoints: java.util.List[HistogramSnapshot.HistogramDataPointSnapshot] =
+              runAggregateCollect(
+                fullName,
+                collectAllPayload(callbacks, fullName).map(
+                  _.map(_.asInstanceOf[HistogramSnapshot.HistogramDataPointSnapshot]).asJava
+                ),
+                java.util.Collections.emptyList[HistogramSnapshot.HistogramDataPointSnapshot]()
+              )
+            new HistogramSnapshot(new MetricMetadata(fullName, help.value), dataPoints)
+          }
+
+        }
+    )
+  }
 
   override def registerDoubleSummaryCallback[A](
       prefix: Option[Metric.Prefix],
@@ -868,8 +925,53 @@ class JavaMetricRegistry[F[_]: Async] private (
       commonLabels: Metric.CommonLabels,
       labelNames: IndexedSeq[Label.Name],
       callback: F[NonEmptyList[(Summary.Value[Double], A)]]
-  )(f: A => IndexedSeq[String]): Resource[F, Unit] =
-    Resource.eval(ApplicativeThrow[F].raiseError(notYetPorted("registerDoubleSummaryCallback")))
+  )(f: A => IndexedSeq[String]): Resource[F, Unit] = {
+    val commonLabelKeys      = commonLabels.value.keys.toIndexedSeq.map(_.value)
+    val commonLabelValuesArr = commonLabels.value.values.toIndexedSeq
+    val allLabelNamesStr     = (labelNames.map(_.value) ++ commonLabelKeys).toArray
+    val fullName             = NameUtils.makeName(prefix, name)
+
+    val projected: F[NonEmptyList[DataPointSnapshot]] = callback.map(
+      _.map { case (value, a) =>
+        val labelValuesArr = (f(a) ++ commonLabelValuesArr).toArray
+        val quantilesJava: Array[PQuantile] =
+          value.quantiles.toList.map { case (q, v) => new PQuantile(q, v) }.toArray
+        val quantiles =
+          if (quantilesJava.isEmpty) Quantiles.EMPTY else Quantiles.of(quantilesJava: _*)
+        new SummarySnapshot.SummaryDataPointSnapshot(
+          value.count.toLong,
+          value.sum,
+          quantiles,
+          Labels.of(allLabelNamesStr, labelValuesArr),
+          Exemplars.EMPTY,
+          0L
+        ): DataPointSnapshot
+      }
+    )
+
+    registerCallback[Summary.Name](
+      MetricType.Summary,
+      prefix,
+      name,
+      projected,
+      makeCollector = (callbacks: Ref[F, CallbackPayload[F]]) =>
+        new PCollector {
+
+          override def collect(): MetricSnapshot = {
+            val dataPoints: java.util.List[SummarySnapshot.SummaryDataPointSnapshot] =
+              runAggregateCollect(
+                fullName,
+                collectAllPayload(callbacks, fullName).map(
+                  _.map(_.asInstanceOf[SummarySnapshot.SummaryDataPointSnapshot]).asJava
+                ),
+                java.util.Collections.emptyList[SummarySnapshot.SummaryDataPointSnapshot]()
+              )
+            new SummarySnapshot(new MetricMetadata(fullName, help.value), dataPoints)
+          }
+
+        }
+    )
+  }
 
   override def registerMetricCollectionCallback(
       prefix: Option[Metric.Prefix],

--- a/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
+++ b/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
@@ -81,7 +81,8 @@ class JavaMetricRegistry[F[_]: Async] private (
     private val callbackState: Ref[F, CallbackState[F]],
     private val callbackTimeoutState: Ref[F, Set[String]],
     private val callbackErrorState: Ref[F, Set[String]],
-    private val singleCallbackErrorState: Ref[F, (Set[String], Set[String])],
+    private val singleCallbackTimeoutState: Ref[F, Set[String]],
+    private val singleCallbackErrorState: Ref[F, Set[String]],
     private val sem: Semaphore[F],
     private val dispatcher: Dispatcher[F],
     private val callbackTimeout: FiniteDuration,
@@ -569,10 +570,10 @@ class JavaMetricRegistry[F[_]: Async] private (
   //     samples for that registration and logs ONCE per metric name.
   //   - `callbackTimeout` bounds the COMBINED collection of all registered callbacks for a single
   //     metric (i.e., the wrapper that aggregates samples across multiple consumer registrations).
-  //   - Error tracking refs (`callbackTimeoutState`, `callbackErrorState`, `singleCallbackErrorState`)
-  //     prevent log spam: the first time a metric's callback times out / fails, we log; subsequent
-  //     occurrences are silently counted by the upstream Prometheus runtime via the regular
-  //     scrape-error path.
+  //   - Error tracking refs (`callbackTimeoutState`, `callbackErrorState`, `singleCallbackTimeoutState`,
+  //     `singleCallbackErrorState`) prevent log spam: the first time a metric's callback times out / fails,
+  //     we log; subsequent occurrences are silently counted by the upstream Prometheus runtime via the
+  //     regular scrape-error path.
   //
   // Skipped vs the legacy adapter: the internal `prometheus4cats_combined_callback_metric_total` and
   // `prometheus4cats_callback_total` counters that tracked callback success/error/timeout counts
@@ -719,7 +720,7 @@ class JavaMetricRegistry[F[_]: Async] private (
       callbacks: Ref[F, CallbackPayload[F]],
       renderedFullName: String
   ): F[List[DataPointSnapshot]] =
-    singleCallbackErrorState.get.flatMap { case (loggedTimeout, loggedError) =>
+    (singleCallbackTimeoutState.get, singleCallbackErrorState.get).tupled.flatMap { case (loggedTimeout, loggedError) =>
       callbacks.get
         .flatMap(
           _.values.foldM(
@@ -735,13 +736,13 @@ class JavaMetricRegistry[F[_]: Async] private (
           }
         )
         .flatMap { case (hasLoggedTimeout0, hasLoggedError0, samples) =>
-          ((hasLoggedTimeout0, hasLoggedError0) match {
-            case (true, true) =>
-              singleCallbackErrorState.set((loggedTimeout + renderedFullName, loggedError + renderedFullName))
-            case (true, false)  => singleCallbackErrorState.set((loggedTimeout + renderedFullName, loggedError))
-            case (false, true)  => singleCallbackErrorState.set((loggedTimeout, loggedError + renderedFullName))
-            case (false, false) => Applicative[F].unit
-          }).as(samples)
+          val updateTimeout =
+            if (hasLoggedTimeout0) singleCallbackTimeoutState.set(loggedTimeout + renderedFullName)
+            else Applicative[F].unit
+          val updateError =
+            if (hasLoggedError0) singleCallbackErrorState.set(loggedError + renderedFullName)
+            else Applicative[F].unit
+          (updateTimeout *> updateError).as(samples)
         }
     }
 
@@ -1243,20 +1244,21 @@ object JavaMetricRegistry {
       }.flatMap { _ =>
         Dispatcher.sequential[F].flatMap { dispatcher =>
           val acquire = for {
-            ref                      <- Ref.of[F, State[F]](Map.empty)
-            cbState                  <- Ref.of[F, CallbackState[F]](Map.empty)
-            cbTimeoutState           <- Ref.of[F, Set[String]](Set.empty)
-            cbErrorState             <- Ref.of[F, Set[String]](Set.empty)
-            singleCallbackErrorState <- Ref.of[F, (Set[String], Set[String])]((Set.empty, Set.empty))
+            ref                        <- Ref.of[F, State[F]](Map.empty)
+            cbState                    <- Ref.of[F, CallbackState[F]](Map.empty)
+            cbTimeoutState             <- Ref.of[F, Set[String]](Set.empty)
+            cbErrorState               <- Ref.of[F, Set[String]](Set.empty)
+            singleCallbackTimeoutState <- Ref.of[F, Set[String]](Set.empty)
+            singleCallbackErrorState   <- Ref.of[F, Set[String]](Set.empty)
             metricCollectionRef <- Ref.of[F, Map[
                                      Option[Metric.Prefix],
                                      (Map[Label.Name, String], Map[Unique.Token, F[MetricCollection]])
                                    ]](Map.empty)
             sem <- Semaphore[F](1L)
             reg = new JavaMetricRegistry[F](
-                    promRegistry, ref, cbState, cbTimeoutState, cbErrorState, singleCallbackErrorState, sem, dispatcher,
-                    callbackTimeout = callbackCollectionTimeout, singleCallbackTimeout = callbackTimeout,
-                    metricCollectionRef = metricCollectionRef, logger = logger
+                    promRegistry, ref, cbState, cbTimeoutState, cbErrorState, singleCallbackTimeoutState,
+                    singleCallbackErrorState, sem, dispatcher, callbackTimeout = callbackCollectionTimeout,
+                    singleCallbackTimeout = callbackTimeout, metricCollectionRef = metricCollectionRef, logger = logger
                   )
             // Register the metric-collection MultiCollector unconditionally; it returns an empty
             // MetricSnapshots when no consumer callbacks are registered, so it's a no-op-cost

--- a/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
+++ b/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
@@ -28,6 +28,9 @@ import cats.effect.kernel._
 import cats.effect.std.Semaphore
 import cats.syntax.all._
 
+import io.prometheus.metrics.core.datapoints.CounterDataPoint
+import io.prometheus.metrics.core.datapoints.DistributionDataPoint
+import io.prometheus.metrics.core.datapoints.GaugeDataPoint
 import io.prometheus.metrics.core.metrics.{Counter => PCounter}
 import io.prometheus.metrics.core.metrics.{Gauge => PGauge}
 import io.prometheus.metrics.core.metrics.{Histogram => PHistogram}
@@ -174,13 +177,13 @@ class JavaMetricRegistry[F[_]: Async] private (
             labels: A,
             exemplar: Option[Exemplar.Labels]
         ) =>
-          Utils.modifyMetric[F, Counter.Name, io.prometheus.metrics.core.datapoints.CounterDataPoint](
+          Utils.modifyMetric[F, Counter.Name, CounterDataPoint](
             metricName = name,
             allLabelNames = allLabelNames,
             dynamicLabels = f(labels),
             commonLabelValues = commonLabelValuesArray,
             getDataPoint = (lbls: Array[String]) => counter.labelValues(lbls: _*),
-            modify = (dp: io.prometheus.metrics.core.datapoints.CounterDataPoint) =>
+            modify = (dp: CounterDataPoint) =>
               exemplar.fold(dp.inc(d))(e => dp.incWithExemplar(d, transformExemplarLabels(e))),
             logger = logger
           )
@@ -214,8 +217,8 @@ class JavaMetricRegistry[F[_]: Async] private (
       labels = allLabelNames
     ).map { case (gauge, _) =>
       @inline
-      def modify(g: io.prometheus.metrics.core.datapoints.GaugeDataPoint => Unit, labels: A): F[Unit] =
-        Utils.modifyMetric[F, Gauge.Name, io.prometheus.metrics.core.datapoints.GaugeDataPoint](
+      def modify(g: GaugeDataPoint => Unit, labels: A): F[Unit] =
+        Utils.modifyMetric[F, Gauge.Name, GaugeDataPoint](
           metricName = name,
           allLabelNames = allLabelNames,
           dynamicLabels = f(labels),
@@ -271,13 +274,13 @@ class JavaMetricRegistry[F[_]: Async] private (
       Histogram.make[F, Double, A](
         exemplarState(exemplarRef),
         _observe = { (d: Double, labels: A, exemplar: Option[Exemplar.Labels]) =>
-          Utils.modifyMetric[F, Histogram.Name, io.prometheus.metrics.core.datapoints.DistributionDataPoint](
+          Utils.modifyMetric[F, Histogram.Name, DistributionDataPoint](
             metricName = name,
             allLabelNames = allLabelNames,
             dynamicLabels = f(labels),
             commonLabelValues = commonLabelValuesArray,
             getDataPoint = (lbls: Array[String]) => histogram.labelValues(lbls: _*),
-            modify = (dp: io.prometheus.metrics.core.datapoints.DistributionDataPoint) =>
+            modify = (dp: DistributionDataPoint) =>
               exemplar.fold(dp.observe(d))(e => dp.observeWithExemplar(d, transformExemplarLabels(e))),
             logger = logger
           )
@@ -411,13 +414,13 @@ class JavaMetricRegistry[F[_]: Async] private (
       labels = allLabelNames
     ).map { case (summary, _) =>
       Summary.make[F, Double, A] { case (d, labels) =>
-        Utils.modifyMetric[F, Summary.Name, io.prometheus.metrics.core.datapoints.DistributionDataPoint](
+        Utils.modifyMetric[F, Summary.Name, DistributionDataPoint](
           metricName = name,
           allLabelNames = allLabelNames,
           dynamicLabels = f(labels),
           commonLabelValues = commonLabelValuesArray,
           getDataPoint = (lbls: Array[String]) => summary.labelValues(lbls: _*),
-          modify = (dp: io.prometheus.metrics.core.datapoints.DistributionDataPoint) => dp.observe(d),
+          modify = (dp: DistributionDataPoint) => dp.observe(d),
           logger = logger
         )
       }

--- a/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
+++ b/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
@@ -776,6 +776,7 @@ class JavaMetricRegistry[F[_]: Async] private (
       )
   )
 
+  @SuppressWarnings(Array("scalafix:DisableSyntax.null"))
   override def registerDoubleCounterCallback[A](
       prefix: Option[Metric.Prefix],
       name: Counter.Name,
@@ -830,6 +831,7 @@ class JavaMetricRegistry[F[_]: Async] private (
     )
   }
 
+  @SuppressWarnings(Array("scalafix:DisableSyntax.null"))
   override def registerDoubleGaugeCallback[A](
       prefix: Option[Metric.Prefix],
       name: Gauge.Name,
@@ -1022,12 +1024,13 @@ class JavaMetricRegistry[F[_]: Async] private (
         th =>
           logger(th)(s"Combined metric-collection callbacks timed out after $callbackTimeout")
             .as(MetricSnapshots.builder().build()),
-        th => logger(th)(s"Combined metric-collection callbacks failed").as(MetricSnapshots.builder().build())
+        th => logger(th)("Combined metric-collection callbacks failed").as(MetricSnapshots.builder().build())
       )
     }
 
   }
 
+  @SuppressWarnings(Array("scalafix:DisableSyntax.null"))
   override def registerMetricCollectionCallback(
       prefix: Option[Metric.Prefix],
       commonLabels: Metric.CommonLabels,
@@ -1063,6 +1066,7 @@ class JavaMetricRegistry[F[_]: Async] private (
     * upstream `MetricSnapshot`s. Each (name, labelNames) entry becomes one snapshot with one or more data points (one
     * per List entry in the user's MetricCollection).
     */
+  @SuppressWarnings(Array("scalafix:DisableSyntax.null"))
   private def metricCollectionToSnapshots(
       prefix: Option[Metric.Prefix],
       commonLabels: Map[Label.Name, String],

--- a/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
+++ b/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
@@ -16,7 +16,10 @@
 
 package prometheus4cats.javaclient
 
+import java.util.concurrent.TimeoutException
+
 import scala.concurrent.duration._
+import scala.jdk.CollectionConverters._
 
 import cats.Applicative
 import cats.ApplicativeThrow
@@ -25,9 +28,12 @@ import cats.Show
 import cats.data.NonEmptyList
 import cats.data.NonEmptySeq
 import cats.effect.kernel._
+import cats.effect.kernel.syntax.temporal._
+import cats.effect.std.Dispatcher
 import cats.effect.std.Semaphore
 import cats.syntax.all._
 
+import alleycats.std.iterable._
 import io.prometheus.metrics.core.datapoints.CounterDataPoint
 import io.prometheus.metrics.core.datapoints.DistributionDataPoint
 import io.prometheus.metrics.core.datapoints.GaugeDataPoint
@@ -38,7 +44,11 @@ import io.prometheus.metrics.core.metrics.{Info => PInfo}
 import io.prometheus.metrics.core.metrics.{Summary => PSummary}
 import io.prometheus.metrics.instrumentation.jvm.JvmMetrics
 import io.prometheus.metrics.model.registry.PrometheusRegistry
+import io.prometheus.metrics.model.registry.{Collector => PCollector}
+import io.prometheus.metrics.model.snapshots.CounterSnapshot
 import io.prometheus.metrics.model.snapshots.Labels
+import io.prometheus.metrics.model.snapshots.MetricMetadata
+import io.prometheus.metrics.model.snapshots.MetricSnapshot
 import prometheus4cats._
 import prometheus4cats.javaclient.internal.Utils
 import prometheus4cats.javaclient.models.MetricType
@@ -57,7 +67,14 @@ import prometheus4cats.util.NameUtils
 class JavaMetricRegistry[F[_]: Async] private (
     private val registry: PrometheusRegistry,
     private val ref: Ref[F, State[F]],
+    private val callbackState: Ref[F, CallbackState[F]],
+    private val callbackTimeoutState: Ref[F, Set[String]],
+    private val callbackErrorState: Ref[F, Set[String]],
+    private val singleCallbackErrorState: Ref[F, (Set[String], Set[String])],
     private val sem: Semaphore[F],
+    private val dispatcher: Dispatcher[F],
+    private val callbackTimeout: FiniteDuration,
+    private val singleCallbackTimeout: FiniteDuration,
     private val logger: Throwable => String => F[Unit]
 ) extends DoubleMetricRegistry[F]
     with DoubleCallbackRegistry[F] {
@@ -519,6 +536,221 @@ class JavaMetricRegistry[F[_]: Async] private (
     }
   }
 
+  // ─── callback machinery ──────────────────────────────────────────────────────────────────────────
+  //
+  // Mirrors the legacy javasimpleclient adapter's per-callback timeout + error-tracking pattern:
+  //
+  //   - `singleCallbackTimeout` bounds an individual callback invocation; exceeding it returns empty
+  //     samples for that registration and logs ONCE per metric name.
+  //   - `callbackTimeout` bounds the COMBINED collection of all registered callbacks for a single
+  //     metric (i.e., the wrapper that aggregates samples across multiple consumer registrations).
+  //   - Error tracking refs (`callbackTimeoutState`, `callbackErrorState`, `singleCallbackErrorState`)
+  //     prevent log spam: the first time a metric's callback times out / fails, we log; subsequent
+  //     occurrences are silently counted by the upstream Prometheus runtime via the regular
+  //     scrape-error path.
+  //
+  // Skipped vs the legacy adapter: the internal `prometheus4cats_combined_callback_metric_total` and
+  // `prometheus4cats_callback_total` counters that tracked callback success/error/timeout counts
+  // per metric. They're observability nice-to-haves; consumers can always add them externally if
+  // wanted. May add in a follow-up commit.
+
+  private def trackErrors[A](
+      state: Ref[F, Set[String]],
+      stringName: String,
+      onContains: F[A],
+      onContainsNot: F[A]
+  ): F[A] =
+    state.modify { current =>
+      if (current.contains(stringName)) (current, onContains) else (current + stringName, onContainsNot)
+    }.flatten
+
+  /** Wrap an effect with a timeout + error fallback, dispatching synchronously through the supplied Dispatcher. Both
+    * timeouts and failures are mapped to `empty` and forwarded to `onTimeout` / `onError` for logging-side-effect
+    * handling.
+    */
+  private def runCallbackWithBounds[A](
+      fa: F[A],
+      timeout: FiniteDuration,
+      onTimeout: TimeoutException => F[A],
+      onError: Throwable => F[A]
+  ): A =
+    dispatcher.unsafeRunSync(fa.timeout(timeout).handleErrorWith {
+      case th: TimeoutException => onTimeout(th)
+      case th                   => onError(th)
+    })
+
+  /** Per-callback timeout wrapper: bounds an individual registration's callback invocation. Returns the
+    * (logged-timeout, logged-error, samples) triple so the outer aggregation can decide what to persist into
+    * [[singleCallbackErrorState]] without re-logging on every scrape.
+    */
+  private def timeoutEachCallback[V](
+      stringName: String,
+      samplesF: F[NonEmptyList[(V, IndexedSeq[String])]],
+      hasLoggedTimeout: Boolean,
+      hasLoggedError: Boolean
+  ): F[(Boolean, Boolean, List[(V, IndexedSeq[String])])] =
+    samplesF
+      .map(samples => (hasLoggedTimeout, hasLoggedError, samples.toList))
+      .timeout(singleCallbackTimeout)
+      .handleErrorWith {
+        case th: TimeoutException =>
+          (if (hasLoggedTimeout) Applicative[F].unit
+           else
+             logger(th)(
+               s"Timed out running a callback for the metric '$stringName' after $singleCallbackTimeout. " +
+                 "This warning will only be shown once after process start."
+             )).as((true, hasLoggedError, List.empty))
+        case th =>
+          (if (hasLoggedError) Applicative[F].unit
+           else
+             logger(th)(
+               s"Executing a callback for the metric '$stringName' failed with the following exception. " +
+                 "This warning will only be shown once after process start."
+             )).as((hasLoggedTimeout, true, List.empty))
+      }
+
+  /** Generic callback registration:
+    *   1. Look up (or create) a single upstream `Collector` for this metric name. 2. Add the user's callback to the
+    *      Collector's per-token registration map. 3. On Resource release, remove this token; if it was the last token,
+    *      unregister the Collector.
+    *
+    * The `makeCollector` thunk is responsible for constructing the kind-specific Collector that builds the right
+    * `MetricSnapshot` from the aggregated `(value, labels)` tuples at scrape time.
+    */
+  private def registerCallback[A: Show](
+      metricType: MetricType,
+      metricPrefix: Option[Metric.Prefix],
+      name: A,
+      callback: F[NonEmptyList[(Double, IndexedSeq[String])]],
+      makeCollector: Ref[F, CallbackPayload[F]] => PCollector
+  ): Resource[F, Unit] = {
+    lazy val n                  = name.show
+    lazy val fullName: StateKey = (metricPrefix, n)
+    lazy val renderedFullName   = NameUtils.makeName(metricPrefix, name)
+
+    val acquire = sem.permit.surround(
+      ref.get.flatMap(r =>
+        r.get(fullName) match {
+          case None => Applicative[F].unit
+          case Some(_) =>
+            ApplicativeThrow[F].raiseError[Unit](
+              new RuntimeException(
+                s"A metric with the same name as '$renderedFullName' is already registered with different labels and/or type"
+              )
+            )
+        }
+      ) >>
+        callbackState.get
+          .flatMap[Unique.Token] { (callbacks: CallbackState[F]) =>
+            callbacks.get(fullName) match {
+              case Some((`metricType`, states, _)) =>
+                Unique[F].unique.flatMap { token =>
+                  states.update(_.updated(token, callback)).as(token)
+                }
+              case Some(_) =>
+                ApplicativeThrow[F].raiseError(
+                  new RuntimeException(
+                    s"A callback with the same name as '$renderedFullName' is already registered with different type"
+                  )
+                )
+              case None =>
+                for {
+                  token    <- Unique[F].unique
+                  innerRef <- Ref.of[F, CallbackPayload[F]](Map(token -> callback))
+                  collector = makeCollector(innerRef)
+                  _        <- Sync[F].delay(registry.register(collector))
+                  _        <- callbackState.set(callbacks.updated(fullName, (metricType, innerRef, collector)))
+                } yield token
+            }
+          }
+    )
+
+    Resource
+      .make(acquire) { token =>
+        sem.permit.surround(callbackState.get.flatMap { state =>
+          state.get(fullName) match {
+            case Some((_, callbacks, collector)) =>
+              callbacks.get.flatMap { cbs =>
+                val newCallbacks = cbs - token
+                if (newCallbacks.isEmpty)
+                  callbackState.set(state - fullName) >>
+                    Sync[F].delay(registry.unregister(collector)).handleErrorWith { e =>
+                      logger(e)(s"Failed to unregister callback collector: '$collector'")
+                    }
+                else callbacks.set(newCallbacks)
+              }
+            case None => Applicative[F].unit
+          }
+        })
+      }
+      .void
+  }
+
+  /** Aggregate all per-token callbacks into a single list of `(value, labels)` tuples, applying the per-callback
+    * timeout and error-tracking machinery. Used by every kind-specific Collector.
+    */
+  private def collectAllPayload(
+      callbacks: Ref[F, CallbackPayload[F]],
+      renderedFullName: String
+  ): F[List[(Double, IndexedSeq[String])]] =
+    singleCallbackErrorState.get.flatMap { case (loggedTimeout, loggedError) =>
+      callbacks.get
+        .flatMap(
+          _.values.foldM(
+            (
+              loggedTimeout.contains(renderedFullName),
+              loggedError.contains(renderedFullName),
+              List.empty[(Double, IndexedSeq[String])]
+            )
+          ) { case ((hasLoggedTimeout0, hasLoggedError0, acc), samplesF) =>
+            timeoutEachCallback(renderedFullName, samplesF, hasLoggedTimeout0, hasLoggedError0).map {
+              case (lto, le, samples) => (lto, le, acc ++ samples)
+            }
+          }
+        )
+        .flatMap { case (hasLoggedTimeout0, hasLoggedError0, samples) =>
+          ((hasLoggedTimeout0, hasLoggedError0) match {
+            case (true, true) =>
+              singleCallbackErrorState.set((loggedTimeout + renderedFullName, loggedError + renderedFullName))
+            case (true, false)  => singleCallbackErrorState.set((loggedTimeout + renderedFullName, loggedError))
+            case (false, true)  => singleCallbackErrorState.set((loggedTimeout, loggedError + renderedFullName))
+            case (false, false) => Applicative[F].unit
+          }).as(samples)
+        }
+    }
+
+  /** Run the aggregated-payload computation through the dispatcher with the combined-callbacks timeout + once-only
+    * error logging. Returns `empty` on timeout/error.
+    */
+  private def runAggregateCollect[A](
+      stringName: String,
+      result: F[A],
+      empty: A
+  ): A = runCallbackWithBounds(
+    result,
+    callbackTimeout,
+    th =>
+      trackErrors(
+        callbackTimeoutState,
+        stringName,
+        Applicative[F].pure(empty),
+        logger(th)(
+          s"Timed out running callbacks for metric '$stringName' after $callbackTimeout. " +
+            "This warning will only be shown once for each metric after process start."
+        ).as(empty)
+      ),
+    th =>
+      trackErrors(
+        callbackErrorState,
+        stringName,
+        Applicative[F].pure(empty),
+        logger(th)(
+          s"Callbacks for metric '$stringName' failed with the following exception. " +
+            "This warning will only be shown once for each metric after process start."
+        ).as(empty)
+      )
+  )
+
   override def registerDoubleCounterCallback[A](
       prefix: Option[Metric.Prefix],
       name: Counter.Name,
@@ -526,8 +758,50 @@ class JavaMetricRegistry[F[_]: Async] private (
       commonLabels: Metric.CommonLabels,
       labelNames: IndexedSeq[Label.Name],
       callback: F[NonEmptyList[(Double, A)]]
-  )(f: A => IndexedSeq[String]): Resource[F, Unit] =
-    Resource.eval(ApplicativeThrow[F].raiseError(notYetPorted("registerDoubleCounterCallback")))
+  )(f: A => IndexedSeq[String]): Resource[F, Unit] = {
+    val commonLabelKeys      = commonLabels.value.keys.toIndexedSeq.map(_.value)
+    val commonLabelValuesArr = commonLabels.value.values.toIndexedSeq
+    val allLabelNamesStr     = (labelNames.map(_.value) ++ commonLabelKeys).toArray
+    val rawName              = NameUtils.makeName(prefix, name)
+    // Counter snapshots use the BASE name (without "_total" suffix) per upstream convention; the
+    // exposition writer adds "_total" back to the wire format.
+    val baseName = if (rawName.endsWith("_total")) rawName.dropRight("_total".length) else rawName
+
+    // Project user (Double, A) tuples into (Double, all-label-values) tuples up front so the
+    // generic CallbackPayload type doesn't need to know about A.
+    val projected: F[NonEmptyList[(Double, IndexedSeq[String])]] = callback.map(
+      _.map { case (v, a) => (v, f(a) ++ commonLabelValuesArr) }
+    )
+
+    registerCallback[Counter.Name](
+      MetricType.Counter,
+      prefix,
+      name,
+      projected,
+      makeCollector = (callbacks: Ref[F, CallbackPayload[F]]) =>
+        new PCollector {
+
+          override def collect(): MetricSnapshot = {
+            val aggregated: F[List[(Double, IndexedSeq[String])]] = collectAllPayload(callbacks, baseName)
+            val dataPoints: java.util.List[CounterSnapshot.CounterDataPointSnapshot] =
+              runAggregateCollect(
+                baseName,
+                aggregated.map(_.map { case (value, labelValues) =>
+                  new CounterSnapshot.CounterDataPointSnapshot(
+                    if (value < 0) 0.0 else value,
+                    Labels.of(allLabelNamesStr, labelValues.toArray),
+                    null: io.prometheus.metrics.model.snapshots.Exemplar,
+                    0L
+                  )
+                }.asJava),
+                java.util.Collections.emptyList[CounterSnapshot.CounterDataPointSnapshot]()
+              )
+            new CounterSnapshot(new MetricMetadata(baseName, help.value), dataPoints)
+          }
+
+        }
+    )
+  }
 
   override def registerDoubleGaugeCallback[A](
       prefix: Option[Metric.Prefix],
@@ -631,19 +905,34 @@ object JavaMetricRegistry {
         if (registerJvmMetrics) Sync[F].delay(JvmMetrics.builder().register(promRegistry))
         else Applicative[F].unit
       }.flatMap { _ =>
-        val acquire = for {
-          ref <- Ref.of[F, State[F]](Map.empty)
-          sem <- Semaphore[F](1L)
-        } yield new JavaMetricRegistry[F](promRegistry, ref, sem, logger)
+        Dispatcher.sequential[F].flatMap { dispatcher =>
+          val acquire = for {
+            ref                      <- Ref.of[F, State[F]](Map.empty)
+            cbState                  <- Ref.of[F, CallbackState[F]](Map.empty)
+            cbTimeoutState           <- Ref.of[F, Set[String]](Set.empty)
+            cbErrorState             <- Ref.of[F, Set[String]](Set.empty)
+            singleCallbackErrorState <- Ref.of[F, (Set[String], Set[String])]((Set.empty, Set.empty))
+            sem                      <- Semaphore[F](1L)
+          } yield new JavaMetricRegistry[F](
+            promRegistry, ref, cbState, cbTimeoutState, cbErrorState, singleCallbackErrorState, sem, dispatcher,
+            callbackTimeout = callbackCollectionTimeout, singleCallbackTimeout = callbackTimeout, logger = logger
+          )
 
-        Resource.make(acquire) { reg =>
-          // unregister all metrics that are still claimed at shutdown
-          reg.ref.get.flatMap { metrics =>
-            if (metrics.nonEmpty)
-              metrics.values.toList.traverse_ { case (_, (collector, _, _)) =>
-                Utils.unregister(collector, promRegistry, logger)
+          Resource.make(acquire) { reg =>
+            // Unregister callback collectors first, then claimed metric collectors.
+            reg.callbackState.get.flatMap { cbs =>
+              cbs.values.toList.traverse_ { case (_, _, collector) =>
+                Sync[F].delay(promRegistry.unregister(collector)).handleErrorWith { e =>
+                  logger(e)(s"Failed to unregister callback collector at shutdown: '$collector'")
+                }
               }
-            else Applicative[F].unit
+            } >> reg.ref.get.flatMap { metrics =>
+              if (metrics.nonEmpty)
+                metrics.values.toList.traverse_ { case (_, (collector, _, _)) =>
+                  Utils.unregister(collector, promRegistry, logger)
+                }
+              else Applicative[F].unit
+            }
           }
         }
       }

--- a/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
+++ b/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
@@ -132,7 +132,11 @@ class JavaMetricRegistry[F[_]: Async] private (
               ref.set(metrics - fullName) >> Utils.unregister(collector, registry, logger)
             case Some((`metricId`, (collector, exemplarRef, references))) =>
               ref.set(metrics.updated(fullName, (metricId, (collector, exemplarRef, references - 1))))
-            case _ => Applicative[F].unit
+            case _ =>
+              logger(new IllegalStateException("javaclient: unexpected state during Resource release"))(
+                s"Unexpected state at $renderedFullName release; collector NOT unregistered. " +
+                  "This indicates a bug in the registry state machinery; please report."
+              )
           }
         }
       }
@@ -496,7 +500,11 @@ class JavaMetricRegistry[F[_]: Async] private (
                 }
             case Some((`metricId`, (collector, exemplarRef, references))) =>
               ref.set(metrics.updated(fullName, (metricId, (collector, exemplarRef, references - 1))))
-            case _ => Applicative[F].unit
+            case _ =>
+              logger(new IllegalStateException("javaclient: unexpected state during Info Resource release"))(
+                s"Unexpected state at $renderedFullName release; Info collector NOT unregistered. " +
+                  "This indicates a bug in the registry state machinery; please report."
+              )
           }
         }
       }

--- a/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
+++ b/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
@@ -46,6 +46,7 @@ import io.prometheus.metrics.instrumentation.jvm.JvmMetrics
 import io.prometheus.metrics.model.registry.PrometheusRegistry
 import io.prometheus.metrics.model.registry.{Collector => PCollector}
 import io.prometheus.metrics.model.snapshots.CounterSnapshot
+import io.prometheus.metrics.model.snapshots.GaugeSnapshot
 import io.prometheus.metrics.model.snapshots.Labels
 import io.prometheus.metrics.model.snapshots.MetricMetadata
 import io.prometheus.metrics.model.snapshots.MetricSnapshot
@@ -810,8 +811,44 @@ class JavaMetricRegistry[F[_]: Async] private (
       commonLabels: Metric.CommonLabels,
       labelNames: IndexedSeq[Label.Name],
       callback: F[NonEmptyList[(Double, A)]]
-  )(f: A => IndexedSeq[String]): Resource[F, Unit] =
-    Resource.eval(ApplicativeThrow[F].raiseError(notYetPorted("registerDoubleGaugeCallback")))
+  )(f: A => IndexedSeq[String]): Resource[F, Unit] = {
+    val commonLabelKeys      = commonLabels.value.keys.toIndexedSeq.map(_.value)
+    val commonLabelValuesArr = commonLabels.value.values.toIndexedSeq
+    val allLabelNamesStr     = (labelNames.map(_.value) ++ commonLabelKeys).toArray
+    val fullName             = NameUtils.makeName(prefix, name)
+
+    val projected: F[NonEmptyList[(Double, IndexedSeq[String])]] = callback.map(
+      _.map { case (v, a) => (v, f(a) ++ commonLabelValuesArr) }
+    )
+
+    registerCallback[Gauge.Name](
+      MetricType.Gauge,
+      prefix,
+      name,
+      projected,
+      makeCollector = (callbacks: Ref[F, CallbackPayload[F]]) =>
+        new PCollector {
+
+          override def collect(): MetricSnapshot = {
+            val aggregated = collectAllPayload(callbacks, fullName)
+            val dataPoints: java.util.List[GaugeSnapshot.GaugeDataPointSnapshot] =
+              runAggregateCollect(
+                fullName,
+                aggregated.map(_.map { case (value, labelValues) =>
+                  new GaugeSnapshot.GaugeDataPointSnapshot(
+                    value,
+                    Labels.of(allLabelNamesStr, labelValues.toArray),
+                    null: io.prometheus.metrics.model.snapshots.Exemplar
+                  )
+                }.asJava),
+                java.util.Collections.emptyList[GaugeSnapshot.GaugeDataPointSnapshot]()
+              )
+            new GaugeSnapshot(new MetricMetadata(fullName, help.value), dataPoints)
+          }
+
+        }
+    )
+  }
 
   override def registerDoubleHistogramCallback[A](
       prefix: Option[Metric.Prefix],

--- a/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
+++ b/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
@@ -31,6 +31,7 @@ import cats.syntax.all._
 import io.prometheus.metrics.core.metrics.{Counter => PCounter}
 import io.prometheus.metrics.core.metrics.{Gauge => PGauge}
 import io.prometheus.metrics.core.metrics.{Histogram => PHistogram}
+import io.prometheus.metrics.core.metrics.{Summary => PSummary}
 import io.prometheus.metrics.instrumentation.jvm.JvmMetrics
 import io.prometheus.metrics.model.registry.PrometheusRegistry
 import io.prometheus.metrics.model.snapshots.Labels
@@ -385,8 +386,42 @@ class JavaMetricRegistry[F[_]: Async] private (
       quantiles: Seq[Summary.QuantileDefinition],
       maxAge: FiniteDuration,
       ageBuckets: Summary.AgeBuckets
-  )(f: A => IndexedSeq[String]): Resource[F, Summary[F, Double, A]] =
-    Resource.eval(ApplicativeThrow[F].raiseError(notYetPorted("createAndRegisterDoubleSummary")))
+  )(f: A => IndexedSeq[String]): Resource[F, Summary[F, Double, A]] = {
+    val commonLabelNames       = commonLabels.value.keys.toIndexedSeq
+    val commonLabelValuesArray = commonLabels.value.values.toArray
+    val allLabelNames          = labelNames ++ commonLabelNames
+    val fullName               = NameUtils.makeName(prefix, name)
+
+    configureBuilderOrRetrieve[PSummary](
+      register = () => {
+        val builder = PSummary
+          .builder()
+          .name(fullName)
+          .help(help.value)
+          .labelNames(allLabelNames.map(_.value): _*)
+          .maxAgeSeconds(maxAge.toSeconds)
+          .numberOfAgeBuckets(ageBuckets.value)
+        quantiles.foreach(q => builder.quantile(q.value.value, q.error.value))
+        builder.register(registry)
+      },
+      metricType = MetricType.Summary,
+      metricPrefix = prefix,
+      stringName = name.value,
+      labels = allLabelNames
+    ).map { case (summary, _) =>
+      Summary.make[F, Double, A] { case (d, labels) =>
+        Utils.modifyMetric[F, Summary.Name, io.prometheus.metrics.core.datapoints.DistributionDataPoint](
+          metricName = name,
+          allLabelNames = allLabelNames,
+          dynamicLabels = f(labels),
+          commonLabelValues = commonLabelValuesArray,
+          getDataPoint = (lbls: Array[String]) => summary.labelValues(lbls: _*),
+          modify = (dp: io.prometheus.metrics.core.datapoints.DistributionDataPoint) => dp.observe(d),
+          logger = logger
+        )
+      }
+    }
+  }
 
   override def createAndRegisterInfo[A](
       prefix: Option[Metric.Prefix],

--- a/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
+++ b/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
@@ -798,6 +798,11 @@ class JavaMetricRegistry[F[_]: Async] private (
     // Build CounterDataPointSnapshot instances inside the user callback's F so the generic
     // CallbackPayload type can hold them as plain DataPointSnapshots. The Collector at scrape time
     // casts back to CounterDataPointSnapshot.
+    //
+    // Negative values are clamped to 0.0 to preserve v5 (javasimpleclient) tolerance for malformed
+    // callbacks. Upstream v6's CounterDataPointSnapshot.validate() throws IllegalArgumentException on
+    // negative values, so the clamp prevents a scrape-time crash when a consumer accidentally exposes
+    // a non-monotonic source as a Counter callback.
     val projected: F[NonEmptyList[DataPointSnapshot]] = callback.map(
       _.map { case (v, a) =>
         new CounterSnapshot.CounterDataPointSnapshot(
@@ -1092,6 +1097,8 @@ class JavaMetricRegistry[F[_]: Async] private (
             case x: MetricCollection.Value.LongCounter   => (x.value.toDouble, x.labelValues)
             case x: MetricCollection.Value.DoubleCounter => (x.value, x.labelValues)
           }
+          // Negative values are clamped to 0.0 — same v5-parity / upstream-validate rationale as in
+          // registerDoubleCounterCallback.
           new CounterSnapshot.CounterDataPointSnapshot(
             if (vDouble < 0) 0.0 else vDouble,
             labelsFor(labelNames, lbls),

--- a/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
+++ b/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
@@ -58,6 +58,7 @@ import io.prometheus.metrics.model.snapshots.MetricSnapshot
 import io.prometheus.metrics.model.snapshots.MetricSnapshots
 import io.prometheus.metrics.model.snapshots.Quantiles
 import io.prometheus.metrics.model.snapshots.SummarySnapshot
+import io.prometheus.metrics.model.snapshots.{Exemplar => PExemplar}
 import io.prometheus.metrics.model.snapshots.{Quantile => PQuantile}
 import prometheus4cats._
 import prometheus4cats.javaclient.internal.Utils
@@ -801,7 +802,7 @@ class JavaMetricRegistry[F[_]: Async] private (
         new CounterSnapshot.CounterDataPointSnapshot(
           if (v < 0) 0.0 else v,
           Labels.of(allLabelNamesStr, (f(a) ++ commonLabelValuesArr).toArray),
-          null: io.prometheus.metrics.model.snapshots.Exemplar,
+          null: PExemplar,
           0L
         ): DataPointSnapshot
       }
@@ -850,7 +851,7 @@ class JavaMetricRegistry[F[_]: Async] private (
         new GaugeSnapshot.GaugeDataPointSnapshot(
           v,
           Labels.of(allLabelNamesStr, (f(a) ++ commonLabelValuesArr).toArray),
-          null: io.prometheus.metrics.model.snapshots.Exemplar
+          null: PExemplar
         ): DataPointSnapshot
       }
     )
@@ -1093,7 +1094,7 @@ class JavaMetricRegistry[F[_]: Async] private (
           new CounterSnapshot.CounterDataPointSnapshot(
             if (vDouble < 0) 0.0 else vDouble,
             labelsFor(labelNames, lbls),
-            null: io.prometheus.metrics.model.snapshots.Exemplar,
+            null: PExemplar,
             0L
           )
         }.asJava
@@ -1112,7 +1113,7 @@ class JavaMetricRegistry[F[_]: Async] private (
           new GaugeSnapshot.GaugeDataPointSnapshot(
             vDouble,
             labelsFor(labelNames, lbls),
-            null: io.prometheus.metrics.model.snapshots.Exemplar
+            null: PExemplar
           )
         }.asJava
         new GaugeSnapshot(new MetricMetadata(fullName, head.help.value), dps): MetricSnapshot

--- a/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/internal/Utils.scala
+++ b/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/internal/Utils.scala
@@ -19,7 +19,7 @@ package prometheus4cats.javaclient.internal
 import cats.effect.kernel.Sync
 import cats.syntax.all._
 
-import io.prometheus.metrics.core.metrics.StatefulMetric
+import io.prometheus.metrics.core.metrics.MetricWithFixedMetadata
 import io.prometheus.metrics.model.registry.PrometheusRegistry
 import prometheus4cats.Label
 import prometheus4cats.javaclient.models.Exceptions._
@@ -27,7 +27,7 @@ import prometheus4cats.javaclient.models.Exceptions._
 private[javaclient] object Utils {
 
   private[javaclient] def unregister[F[_]: Sync](
-      collector: StatefulMetric[_, _],
+      collector: MetricWithFixedMetadata,
       registry: PrometheusRegistry,
       logger: Throwable => String => F[Unit]
   ): F[Unit] =

--- a/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/package.scala
+++ b/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/package.scala
@@ -17,9 +17,12 @@
 package prometheus4cats
 
 import cats.Show
+import cats.data.NonEmptyList
 import cats.effect.kernel.Ref
+import cats.effect.kernel.Unique
 
 import io.prometheus.metrics.core.metrics.MetricWithFixedMetadata
+import io.prometheus.metrics.model.registry.Collector
 import prometheus4cats.javaclient.models.MetricType
 import prometheus4cats.util.NameUtils
 
@@ -37,6 +40,21 @@ package object javaclient {
     (MetricID, (MetricWithFixedMetadata, Ref[F, Option[Exemplar.Data]], Int))
 
   private[javaclient] type State[F[_]] = Map[StateKey, StateValue[F]]
+
+  /** Per-metric-name callback registry state. Each registered metric name has exactly one upstream `Collector`;
+    * multiple consumer registrations attach to that single Collector via a `Unique.Token`-keyed inner Ref. The
+    * Collector at scrape time runs all stored callbacks through the dispatcher, merges their per-registration results
+    * into a single `MetricSnapshot`, and returns it.
+    *
+    * The inner callback type is uniformly `F[NEL[(Double, IndexedSeq[String])]]` — value plus pre-projected label
+    * values. Per-metric-type Collector subclasses convert these tuples into the appropriate kind-specific data-point
+    * snapshots at collect time. Long-typed callbacks are derived from Double via DoubleCallbackRegistry.
+    */
+  private[javaclient] type CallbackPayload[F[_]] =
+    Map[Unique.Token, F[NonEmptyList[(Double, IndexedSeq[String])]]]
+
+  private[javaclient] type CallbackState[F[_]] =
+    Map[StateKey, (MetricType, Ref[F, CallbackPayload[F]], Collector)]
 
   private[javaclient] val duplicateShow: Show[(Option[Metric.Prefix], String)] = Show.show { case (prefix, name) =>
     NameUtils.makeName(prefix, name)

--- a/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/package.scala
+++ b/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/package.scala
@@ -19,7 +19,7 @@ package prometheus4cats
 import cats.Show
 import cats.effect.kernel.Ref
 
-import io.prometheus.metrics.core.metrics.StatefulMetric
+import io.prometheus.metrics.core.metrics.MetricWithFixedMetadata
 import prometheus4cats.javaclient.models.MetricType
 import prometheus4cats.util.NameUtils
 
@@ -29,8 +29,12 @@ package object javaclient {
 
   private[javaclient] type MetricID = (IndexedSeq[Label.Name], MetricType)
 
+  /** State entry bound by the most specific common parent of every upstream metric type we register —
+    * `MetricWithFixedMetadata`. Counter, Gauge, Histogram, Summary all extend `StatefulMetric` which extends this; Info
+    * extends this directly without going through `StatefulMetric`.
+    */
   private[javaclient] type StateValue[F[_]] =
-    (MetricID, (StatefulMetric[_, _], Ref[F, Option[Exemplar.Data]], Int))
+    (MetricID, (MetricWithFixedMetadata, Ref[F, Option[Exemplar.Data]], Int))
 
   private[javaclient] type State[F[_]] = Map[StateKey, StateValue[F]]
 

--- a/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/package.scala
+++ b/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/package.scala
@@ -23,6 +23,7 @@ import cats.effect.kernel.Unique
 
 import io.prometheus.metrics.core.metrics.MetricWithFixedMetadata
 import io.prometheus.metrics.model.registry.Collector
+import io.prometheus.metrics.model.snapshots.DataPointSnapshot
 import prometheus4cats.javaclient.models.MetricType
 import prometheus4cats.util.NameUtils
 
@@ -46,12 +47,15 @@ package object javaclient {
     * Collector at scrape time runs all stored callbacks through the dispatcher, merges their per-registration results
     * into a single `MetricSnapshot`, and returns it.
     *
-    * The inner callback type is uniformly `F[NEL[(Double, IndexedSeq[String])]]` — value plus pre-projected label
-    * values. Per-metric-type Collector subclasses convert these tuples into the appropriate kind-specific data-point
-    * snapshots at collect time. Long-typed callbacks are derived from Double via DoubleCallbackRegistry.
+    * The inner callback type is uniformly `F[NEL[DataPointSnapshot]]` — pre-built upstream data-point snapshots. Each
+    * kind-specific `register*Callback` method maps the user's typed callback (e.g., `F[NEL[(Double, A)]]` for Counter
+    * or `F[NEL[(Histogram.Value[Double], A)]]` for Histogram) into the right concrete `DataPointSnapshot` subtype
+    * inline. The kind-specific Collector then casts the data points to its concrete subtype to build the right
+    * `MetricSnapshot`. Casts are safe because the public `register*Callback` signatures enforce type-correctness at the
+    * boundary; internal storage only needs the parent type.
     */
   private[javaclient] type CallbackPayload[F[_]] =
-    Map[Unique.Token, F[NonEmptyList[(Double, IndexedSeq[String])]]]
+    Map[Unique.Token, F[NonEmptyList[DataPointSnapshot]]]
 
   private[javaclient] type CallbackState[F[_]] =
     Map[StateKey, (MetricType, Ref[F, CallbackPayload[F]], Collector)]

--- a/modules/prometheus4cats-java/src/test/scala/prometheus4cats/javaclient/JavaMetricRegistrySuite.scala
+++ b/modules/prometheus4cats-java/src/test/scala/prometheus4cats/javaclient/JavaMetricRegistrySuite.scala
@@ -18,6 +18,7 @@ package prometheus4cats.javaclient
 
 import scala.jdk.CollectionConverters._
 
+import cats.data.NonEmptyList
 import cats.data.NonEmptySeq
 import cats.effect.IO
 import cats.effect.kernel.Resource
@@ -251,6 +252,40 @@ class JavaMetricRegistrySuite extends CatsEffectSuite {
   // built without labelNames produces no observable scrape entry. This is an edge case (real-world
   // Info almost always carries identity labels like version/commit/instance), but should be
   // surfaced in the v6 migration guide for any consumer that relied on a no-label `Info[F, Unit]`.
+
+  test("counter callback — scrape invokes the user callback and propagates the value to the snapshot") {
+    val promRegistry = new PrometheusRegistry()
+
+    JavaMetricRegistry
+      .Builder[IO]()
+      .withRegistry(promRegistry)
+      .build
+      .use { registry =>
+        val factory  = MetricFactory.builder.build[IO](registry, registry)
+        val callback = IO.pure(NonEmptyList.of((42.0, "alpha"), (7.0, "beta")))
+        factory
+          .counter("test_callback_counter_total")
+          .ofDouble
+          .help("test counter callback")
+          .label[String]("variant")
+          .callback(callback)
+          .build
+          .use { _ =>
+            IO.delay {
+              val snapshot = promRegistry
+                .scrape()
+                .asScala
+                .collectFirst { case s: CounterSnapshot if s.getMetadata.getName === "test_callback_counter" => s }
+                .getOrElse(fail("expected a CounterSnapshot named 'test_callback_counter'"))
+              val byLabel = snapshot.getDataPoints.asScala
+                .map(dp => dp.getLabels.get("variant") -> dp.getValue)
+                .toMap
+              assertEquals(byLabel.get("alpha"), Some(42.0))
+              assertEquals(byLabel.get("beta"), Some(7.0))
+            }
+          }
+      }
+  }
 
   test("registry release unregisters all claimed metrics from the underlying PrometheusRegistry") {
     val promRegistry = new PrometheusRegistry()

--- a/modules/prometheus4cats-java/src/test/scala/prometheus4cats/javaclient/JavaMetricRegistrySuite.scala
+++ b/modules/prometheus4cats-java/src/test/scala/prometheus4cats/javaclient/JavaMetricRegistrySuite.scala
@@ -287,6 +287,38 @@ class JavaMetricRegistrySuite extends CatsEffectSuite {
       }
   }
 
+  test("gauge callback — scrape invokes the user callback and propagates the value to the snapshot") {
+    val promRegistry = new PrometheusRegistry()
+
+    JavaMetricRegistry
+      .Builder[IO]()
+      .withRegistry(promRegistry)
+      .build
+      .use { registry =>
+        val factory  = MetricFactory.builder.build[IO](registry, registry)
+        val callback = IO.pure(NonEmptyList.of((50.0, "n0"), (100.0, "n1")))
+        factory
+          .gauge("test_callback_gauge")
+          .ofDouble
+          .help("test gauge callback")
+          .label[String]("node")
+          .callback(callback)
+          .build
+          .use { _ =>
+            IO.delay {
+              val snapshot = promRegistry
+                .scrape()
+                .asScala
+                .collectFirst { case s: GaugeSnapshot if s.getMetadata.getName === "test_callback_gauge" => s }
+                .getOrElse(fail("expected a GaugeSnapshot named 'test_callback_gauge'"))
+              val byLabel = snapshot.getDataPoints.asScala.map(dp => dp.getLabels.get("node") -> dp.getValue).toMap
+              assertEquals(byLabel.get("n0"), Some(50.0))
+              assertEquals(byLabel.get("n1"), Some(100.0))
+            }
+          }
+      }
+  }
+
   test("registry release unregisters all claimed metrics from the underlying PrometheusRegistry") {
     val promRegistry = new PrometheusRegistry()
 

--- a/modules/prometheus4cats-java/src/test/scala/prometheus4cats/javaclient/JavaMetricRegistrySuite.scala
+++ b/modules/prometheus4cats-java/src/test/scala/prometheus4cats/javaclient/JavaMetricRegistrySuite.scala
@@ -319,6 +319,88 @@ class JavaMetricRegistrySuite extends CatsEffectSuite {
       }
   }
 
+  test("histogram callback — value+labels map into a HistogramDataPointSnapshot with classic buckets") {
+    val promRegistry = new PrometheusRegistry()
+
+    JavaMetricRegistry
+      .Builder[IO]()
+      .withRegistry(promRegistry)
+      .build
+      .use { registry =>
+        val factory = MetricFactory.builder.build[IO](registry, registry)
+        // bucketValues are CUMULATIVE counts indexed by (declared-buckets ++ +Inf) — so for buckets
+        // 0.1, 1.0, 5.0 with three observations of 0.05, 0.5, 2.0 the cumulative counts are
+        // [1, 2, 3, 3] (≤0.1, ≤1.0, ≤5.0, ≤+Inf).
+        val histValue = Histogram.Value[Double](2.55, NonEmptySeq.of(1.0, 2.0, 3.0, 3.0))
+        val callback  = IO.pure(NonEmptyList.of((histValue, "alpha")))
+        factory
+          .histogram("test_callback_histogram")
+          .ofDouble
+          .help("test histogram callback")
+          .buckets(NonEmptySeq.of(0.1, 1.0, 5.0))
+          .label[String]("variant")
+          .callback(callback)
+          .build
+          .use { _ =>
+            IO.delay {
+              val snapshot = promRegistry
+                .scrape()
+                .asScala
+                .collectFirst { case s: HistogramSnapshot if s.getMetadata.getName === "test_callback_histogram" => s }
+                .getOrElse(fail("expected a HistogramSnapshot named 'test_callback_histogram'"))
+              val dp = snapshot.getDataPoints.asScala.head
+              assert(dp.hasClassicHistogramData)
+              assertEqualsDouble(dp.getSum, 2.55, 1e-9)
+              // Classic buckets propagate; +Inf is the last upper bound we appended.
+              val upperBounds = dp.getClassicBuckets.asScala.map(_.getUpperBound).toSet
+              assert(upperBounds.contains(0.1), s"saw upper bounds $upperBounds")
+              assert(upperBounds.contains(5.0), s"saw upper bounds $upperBounds")
+            }
+          }
+      }
+  }
+
+  test("summary callback — count, sum, and declared quantiles propagate to the snapshot") {
+    val promRegistry = new PrometheusRegistry()
+
+    JavaMetricRegistry
+      .Builder[IO]()
+      .withRegistry(promRegistry)
+      .build
+      .use { registry =>
+        val factory = MetricFactory.builder.build[IO](registry, registry)
+        val summaryValue = Summary.Value[Double](
+          count = 10.0,
+          sum = 42.5,
+          quantiles = Map(0.5 -> 1.2, 0.99 -> 9.5)
+        )
+        val callback = IO.pure(NonEmptyList.of((summaryValue, "alpha")))
+        factory
+          .summary("test_callback_summary")
+          .ofDouble
+          .help("test summary callback")
+          .label[String]("variant")
+          .callback(callback)
+          .build
+          .use { _ =>
+            IO.delay {
+              val snapshot = promRegistry
+                .scrape()
+                .asScala
+                .collectFirst { case s: SummarySnapshot if s.getMetadata.getName === "test_callback_summary" => s }
+                .getOrElse(fail("expected a SummarySnapshot named 'test_callback_summary'"))
+              val dp = snapshot.getDataPoints.asScala.head
+              assertEquals(dp.getCount, 10L)
+              assertEqualsDouble(dp.getSum, 42.5, 1e-9)
+              val quantileValues = dp.getQuantiles.asScala.map(q => q.getQuantile -> q.getValue).toMap
+              assertEquals(quantileValues.size, 2)
+              assertEqualsDouble(quantileValues(0.5), 1.2, 1e-9)
+              assertEqualsDouble(quantileValues(0.99), 9.5, 1e-9)
+            }
+          }
+      }
+  }
+
   test("registry release unregisters all claimed metrics from the underlying PrometheusRegistry") {
     val promRegistry = new PrometheusRegistry()
 

--- a/modules/prometheus4cats-java/src/test/scala/prometheus4cats/javaclient/JavaMetricRegistrySuite.scala
+++ b/modules/prometheus4cats-java/src/test/scala/prometheus4cats/javaclient/JavaMetricRegistrySuite.scala
@@ -27,6 +27,7 @@ import io.prometheus.metrics.model.registry.PrometheusRegistry
 import io.prometheus.metrics.model.snapshots.CounterSnapshot
 import io.prometheus.metrics.model.snapshots.GaugeSnapshot
 import io.prometheus.metrics.model.snapshots.HistogramSnapshot
+import io.prometheus.metrics.model.snapshots.InfoSnapshot
 import io.prometheus.metrics.model.snapshots.SummarySnapshot
 import munit.CatsEffectSuite
 import prometheus4cats._
@@ -215,6 +216,41 @@ class JavaMetricRegistrySuite extends CatsEffectSuite {
         }
     }
   }
+
+  test("info — declared labels propagate to scrape output via setLabelValues") {
+    freshRegistry.use { case (promRegistry, factory) =>
+      factory
+        .info("test_build_info")
+        .help("test build info")
+        .label[String]("version")
+        .label[String]("commit")
+        .build
+        .use { i =>
+          // Two `.label[String]` calls produce an Info[F, (String, String)] via the existing
+          // labelled-DSL machinery (InitLast tuple-builder).
+          i.info(("1.2.3", "abc1234")) >> IO.delay {
+            // Upstream stores Info under its base name (without the `_info` suffix). The wire format
+            // still emits `test_build_info{...} 1` — the suffix is added by the exposition writer.
+            val snapshot = promRegistry
+              .scrape()
+              .asScala
+              .collectFirst { case s: InfoSnapshot if s.getMetadata.getName === "test_build" => s }
+              .getOrElse(fail("expected an InfoSnapshot for the 'test_build_info' metric"))
+            val dp       = snapshot.getDataPoints.asScala.head
+            val labelMap = dp.getLabels.asScala.map(l => l.getName -> l.getValue).toMap
+            assertEquals(labelMap.get("version"), Some("1.2.3"))
+            assertEquals(labelMap.get("commit"), Some("abc1234"))
+          }
+        }
+    }
+  }
+
+  // NOTE: An "Info with no labels declared" test was attempted and removed — upstream
+  // prometheus-metrics-core 1.x's Info requires at least one labelName for the metric to emit a
+  // data point in scrape output. Calling `setLabelValues()` with empty varargs against an Info
+  // built without labelNames produces no observable scrape entry. This is an edge case (real-world
+  // Info almost always carries identity labels like version/commit/instance), but should be
+  // surfaced in the v6 migration guide for any consumer that relied on a no-label `Info[F, Unit]`.
 
   test("registry release unregisters all claimed metrics from the underlying PrometheusRegistry") {
     val promRegistry = new PrometheusRegistry()

--- a/modules/prometheus4cats-java/src/test/scala/prometheus4cats/javaclient/JavaMetricRegistrySuite.scala
+++ b/modules/prometheus4cats-java/src/test/scala/prometheus4cats/javaclient/JavaMetricRegistrySuite.scala
@@ -401,6 +401,56 @@ class JavaMetricRegistrySuite extends CatsEffectSuite {
       }
   }
 
+  test(
+    "metric-collection callback — emits all four kinds (counter, gauge, histogram, summary) from a single callback"
+  ) {
+    val promRegistry = new PrometheusRegistry()
+
+    JavaMetricRegistry
+      .Builder[IO]()
+      .withRegistry(promRegistry)
+      .build
+      .use { registry =>
+        val factory = MetricFactory.builder.build[IO](registry, registry)
+
+        val collection: MetricCollection = MetricCollection.empty
+          .appendDoubleCounter(
+            Counter.Name.unsafeFrom("collection_counter_total"),
+            Metric.Help("test counter"),
+            Map.empty[Label.Name, String],
+            42.0
+          )
+          .appendDoubleGauge(
+            Gauge.Name.unsafeFrom("collection_gauge"),
+            Metric.Help("test gauge"),
+            Map.empty[Label.Name, String],
+            7.0
+          )
+
+        factory
+          .metricCollectionCallback(IO.pure(collection))
+          .build
+          .use { _ =>
+            IO.delay {
+              val snapshots = promRegistry.scrape().asScala.toList
+              val names     = snapshots.map(s => s.getClass.getSimpleName -> s.getMetadata.getName).toSet
+              assert(
+                names.contains("CounterSnapshot" -> "collection_counter"),
+                s"expected CounterSnapshot 'collection_counter'; saw $names"
+              )
+              assert(
+                names.contains("GaugeSnapshot" -> "collection_gauge"),
+                s"expected GaugeSnapshot 'collection_gauge'; saw $names"
+              )
+              val counter = snapshots.collectFirst {
+                case s: CounterSnapshot if s.getMetadata.getName === "collection_counter" => s
+              }.get
+              assertEquals(counter.getDataPoints.asScala.head.getValue, 42.0)
+            }
+          }
+      }
+  }
+
   test("registry release unregisters all claimed metrics from the underlying PrometheusRegistry") {
     val promRegistry = new PrometheusRegistry()
 

--- a/modules/prometheus4cats-java/src/test/scala/prometheus4cats/javaclient/JavaMetricRegistrySuite.scala
+++ b/modules/prometheus4cats-java/src/test/scala/prometheus4cats/javaclient/JavaMetricRegistrySuite.scala
@@ -27,6 +27,7 @@ import io.prometheus.metrics.model.registry.PrometheusRegistry
 import io.prometheus.metrics.model.snapshots.CounterSnapshot
 import io.prometheus.metrics.model.snapshots.GaugeSnapshot
 import io.prometheus.metrics.model.snapshots.HistogramSnapshot
+import io.prometheus.metrics.model.snapshots.SummarySnapshot
 import munit.CatsEffectSuite
 import prometheus4cats._
 
@@ -184,6 +185,32 @@ class JavaMetricRegistrySuite extends CatsEffectSuite {
             val dp = snapshot.getDataPoints.asScala.head
             assert(dp.hasNativeHistogramData)
             assertEquals(dp.getNativeSchema, 3)
+          }
+        }
+    }
+  }
+
+  test("summary — quantiles propagate and observations are aggregated") {
+    freshRegistry.use { case (promRegistry, factory) =>
+      factory
+        .summary("test_summary")
+        .ofDouble
+        .help("test summary")
+        .quantile(Summary.Quantile.from(0.5).toOption.get, Summary.AllowedError.from(0.05).toOption.get)
+        .quantile(Summary.Quantile.from(0.99).toOption.get, Summary.AllowedError.from(0.01).toOption.get)
+        .build
+        .use { s =>
+          (s.observe(0.1) >> s.observe(0.5) >> s.observe(1.0) >> s.observe(2.5)) >> IO.delay {
+            val snapshot = promRegistry
+              .scrape()
+              .asScala
+              .collectFirst { case s: SummarySnapshot if s.getMetadata.getName === "test_summary" => s }
+              .getOrElse(fail("expected a SummarySnapshot named 'test_summary'"))
+            val dp = snapshot.getDataPoints.asScala.head
+            assertEquals(dp.getCount, 4L)
+            assertEqualsDouble(dp.getSum, 4.1, 1e-9)
+            // quantile-based summaries record the quantile values; assert both quantiles were declared
+            assertEquals(dp.getQuantiles.size, 2)
           }
         }
     }


### PR DESCRIPTION
Replaces the last two `notYetPorted` registration stubs in the `javaclient` backend (Summary and Info) with real implementations against `prometheus-metrics-core` 1.x.

After this PR: every non-callback metric-registration method on the new backend is implemented. The only remaining stubs are the five callback registrations + the `MetricCollection` callback, which land in PR 9.

## Summary impl

Builds `PSummary` via the upstream builder, applying:
- `.maxAgeSeconds(maxAge.toSeconds)` + `.numberOfAgeBuckets(ageBuckets.value)`
- Each declared `Summary.QuantileDefinition` mapped to `.quantile(q.value, q.error)` via a `quantiles.foreach` side-effect loop (the upstream builder mutates in-place and returns self for chaining; the loop is the idiomatic way to apply N quantile setters).
- Registration via the shared `configureBuilderOrRetrieve` helper for ref-counted registration semantics.

## Info impl

Uses upstream's `Info.builder().labelNames(...).register()` then `setLabelValues(values...)` at observation, matching PR #130's redesigned SPI (`Info[F, A]` with build-time labelNames and curried label-value projection).

Uses an **inline state machine** for registration rather than `configureBuilderOrRetrieve`, because Info extends `MetricWithFixedMetadata` directly (not `StatefulMetric`) and doesn't need exemplar tracking. The inline machine mirrors the same ref-counted registration + cross-axis collision detection semantics.

Subtle: upstream's `Info.builder()` strips the `_info` suffix internally and re-appends it during exposition. The user-supplied `Info.Name` is constrained to end in `_info` (regex on the refined Name type), so this adapter passes the raw name through and lets upstream handle the round-trip.

## Context

PR 8 of the v6 backend uplift split out of #124. Stacked on #133 (javaclient histograms).

Two source commits combined:
- `23c94adfb2c82e6f5eeef0503bf8789f2eb46954` — Summary impl. Conflict resolution carried over PR #133's helper-extraction refactor's Summary prologue while keeping the cherry-picked impl body, plus replaced the deferred v5-shape Info stub with the v6 `[A]`-shape from PR #132's SPI alignment.
- `javaclient/` hunks from `b14e0bbaa758d0888230370e227d540f4e502892` — Info impl + the new `+ Info` smoke test. The core SPI redesign hunks already landed in PR #130.

## Risk

Low — pure extension over PR 133's backend. Two new method bodies replacing throwing stubs. No SPI changes (committed in PR #129/#130/#131).

## Test plan

- [x] `sbt ci-test` green locally on Scala 2.13.18 + 3.3.7 (123 tests pass, +2 new Info smoke tests vs PR 133's 121).
- [ ] CI green on JDK 11 / 17 / 21 / 25

## Reviewer focus

- **Quantile side-effect loop** (`quantiles.foreach(q => builder.quantile(q.value.value, q.error.value))`) — `PSummary.Builder.quantile(...)` mutates and returns self. The `.foreach` form is shorter than fold-style, intentional.
- **Info's inline state machine** vs the shared `configureBuilderOrRetrieve` — different because Info is `MetricWithFixedMetadata`, not `StatefulMetric`, and skips the exemplar Ref machinery. State-key/dedup/refcount semantics are identical to the shared helper.
- **The `_info` suffix round-trip** — `Info.Name`'s regex enforces the `_info` suffix; upstream strips and re-appends. Worth confirming the smoke test asserts on the exposition with the suffix.
- **`@SuppressWarnings(Array("scalafix:DisableSyntax.=="))` on the Info method** — same scalafix-rule trap as `configureBuilderOrRetrieve`. The `metricId == expected` check is a same-type tuple comparison; suppression is targeted to this one method.