### PR TITLE
series/6.x - improve test suite

### DIFF
--- a/modules/prometheus4cats-java/src/test/scala/prometheus4cats/javaclient/JavaMetricRegistrySuite.scala
+++ b/modules/prometheus4cats-java/src/test/scala/prometheus4cats/javaclient/JavaMetricRegistrySuite.scala
@@ -18,11 +18,9 @@ package prometheus4cats.javaclient
 
 import scala.jdk.CollectionConverters._
 
-import cats.data.NonEmptyList
-import cats.data.NonEmptySeq
 import cats.effect.IO
+import cats.effect.Ref
 import cats.effect.kernel.Resource
-import cats.syntax.all._
 
 import io.prometheus.metrics.model.registry.PrometheusRegistry
 import io.prometheus.metrics.model.snapshots.CounterSnapshot
@@ -32,572 +30,126 @@ import io.prometheus.metrics.model.snapshots.InfoSnapshot
 import io.prometheus.metrics.model.snapshots.SummarySnapshot
 import munit.CatsEffectSuite
 import prometheus4cats._
+import prometheus4cats.testkit.DslSuite
 
-/** Smoke tests for the new javaclient backend covering Counter, Gauge, and (most importantly) the classic vs native
-  * histogram distinction.
+/** v6-backend wiring for the cross-backend [[DslSuite]].
   *
-  * The comprehensive testkit-based [[MetricRegistrySuite]] / [[CallbackRegistrySuite]] (which auto-tests every method)
-  * will be wired in once Summary, Info, and the callback path are also implemented in this backend. Until then, the
-  * testkit suites can't be applied because the unimplemented methods would throw.
+  * No tests are declared here — every DSL test (counter / gauge / histogram (classic + native + dual) / summary / info
+  * / callbacks / metric-collection / release / 5 name-collision contracts) lives in [[DslSuite]]. This class implements
+  * the two abstract hooks and provides the v6-snapshot → `FamilyState` translation.
+  *
+  * `getRegistryState` is parameterless on the testkit side, so the currently-active `PrometheusRegistry` is threaded
+  * through a `Ref` set inside the `resource` acquire and cleared on release. MUnit runs tests within a suite
+  * sequentially and every `getRegistryState` call happens inside an active `resource.use { … }` scope, so the Ref
+  * always has a value when read.
   */
-class JavaMetricRegistrySuite extends CatsEffectSuite {
+class JavaMetricRegistrySuite extends CatsEffectSuite with DslSuite {
 
-  private def freshRegistry: Resource[IO, (PrometheusRegistry, MetricFactory[IO])] =
+  // ─── DslSuite hooks ───────────────────────────────────────────────────────────────────────────────
+
+  private val promRegistryRef: Ref[IO, Option[PrometheusRegistry]] =
+    Ref.unsafe[IO, Option[PrometheusRegistry]](None)
+
+  override def resource: Resource[IO, MetricFactory.WithCallbacks[IO]] =
     for {
       promRegistry <- Resource.eval(IO.delay(new PrometheusRegistry()))
+      _            <- Resource.make(promRegistryRef.set(Some(promRegistry)))(_ => promRegistryRef.set(None))
       registry     <- JavaMetricRegistry.Builder[IO]().withRegistry(promRegistry).build
-      factory       = MetricFactory.builder.build[IO](registry)
-    } yield (promRegistry, factory)
+    } yield MetricFactory.builder.build[IO](registry)
 
-  // Snapshots are only present in the underlying PrometheusRegistry while the metric Resource is held;
-  // releasing the metric unregisters it. So all assertions must run inside the metric's `.use` scope.
-
-  test("counter — inc once, scrape returns the incremented value") {
-    freshRegistry.use { case (promRegistry, factory) =>
-      factory
-        .counter("test_counter_total")
-        .ofDouble
-        .help("test counter")
-        .build
-        .use { c =>
-          c.inc(1.0) >> IO.delay {
-            val snapshot = promRegistry
-              .scrape()
-              .asScala
-              .collectFirst { case s: CounterSnapshot if s.getMetadata.getName === "test_counter" => s }
-              .getOrElse(fail("expected a CounterSnapshot named 'test_counter'"))
-            assertEquals(snapshot.getDataPoints.asScala.head.getValue, 1.0)
-          }
-        }
-    }
-  }
-
-  test("gauge — inc, dec, and set are each reflected in the scrape") {
-    freshRegistry.use { case (promRegistry, factory) =>
-      factory
-        .gauge("test_gauge")
-        .ofDouble
-        .help("test gauge")
-        .build
-        .use { g =>
-          g.inc(5.0) >> g.dec(2.0) >> g.set(10.0) >> IO.delay {
-            val snapshot = promRegistry
-              .scrape()
-              .asScala
-              .collectFirst { case s: GaugeSnapshot if s.getMetadata.getName === "test_gauge" => s }
-              .getOrElse(fail("expected a GaugeSnapshot named 'test_gauge'"))
-            assertEquals(snapshot.getDataPoints.asScala.head.getValue, 10.0)
-          }
-        }
-    }
-  }
-
-  test("classic histogram — scrape produces classic buckets, no native data") {
-    freshRegistry.use { case (promRegistry, factory) =>
-      factory
-        .histogram("test_classic_histogram")
-        .ofDouble
-        .help("test classic histogram")
-        .buckets(NonEmptySeq.of(0.1, 0.5, 1.0, 5.0))
-        .build
-        .use { h =>
-          (h.observe(0.05) >> h.observe(0.3) >> h.observe(0.7) >> h.observe(2.0)) >> IO.delay {
-            val snapshot = promRegistry
-              .scrape()
-              .asScala
-              .collectFirst { case s: HistogramSnapshot if s.getMetadata.getName === "test_classic_histogram" => s }
-              .getOrElse(fail("expected a HistogramSnapshot named 'test_classic_histogram'"))
-            val dp = snapshot.getDataPoints.asScala.head
-            assert(dp.hasClassicHistogramData, "expected classic histogram data")
-            assert(!dp.hasNativeHistogramData, "did not expect native histogram data on a classic histogram")
-            assertEquals(dp.getCount, 4L)
-            assertEqualsDouble(dp.getSum, 3.05, 1e-9)
-          }
-        }
-    }
-  }
-
-  test("native histogram — scrape produces native bucket data, no classic buckets") {
-    freshRegistry.use { case (promRegistry, factory) =>
-      factory
-        .nativeHistogram("test_native_histogram")
-        .help("test native histogram")
-        .build
-        .use { h =>
-          (h.observe(0.05) >> h.observe(0.3) >> h.observe(0.7) >> h.observe(2.0)) >> IO.delay {
-            val snapshot = promRegistry
-              .scrape()
-              .asScala
-              .collectFirst { case s: HistogramSnapshot if s.getMetadata.getName === "test_native_histogram" => s }
-              .getOrElse(fail("expected a HistogramSnapshot named 'test_native_histogram'"))
-            val dp = snapshot.getDataPoints.asScala.head
-            assert(!dp.hasClassicHistogramData, "did not expect classic histogram data on a native histogram")
-            assert(dp.hasNativeHistogramData, "expected native histogram data")
-            assertEquals(dp.getCount, 4L)
-            assertEqualsDouble(dp.getSum, 3.05, 1e-9)
-          }
-        }
-    }
-  }
-
-  test("dual-mode histogram (.withNative) — scrape produces BOTH classic and native data") {
-    freshRegistry.use { case (promRegistry, factory) =>
-      factory
-        .histogram("test_dual_histogram")
-        .ofDouble
-        .help("test dual-mode (NHCB-friendly) histogram")
-        .buckets(NonEmptySeq.of(0.1, 0.5, 1.0, 5.0))
-        .withNative
-        .build
-        .use { h =>
-          (h.observe(0.05) >> h.observe(0.3) >> h.observe(0.7) >> h.observe(2.0)) >> IO.delay {
-            val snapshot = promRegistry
-              .scrape()
-              .asScala
-              .collectFirst { case s: HistogramSnapshot if s.getMetadata.getName === "test_dual_histogram" => s }
-              .getOrElse(fail("expected a HistogramSnapshot named 'test_dual_histogram'"))
-            val dp = snapshot.getDataPoints.asScala.head
-            // The headline assertion: BOTH classic and native data are emitted from a single declaration.
-            assert(dp.hasClassicHistogramData, "expected classic histogram data on dual-mode histogram")
-            assert(dp.hasNativeHistogramData, "expected native histogram data on dual-mode histogram")
-            assertEquals(dp.getCount, 4L)
-            assertEqualsDouble(dp.getSum, 3.05, 1e-9)
-            // Classic buckets are preserved as supplied.
-            val classicBuckets = dp.getClassicBuckets.asScala.map(_.getUpperBound).toSet
-            assert(classicBuckets.contains(0.1), s"expected classic bucket 0.1; got $classicBuckets")
-            assert(classicBuckets.contains(5.0), s"expected classic bucket 5.0; got $classicBuckets")
-          }
-        }
-    }
-  }
-
-  test("native histogram — custom NativeHistogram config propagates initialSchema to the scraped snapshot") {
-    freshRegistry.use { case (promRegistry, factory) =>
-      factory
-        .nativeHistogram("test_native_tuned", NativeHistogram.Default.withInitialSchema(3))
-        .help("native with custom schema")
-        .build
-        .use { h =>
-          h.observe(1.0) >> IO.delay {
-            val snapshot = promRegistry
-              .scrape()
-              .asScala
-              .collectFirst { case s: HistogramSnapshot if s.getMetadata.getName === "test_native_tuned" => s }
-              .getOrElse(fail("expected a HistogramSnapshot named 'test_native_tuned'"))
-            val dp = snapshot.getDataPoints.asScala.head
-            assert(dp.hasNativeHistogramData)
-            assertEquals(dp.getNativeSchema, 3)
-          }
-        }
-    }
-  }
-
-  test("summary — quantiles propagate and observations are aggregated") {
-    freshRegistry.use { case (promRegistry, factory) =>
-      factory
-        .summary("test_summary")
-        .ofDouble
-        .help("test summary")
-        .quantile(Summary.Quantile.from(0.5).toOption.get, Summary.AllowedError.from(0.05).toOption.get)
-        .quantile(Summary.Quantile.from(0.99).toOption.get, Summary.AllowedError.from(0.01).toOption.get)
-        .build
-        .use { s =>
-          (s.observe(0.1) >> s.observe(0.5) >> s.observe(1.0) >> s.observe(2.5)) >> IO.delay {
-            val snapshot = promRegistry
-              .scrape()
-              .asScala
-              .collectFirst { case s: SummarySnapshot if s.getMetadata.getName === "test_summary" => s }
-              .getOrElse(fail("expected a SummarySnapshot named 'test_summary'"))
-            val dp = snapshot.getDataPoints.asScala.head
-            assertEquals(dp.getCount, 4L)
-            assertEqualsDouble(dp.getSum, 4.1, 1e-9)
-            // quantile-based summaries record the quantile values; assert both quantiles were declared
-            assertEquals(dp.getQuantiles.size, 2)
-          }
-        }
-    }
-  }
-
-  test("info — declared labels propagate to scrape output via setLabelValues") {
-    freshRegistry.use { case (promRegistry, factory) =>
-      factory
-        .info("test_build_info")
-        .help("test build info")
-        .label[String]("version")
-        .label[String]("commit")
-        .build
-        .use { i =>
-          // Two `.label[String]` calls produce an Info[F, (String, String)] via the existing
-          // labelled-DSL machinery (InitLast tuple-builder).
-          i.info(("1.2.3", "abc1234")) >> IO.delay {
-            // Upstream stores Info under its base name (without the `_info` suffix). The wire format
-            // still emits `test_build_info{...} 1` — the suffix is added by the exposition writer.
-            val snapshot = promRegistry
-              .scrape()
-              .asScala
-              .collectFirst { case s: InfoSnapshot if s.getMetadata.getName === "test_build" => s }
-              .getOrElse(fail("expected an InfoSnapshot for the 'test_build_info' metric"))
-            val dp       = snapshot.getDataPoints.asScala.head
-            val labelMap = dp.getLabels.asScala.map(l => l.getName -> l.getValue).toMap
-            assertEquals(labelMap.get("version"), Some("1.2.3"))
-            assertEquals(labelMap.get("commit"), Some("abc1234"))
-          }
-        }
-    }
-  }
-
-  // NOTE: An "Info with no labels declared" test was attempted and removed — upstream
-  // prometheus-metrics-core 1.x's Info requires at least one labelName for the metric to emit a
-  // data point in scrape output. Calling `setLabelValues()` with empty varargs against an Info
-  // built without labelNames produces no observable scrape entry. This is an edge case (real-world
-  // Info almost always carries identity labels like version/commit/instance), but should be
-  // surfaced in the v6 migration guide for any consumer that relied on a no-label `Info[F, Unit]`.
-
-  test("counter callback — scrape invokes the user callback and propagates the value to the snapshot") {
-    val promRegistry = new PrometheusRegistry()
-
-    JavaMetricRegistry
-      .Builder[IO]()
-      .withRegistry(promRegistry)
-      .build
-      .use { registry =>
-        val factory  = MetricFactory.builder.build[IO](registry, registry)
-        val callback = IO.pure(NonEmptyList.of((42.0, "alpha"), (7.0, "beta")))
-        factory
-          .counter("test_callback_counter_total")
-          .ofDouble
-          .help("test counter callback")
-          .label[String]("variant")
-          .callback(callback)
-          .build
-          .use { _ =>
-            IO.delay {
-              val snapshot = promRegistry
-                .scrape()
-                .asScala
-                .collectFirst { case s: CounterSnapshot if s.getMetadata.getName === "test_callback_counter" => s }
-                .getOrElse(fail("expected a CounterSnapshot named 'test_callback_counter'"))
-              val byLabel = snapshot.getDataPoints.asScala
-                .map(dp => dp.getLabels.get("variant") -> dp.getValue)
-                .toMap
-              assertEquals(byLabel.get("alpha"), Some(42.0))
-              assertEquals(byLabel.get("beta"), Some(7.0))
-            }
-          }
-      }
-  }
-
-  test("gauge callback — scrape invokes the user callback and propagates the value to the snapshot") {
-    val promRegistry = new PrometheusRegistry()
-
-    JavaMetricRegistry
-      .Builder[IO]()
-      .withRegistry(promRegistry)
-      .build
-      .use { registry =>
-        val factory  = MetricFactory.builder.build[IO](registry, registry)
-        val callback = IO.pure(NonEmptyList.of((50.0, "n0"), (100.0, "n1")))
-        factory
-          .gauge("test_callback_gauge")
-          .ofDouble
-          .help("test gauge callback")
-          .label[String]("node")
-          .callback(callback)
-          .build
-          .use { _ =>
-            IO.delay {
-              val snapshot = promRegistry
-                .scrape()
-                .asScala
-                .collectFirst { case s: GaugeSnapshot if s.getMetadata.getName === "test_callback_gauge" => s }
-                .getOrElse(fail("expected a GaugeSnapshot named 'test_callback_gauge'"))
-              val byLabel = snapshot.getDataPoints.asScala.map(dp => dp.getLabels.get("node") -> dp.getValue).toMap
-              assertEquals(byLabel.get("n0"), Some(50.0))
-              assertEquals(byLabel.get("n1"), Some(100.0))
-            }
-          }
-      }
-  }
-
-  test("histogram callback — value+labels map into a HistogramDataPointSnapshot with classic buckets") {
-    val promRegistry = new PrometheusRegistry()
-
-    JavaMetricRegistry
-      .Builder[IO]()
-      .withRegistry(promRegistry)
-      .build
-      .use { registry =>
-        val factory = MetricFactory.builder.build[IO](registry, registry)
-        // bucketValues are CUMULATIVE counts indexed by (declared-buckets ++ +Inf) — so for buckets
-        // 0.1, 1.0, 5.0 with three observations of 0.05, 0.5, 2.0 the cumulative counts are
-        // [1, 2, 3, 3] (≤0.1, ≤1.0, ≤5.0, ≤+Inf).
-        val histValue = Histogram.Value[Double](2.55, NonEmptySeq.of(1.0, 2.0, 3.0, 3.0))
-        val callback  = IO.pure(NonEmptyList.of((histValue, "alpha")))
-        factory
-          .histogram("test_callback_histogram")
-          .ofDouble
-          .help("test histogram callback")
-          .buckets(NonEmptySeq.of(0.1, 1.0, 5.0))
-          .label[String]("variant")
-          .callback(callback)
-          .build
-          .use { _ =>
-            IO.delay {
-              val snapshot = promRegistry
-                .scrape()
-                .asScala
-                .collectFirst { case s: HistogramSnapshot if s.getMetadata.getName === "test_callback_histogram" => s }
-                .getOrElse(fail("expected a HistogramSnapshot named 'test_callback_histogram'"))
-              val dp = snapshot.getDataPoints.asScala.head
-              assert(dp.hasClassicHistogramData)
-              assertEqualsDouble(dp.getSum, 2.55, 1e-9)
-              // Classic buckets propagate; +Inf is the last upper bound we appended.
-              val upperBounds = dp.getClassicBuckets.asScala.map(_.getUpperBound).toSet
-              assert(upperBounds.contains(0.1), s"saw upper bounds $upperBounds")
-              assert(upperBounds.contains(5.0), s"saw upper bounds $upperBounds")
-            }
-          }
-      }
-  }
-
-  test("summary callback — count, sum, and declared quantiles propagate to the snapshot") {
-    val promRegistry = new PrometheusRegistry()
-
-    JavaMetricRegistry
-      .Builder[IO]()
-      .withRegistry(promRegistry)
-      .build
-      .use { registry =>
-        val factory = MetricFactory.builder.build[IO](registry, registry)
-        val summaryValue = Summary.Value[Double](
-          count = 10L,
-          sum = 42.5,
-          quantiles = Map(0.5 -> 1.2, 0.99 -> 9.5)
+  override def getRegistryState: IO[List[FamilyState]] =
+    promRegistryRef.get.flatMap {
+      case Some(pr) => IO.delay(scrapeToFamilyStates(pr))
+      case None     =>
+        IO.raiseError(
+          new IllegalStateException("getRegistryState called outside of an active `resource.use { … }` scope")
         )
-        val callback = IO.pure(NonEmptyList.of((summaryValue, "alpha")))
-        factory
-          .summary("test_callback_summary")
-          .ofDouble
-          .help("test summary callback")
-          .label[String]("variant")
-          .callback(callback)
-          .build
-          .use { _ =>
-            IO.delay {
-              val snapshot = promRegistry
-                .scrape()
-                .asScala
-                .collectFirst { case s: SummarySnapshot if s.getMetadata.getName === "test_callback_summary" => s }
-                .getOrElse(fail("expected a SummarySnapshot named 'test_callback_summary'"))
-              val dp = snapshot.getDataPoints.asScala.head
-              assertEquals(dp.getCount, 10L)
-              assertEqualsDouble(dp.getSum, 42.5, 1e-9)
-              val quantileValues = dp.getQuantiles.asScala.map(q => q.getQuantile -> q.getValue).toMap
-              assertEquals(quantileValues.size, 2)
-              assertEqualsDouble(quantileValues(0.5), 1.2, 1e-9)
-              assertEqualsDouble(quantileValues(0.99), 9.5, 1e-9)
-            }
-          }
-      }
-  }
+    }
 
-  test(
-    "metric-collection callback — emits all four kinds (counter, gauge, histogram, summary) from a single callback"
-  ) {
-    val promRegistry = new PrometheusRegistry()
+  // ─── v6 snapshot → FamilyState translation ────────────────────────────────────────────────────────
 
-    JavaMetricRegistry
-      .Builder[IO]()
-      .withRegistry(promRegistry)
-      .build
-      .use { registry =>
-        val factory = MetricFactory.builder.build[IO](registry, registry)
+  private def promLabelsToMap(labels: io.prometheus.metrics.model.snapshots.Labels): Map[String, String] =
+    labels.asScala.map(l => l.getName -> l.getValue).toMap
 
-        val collection: MetricCollection = MetricCollection.empty
-          .appendDoubleCounter(
-            Counter.Name.unsafeFrom("collection_counter_total"),
-            Metric.Help("test counter"),
-            Map.empty[Label.Name, String],
-            42.0
-          )
-          .appendDoubleGauge(
-            Gauge.Name.unsafeFrom("collection_gauge"),
-            Metric.Help("test gauge"),
-            Map.empty[Label.Name, String],
-            7.0
-          )
+  private def promExemplarToMap(
+      ex: io.prometheus.metrics.model.snapshots.Exemplar
+  ): Option[Map[String, String]] =
+    Option(ex).map(_.getLabels.asScala.map(l => l.getName -> l.getValue).toMap)
 
-        factory
-          .metricCollectionCallback(IO.pure(collection))
-          .build
-          .use { _ =>
-            IO.delay {
-              val snapshots = promRegistry.scrape().asScala.toList
-              val names     = snapshots.map(s => s.getClass.getSimpleName -> s.getMetadata.getName).toSet
-              assert(
-                names.contains("CounterSnapshot" -> "collection_counter"),
-                s"expected CounterSnapshot 'collection_counter'; saw $names"
+  private def sortDataPoints(dps: List[DataPointState]): List[DataPointState] =
+    dps.sortBy(_.labels.toSeq.sortBy(_._1).mkString(","))
+
+  private def scrapeToFamilyStates(promRegistry: PrometheusRegistry): List[FamilyState] =
+    promRegistry
+      .scrape()
+      .asScala
+      .toList
+      .map {
+        case s: CounterSnapshot =>
+          FamilyState(
+            s.getMetadata.getName,
+            "COUNTER",
+            s.getMetadata.getHelp,
+            sortDataPoints(
+              s.getDataPoints.asScala.toList.map(dp =>
+                CounterDP(promLabelsToMap(dp.getLabels), dp.getValue, promExemplarToMap(dp.getExemplar))
               )
-              assert(
-                names.contains("GaugeSnapshot" -> "collection_gauge"),
-                s"expected GaugeSnapshot 'collection_gauge'; saw $names"
-              )
-              val counter = snapshots.collectFirst {
-                case s: CounterSnapshot if s.getMetadata.getName === "collection_counter" => s
-              }.get
-              assertEquals(counter.getDataPoints.asScala.head.getValue, 42.0)
-            }
-          }
+            )
+          )
+        case s: GaugeSnapshot =>
+          FamilyState(
+            s.getMetadata.getName,
+            "GAUGE",
+            s.getMetadata.getHelp,
+            sortDataPoints(
+              s.getDataPoints.asScala.toList.map(dp => GaugeDP(promLabelsToMap(dp.getLabels), dp.getValue))
+            )
+          )
+        case s: HistogramSnapshot =>
+          FamilyState(
+            s.getMetadata.getName,
+            "HISTOGRAM",
+            s.getMetadata.getHelp,
+            sortDataPoints(s.getDataPoints.asScala.toList.map { dp =>
+              // v6's ClassicHistogramBucket doesn't carry a per-bucket exemplar — exemplars live on
+              // the data point (`dp.getExemplars`) and are matched to buckets by observation-value
+              // range. Per-bucket exemplar slot is reserved on the model for future use; populate it
+              // None until a test exercises exemplars.
+              val classic =
+                if (dp.hasClassicHistogramData)
+                  Some(
+                    dp.getClassicBuckets.asScala.toList
+                      .sortBy(_.getUpperBound)
+                      .map(b => ClassicBucket(b.getUpperBound, b.getCount, exemplar = None))
+                  )
+                else None
+              val native =
+                if (dp.hasNativeHistogramData) Some(NativeHistogramState(schema = dp.getNativeSchema)) else None
+              HistogramDP(promLabelsToMap(dp.getLabels), dp.getCount, dp.getSum, classic, native)
+            })
+          )
+        case s: SummarySnapshot =>
+          FamilyState(
+            s.getMetadata.getName,
+            "SUMMARY",
+            s.getMetadata.getHelp,
+            sortDataPoints(s.getDataPoints.asScala.toList.map { dp =>
+              val quantiles = dp.getQuantiles.asScala.map(q => q.getQuantile -> q.getValue).toMap
+              SummaryDP(promLabelsToMap(dp.getLabels), dp.getCount, dp.getSum, quantiles)
+            })
+          )
+        case s: InfoSnapshot =>
+          FamilyState(
+            s.getMetadata.getName,
+            "INFO",
+            s.getMetadata.getHelp,
+            sortDataPoints(s.getDataPoints.asScala.toList.map(dp => InfoDP(promLabelsToMap(dp.getLabels))))
+          )
+        case other =>
+          throw new NotImplementedError(
+            s"scrapeToFamilyStates: no FamilyState translation for ${other.getClass.getSimpleName}; extend the model"
+          )
       }
-  }
-
-  test("registry release unregisters all claimed metrics from the underlying PrometheusRegistry") {
-    val promRegistry = new PrometheusRegistry()
-
-    JavaMetricRegistry
-      .Builder[IO]()
-      .withRegistry(promRegistry)
-      .build
-      .use { registry =>
-        val factory = MetricFactory.builder.build[IO](registry)
-        factory.counter("teardown_counter_total").ofDouble.help("test").build.use(_.inc(1.0))
-      } >> IO.delay {
-      val names = promRegistry.scrape().asScala.map(_.getMetadata.getName).toSet
-      assert(
-        !names.contains("teardown_counter"),
-        s"counter should have been unregistered after the registry resource closed; saw $names"
-      )
-    }
-  }
-
-  // ─── name-collision contract tests ────────────────────────────────────────────────────────────────
-  //
-  // Promoted from `javasimpleclient.JavaMetricRegistrySuite` ahead of the legacy package's deletion.
-  // These exercise reference-counted reuse + same-name-different-shape rejection — behaviour the v6
-  // backend honours with the same error messages as v5. Kept here (not in the cross-backend testkit)
-  // because they need a single registry instance implementing BOTH `MetricRegistry` and
-  // `CallbackRegistry`; the testkit's separate resources would yield disjoint internal state and
-  // defeat the cross-axis collision check.
-  //
-  // The legacy versions used `forAllF` against the testkit's Arbitrary[*] instances. These plain-MUnit
-  // versions exercise the same contract with deterministic inputs — the property-based shape was
-  // never load-bearing for these tests (the contract is "registry rejects collision", not "registry
-  // rejects collision under arbitrary names").
-
-  private def collisionRegistry: Resource[IO, MetricRegistry[IO] with CallbackRegistry[IO]] =
-    Resource
-      .eval(IO.delay(new PrometheusRegistry()))
-      .flatMap(JavaMetricRegistry.Builder[IO]().withRegistry(_).build)
-
-  private val testHelp = Metric.Help("collision contract test")
-
-  private val testCommonLabels = Metric.CommonLabels.empty
-
-  private val testLabel = Label.Name("region")
-
-  private val testLabels: IndexedSeq[Label.Name] = IndexedSeq(testLabel)
-
-  test("name-collision: returns an existing metric when labels and name are the same") {
-    val counterName = Counter.Name("collision_one_total")
-
-    collisionRegistry.use { reg =>
-      val metric = reg.createAndRegisterDoubleCounter[Map[Label.Name, String]](
-        None, counterName, testHelp, testCommonLabels, testLabels
-      )(_.values.toIndexedSeq)
-
-      (metric >> metric).use_
-    }
-  }
-
-  test("name-collision: fails to build a metric when a callback of the same name exists") {
-    val counterName = Counter.Name("collision_two_total")
-    val rendered    = counterName.value
-
-    collisionRegistry.use { reg =>
-      val metric = reg.createAndRegisterDoubleCounter[Map[Label.Name, String]](
-        None, counterName, testHelp, testCommonLabels, testLabels
-      )(_.values.toIndexedSeq)
-
-      val callback = reg.registerDoubleCounterCallback[Map[Label.Name, String]](
-        None,
-        counterName,
-        testHelp,
-        testCommonLabels,
-        testLabels,
-        IO(NonEmptyList.one(0.0 -> Map.empty[Label.Name, String]))
-      )(_.values.toIndexedSeq)
-
-      (callback >> metric).use_
-    }.attempt.map { res =>
-      assertEquals(
-        res.leftMap(_.getMessage),
-        Left(s"A callback with the same name as '$rendered' is already registered with different labels and/or type")
-      )
-    }
-  }
-
-  test("name-collision: fails to build a callback when a metric of the same name exists") {
-    val counterName = Counter.Name("collision_three_total")
-    val rendered    = counterName.value
-
-    collisionRegistry.use { reg =>
-      val metric = reg.createAndRegisterDoubleCounter[Map[Label.Name, String]](
-        None, counterName, testHelp, testCommonLabels, testLabels
-      )(_.values.toIndexedSeq)
-
-      val callback = reg.registerDoubleCounterCallback[Map[Label.Name, String]](
-        None,
-        counterName,
-        testHelp,
-        testCommonLabels,
-        testLabels,
-        IO(NonEmptyList.one(0.0 -> Map.empty[Label.Name, String]))
-      )(_.values.toIndexedSeq)
-
-      (metric >> callback).use_
-    }.attempt.map { res =>
-      assertEquals(
-        res.leftMap(_.getMessage),
-        Left(s"A metric with the same name as '$rendered' is already registered with different labels and/or type")
-      )
-    }
-  }
-
-  test("name-collision: fails when a metric with the same name and different labels") {
-    val counterName = Counter.Name("collision_four_total")
-    val rendered    = counterName.value
-
-    collisionRegistry.use { reg =>
-      (reg.createAndRegisterDoubleCounter[Map[Label.Name, String]](
-        None, counterName, testHelp, testCommonLabels, testLabels
-      )(_.values.toIndexedSeq) >> reg.createAndRegisterDoubleCounter[Map[Label.Name, String]](
-        None, counterName, testHelp, testCommonLabels, IndexedSeq(Label.Name("different"))
-      )(_.values.toIndexedSeq)).use_
-    }.attempt.map { res =>
-      assertEquals(
-        res.leftMap(_.getMessage),
-        Left(s"A metric with the same name as '$rendered' is already registered with different labels and/or type")
-      )
-    }
-  }
-
-  test("name-collision: fails when a metric with the same name and different type") {
-    val counterName = Counter.Name("collision_five_total")
-    val gaugeName   = Gauge.Name("collision_five")
-    val rendered    = gaugeName.value
-
-    collisionRegistry.use { reg =>
-      (reg.createAndRegisterDoubleCounter[Map[Label.Name, String]](
-        None, counterName, testHelp, testCommonLabels, testLabels
-      )(_.values.toIndexedSeq) >> reg.createAndRegisterDoubleGauge[Map[Label.Name, String]](
-        None, gaugeName, testHelp, testCommonLabels, testLabels
-      )(_.values.toIndexedSeq)).use_
-    }.attempt.map { res =>
-      assertEquals(
-        res.leftMap(_.getMessage),
-        Left(s"A metric with the same name as '$rendered' is already registered with different labels and/or type")
-      )
-    }
-  }
+      .sortBy(_.name)
 
 }

--- a/modules/prometheus4cats-java/src/test/scala/prometheus4cats/javaclient/JavaMetricRegistrySuite.scala
+++ b/modules/prometheus4cats-java/src/test/scala/prometheus4cats/javaclient/JavaMetricRegistrySuite.scala
@@ -113,16 +113,19 @@ class JavaMetricRegistrySuite extends CatsEffectSuite with DslSuite {
             sortDataPoints(s.getDataPoints.asScala.toList.map { dp =>
               // v6's ClassicHistogramBucket doesn't carry a per-bucket exemplar — exemplars live on
               // the data point (`dp.getExemplars`) and are matched to buckets by observation-value
-              // range. Per-bucket exemplar slot is reserved on the model for future use; populate it
-              // None until a test exercises exemplars.
+              // range (smallest bucket whose upper-bound ≥ value, i.e. exclusive-lower, inclusive-upper).
               val classic =
-                if (dp.hasClassicHistogramData)
-                  Some(
-                    dp.getClassicBuckets.asScala.toList
-                      .sortBy(_.getUpperBound)
-                      .map(b => ClassicBucket(b.getUpperBound, b.getCount, exemplar = None))
-                  )
-                else None
+                if (dp.hasClassicHistogramData) {
+                  val sortedBuckets = dp.getClassicBuckets.asScala.toList.sortBy(_.getUpperBound)
+                  val lowerBounds   = Double.NegativeInfinity +: sortedBuckets.map(_.getUpperBound).init
+                  val allExemplars  = Option(dp.getExemplars).map(_.asScala.toList).getOrElse(Nil)
+                  Some(sortedBuckets.zip(lowerBounds).map { case (b, lower) =>
+                    val maybeExemplar = allExemplars
+                      .find(e => e.getValue > lower && e.getValue <= b.getUpperBound)
+                      .map(e => e.getLabels.asScala.map(l => l.getName -> l.getValue).toMap)
+                    ClassicBucket(b.getUpperBound, b.getCount, maybeExemplar)
+                  })
+                } else None
               val native =
                 if (dp.hasNativeHistogramData) Some(NativeHistogramState(schema = dp.getNativeSchema)) else None
               HistogramDP(promLabelsToMap(dp.getLabels), dp.getCount, dp.getSum, classic, native)

--- a/modules/prometheus4cats-java/src/test/scala/prometheus4cats/javaclient/JavaMetricRegistrySuite.scala
+++ b/modules/prometheus4cats-java/src/test/scala/prometheus4cats/javaclient/JavaMetricRegistrySuite.scala
@@ -60,7 +60,7 @@ class JavaMetricRegistrySuite extends CatsEffectSuite with DslSuite {
   override def getRegistryState: IO[List[FamilyState]] =
     promRegistryRef.get.flatMap {
       case Some(pr) => IO.delay(scrapeToFamilyStates(pr))
-      case None     =>
+      case None =>
         IO.raiseError(
           new IllegalStateException("getRegistryState called outside of an active `resource.use { … }` scope")
         )

--- a/modules/prometheus4cats-java/src/test/scala/prometheus4cats/javaclient/JavaMetricRegistrySuite.scala
+++ b/modules/prometheus4cats-java/src/test/scala/prometheus4cats/javaclient/JavaMetricRegistrySuite.scala
@@ -43,6 +43,7 @@ import prometheus4cats.testkit.DslSuite
   * sequentially and every `getRegistryState` call happens inside an active `resource.use { … }` scope, so the Ref
   * always has a value when read.
   */
+@SuppressWarnings(Array("scalafix:DisableSyntax"))
 class JavaMetricRegistrySuite extends CatsEffectSuite with DslSuite {
 
   // ─── DslSuite hooks ───────────────────────────────────────────────────────────────────────────────

--- a/modules/prometheus4cats-testkit/src/main/scala/prometheus4cats/testkit/DslSuite.scala
+++ b/modules/prometheus4cats-testkit/src/main/scala/prometheus4cats/testkit/DslSuite.scala
@@ -1110,10 +1110,10 @@ trait DslSuite { self: CatsEffectSuite =>
 
   test("name-collision: returns an existing metric when labels and name are the same") {
     resource.use { factory =>
-      val mk = factory.counter("collision_one_total").ofDouble.help(collisionHelp).label[String]("region").build
+      val mk = factory.counter("collision_reuse_total").ofDouble.help(collisionHelp).label[String]("region").build
       def expected(value: Double) = List(
         FamilyState(
-          name = "collision_one",
+          name = "collision_reuse",
           `type` = "COUNTER",
           help = "collision contract test",
           dataPoints = List(
@@ -1142,14 +1142,14 @@ trait DslSuite { self: CatsEffectSuite =>
   test("name-collision: fails to build a metric when a callback of the same name exists") {
     resource.use { factory =>
       val callback = factory
-        .counter("collision_two_total")
+        .counter("collision_metric_after_callback_total")
         .ofDouble
         .help(collisionHelp)
         .label[String]("region")
         .callback(IO.pure(NonEmptyList.one((0.0, "x"))))
         .build
       val metric = factory
-        .counter("collision_two_total")
+        .counter("collision_metric_after_callback_total")
         .ofDouble
         .help(collisionHelp)
         .label[String]("region")
@@ -1158,7 +1158,7 @@ trait DslSuite { self: CatsEffectSuite =>
       (callback >> metric).use_.attempt.map { res =>
         assertEquals(
           res.leftMap(_.getMessage),
-          Left(s"A callback with the same name as 'collision_two_total' is already registered with different labels and/or type")
+          Left(s"A callback with the same name as 'collision_metric_after_callback_total' is already registered with different labels and/or type")
         )
       }
     }
@@ -1167,13 +1167,13 @@ trait DslSuite { self: CatsEffectSuite =>
   test("name-collision: fails to build a callback when a metric of the same name exists") {
     resource.use { factory =>
       val metric = factory
-        .counter("collision_three_total")
+        .counter("collision_callback_after_metric_total")
         .ofDouble
         .help(collisionHelp)
         .label[String]("region")
         .build
       val callback = factory
-        .counter("collision_three_total")
+        .counter("collision_callback_after_metric_total")
         .ofDouble
         .help(collisionHelp)
         .label[String]("region")
@@ -1183,7 +1183,7 @@ trait DslSuite { self: CatsEffectSuite =>
       (metric >> callback).use_.attempt.map { res =>
         assertEquals(
           res.leftMap(_.getMessage),
-          Left(metricCollisionMessage("collision_three_total"))
+          Left(metricCollisionMessage("collision_callback_after_metric_total"))
         )
       }
     }
@@ -1192,13 +1192,13 @@ trait DslSuite { self: CatsEffectSuite =>
   test("name-collision: fails when a metric with the same name and different labels") {
     resource.use { factory =>
       val m1 = factory
-        .counter("collision_four_total")
+        .counter("collision_different_labels_total")
         .ofDouble
         .help(collisionHelp)
         .label[String]("region")
         .build
       val m2 = factory
-        .counter("collision_four_total")
+        .counter("collision_different_labels_total")
         .ofDouble
         .help(collisionHelp)
         .label[String]("different")
@@ -1207,22 +1207,48 @@ trait DslSuite { self: CatsEffectSuite =>
       (m1 >> m2).use_.attempt.map { res =>
         assertEquals(
           res.leftMap(_.getMessage),
-          Left(metricCollisionMessage("collision_four_total"))
+          Left(metricCollisionMessage("collision_different_labels_total"))
         )
       }
+    }
+  }
+
+  test("name-collision: counter callback emitting duplicate label values within one NonEmptyList") {
+    resource.use { factory =>
+      // Two tuples with the SAME label value `x` but different metric values. The registry sees two
+      // CounterDataPointSnapshots with identical label sets in a single scrape — a duplicate-series
+      // condition the wire format normally rejects.
+      val callback = IO.pure(NonEmptyList.of((1.0, "x"), (2.0, "x")))
+      factory
+        .counter("collision_dup_label_total")
+        .ofDouble
+        .help(collisionHelp)
+        .label[String]("name")
+        .callback(callback)
+        .build
+        .use { _ =>
+          getRegistryState.attempt.map { res =>
+            // Behaviour to pin once we observe it on a test run. Likely one of:
+            //   - registry raises at scrape time (`res` is Left with an upstream-validation message)
+            //   - registry silently keeps the LAST entry (Right with one CounterDP value=2.0)
+            //   - registry emits both as duplicate samples (Right with two CounterDPs sharing labels)
+            // Asserting `isLeft` for now — adjust to the exact shape after first run.
+            assert(res.isLeft, s"expected duplicate-label callback emission to fail, got: $res")
+          }
+        }
     }
   }
 
   test("name-collision: fails when a metric with the same name and different type") {
     resource.use { factory =>
       val counter = factory
-        .counter("collision_five_total")
+        .counter("collision_different_type_total")
         .ofDouble
         .help(collisionHelp)
         .label[String]("region")
         .build
       val gauge = factory
-        .gauge("collision_five")
+        .gauge("collision_different_type")
         .ofDouble
         .help(collisionHelp)
         .label[String]("region")
@@ -1231,7 +1257,7 @@ trait DslSuite { self: CatsEffectSuite =>
       (counter >> gauge).use_.attempt.map { res =>
         assertEquals(
           res.leftMap(_.getMessage),
-          Left(metricCollisionMessage("collision_five"))
+          Left(metricCollisionMessage("collision_different_type"))
         )
       }
     }

--- a/modules/prometheus4cats-testkit/src/main/scala/prometheus4cats/testkit/DslSuite.scala
+++ b/modules/prometheus4cats-testkit/src/main/scala/prometheus4cats/testkit/DslSuite.scala
@@ -23,6 +23,7 @@ import cats.data.NonEmptySeq
 import cats.effect.IO
 import cats.effect.kernel.Resource
 import cats.syntax.all._
+
 import munit.CatsEffectSuite
 import prometheus4cats._
 

--- a/modules/prometheus4cats-testkit/src/main/scala/prometheus4cats/testkit/DslSuite.scala
+++ b/modules/prometheus4cats-testkit/src/main/scala/prometheus4cats/testkit/DslSuite.scala
@@ -1,0 +1,783 @@
+/*
+ * Copyright 2022-2026 Permutive Ltd. <https://permutive.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package prometheus4cats.testkit
+
+import cats.data.NonEmptyList
+import cats.data.NonEmptySeq
+import cats.effect.IO
+import cats.effect.kernel.Resource
+import cats.syntax.all._
+
+import munit.CatsEffectSuite
+import prometheus4cats._
+
+/** Cross-backend test suite for the user-facing `MetricFactory` DSL.
+  *
+  * Backends provide a fresh `MetricFactory.WithCallbacks[IO]` `Resource` plus a way to snapshot the registry's whole
+  * observable state into the uniform `List[FamilyState]` representation defined here. The tests then exercise the DSL
+  * surface (counter / gauge / histogram / native histogram / dual-mode / summary / info / callbacks / metric-collection
+  * / collision contract) and assert against the snapshot as a literal — no narrow per-type getters.
+  *
+  * Unlike [[MetricRegistrySuite]] which pins the `MetricRegistry[F]` *trait* contract by calling low-level
+  * `createAndRegisterDouble*` methods directly, this suite pins the *DSL → trait* handshake: every test goes through
+  * `factory.<kind>(name).…build` so a backend can fail this suite even when [[MetricRegistrySuite]] passes (e.g. if the
+  * DSL routes labels incorrectly into the registry).
+  *
+  * `getRegistryState` is parameterless — the backend is expected to close over its underlying registry (typically via a
+  * `Ref` set inside the `resource` acquire) so that `getRegistryState` reads the registry that the *current* test is
+  * exercising. Tests only call `getRegistryState` inside `resource.use { … }`, so it always runs within a live
+  * registry's scope.
+  *
+  * A few protected `def`s capture values that may vary between backends (default native-histogram schema, collision
+  * error messages). They're concrete with the current backend's defaults; future backends with different conventions
+  * can override them.
+  */
+@SuppressWarnings(Array("all"))
+trait DslSuite { self: CatsEffectSuite =>
+
+  // full-state snapshot model
+
+  sealed trait DataPointState { def labels: Map[String, String] }
+
+  case class CounterDP(labels: Map[String, String], value: Double, exemplar: Option[Map[String, String]])
+      extends DataPointState
+
+  case class GaugeDP(labels: Map[String, String], value: Double) extends DataPointState
+
+  case class ClassicBucket(upperBound: Double, count: Long, exemplar: Option[Map[String, String]])
+
+  /** Minimal projection of a native-histogram data point — only `schema` is asserted today. */
+  case class NativeHistogramState(schema: Int)
+
+  case class HistogramDP(
+      labels: Map[String, String],
+      count: Long,
+      sum: Double,
+      classic: Option[List[ClassicBucket]],
+      native: Option[NativeHistogramState]
+  ) extends DataPointState
+
+  case class SummaryDP(labels: Map[String, String], count: Long, sum: Double, quantiles: Map[Double, Double])
+      extends DataPointState
+
+  case class InfoDP(labels: Map[String, String]) extends DataPointState
+
+  case class FamilyState(name: String, `type`: String, help: String, dataPoints: List[DataPointState])
+
+  // abstract backend hooks
+
+  def resource: Resource[IO, MetricFactory.WithCallbacks[IO]]
+
+  def getRegistryState: IO[List[FamilyState]]
+
+  // backend-tunable defaults
+
+  /** Default `initialSchema` a backend picks for a `NativeHistogram` when none is configured. */
+  protected def defaultNativeSchema: Int = 5
+
+  /** Error message a backend raises when a `factory.<kind>(name).callback(...)` is registered against a name already
+    * owned by an active (push) metric. Backends that route through the prometheus4cats core get this for free.
+    */
+  protected def metricCollisionMessage(renderedName: String): String =
+    s"A metric with the same name as '$renderedName' is already registered with different labels and/or type"
+
+  // helpers
+
+  /** Replaces the algorithm-dependent quantile *values* of every summary data point with 0.0, leaving count, sum, and
+    * the declared quantile *levels* intact. Use when a live `Summary` records observations — the streaming algorithm's
+    * output is implementation-defined.
+    */
+  protected def zeroSummaryQuantiles(state: List[FamilyState]): List[FamilyState] =
+    state.map(fs =>
+      fs.copy(dataPoints = fs.dataPoints.map {
+        case s: SummaryDP => s.copy(quantiles = s.quantiles.view.mapValues(_ => 0.0).toMap)
+        case other        => other
+      })
+    )
+
+  // counter
+
+  test("counter — inc, scrape returns the incremented value") {
+    resource.use { factory =>
+      factory
+        .counter("test_counter_total")
+        .ofDouble
+        .help("test counter")
+        .label[String]("variant")
+        .build
+        .use { c =>
+          for {
+            _     <- c.inc(1.0, "alpha")
+            snap1 <- getRegistryState
+            _     <- c.inc(2.0, "alpha")
+            snap2 <- getRegistryState
+          } yield {
+            assertEquals(
+              snap1,
+              List(
+                FamilyState(
+                  name = "test_counter",
+                  `type` = "COUNTER",
+                  help = "test counter",
+                  dataPoints = List(CounterDP(Map("variant" -> "alpha"), 1.0, None))
+                )
+              )
+            )
+            assertEquals(
+              snap2,
+              List(
+                FamilyState(
+                  name = "test_counter",
+                  `type` = "COUNTER",
+                  help = "test counter",
+                  dataPoints = List(CounterDP(Map("variant" -> "alpha"), 3.0, None))
+                )
+              )
+            )
+          }
+        }
+        .flatMap(_ => getRegistryState)
+        .map(snap => assertEquals(snap, Nil))
+
+    }
+  }
+
+  test("counter callback — scrape invokes the user callback and propagates the value to the snapshot") {
+    resource.use { factory =>
+      val iterator = Iterator((42.0, "alpha"), (45.0, "alpha"))
+      val callback = IO.delay(NonEmptyList.of(iterator.next()))
+      factory
+        .counter("test_callback_counter_total")
+        .ofDouble
+        .help("test counter callback")
+        .label[String]("variant")
+        .callback(callback)
+        .build
+        .use { _ =>
+          def expected(value: Double, label: String) = List(
+            FamilyState(
+              name = "test_callback_counter",
+              `type` = "COUNTER",
+              help = "test counter callback",
+              dataPoints = List(
+                CounterDP(Map("variant" -> label), value, None)
+              )
+            )
+          )
+          for {
+            snap1 <- getRegistryState
+            snap2 <- getRegistryState
+          } yield {
+            assertEquals(snap1, expected(42.0, "alpha"))
+            assertEquals(snap2, expected(45.0, "alpha"))
+          }
+        }
+        .flatMap(_ => getRegistryState)
+        .map(snap => assertEquals(snap, Nil))
+    }
+  }
+
+  // gauge
+
+  test("gauge — inc, dec, and set are each reflected in the scrape") {
+    resource.use { factory =>
+      factory
+        .gauge("test_gauge")
+        .ofDouble
+        .help("test gauge")
+        .build
+        .use { g =>
+          for {
+            _  <- g.inc(5.0)
+            s1 <- getRegistryState
+            _  <- g.dec(2.0)
+            s2 <- getRegistryState
+            _  <- g.set(10.0)
+            s3 <- getRegistryState
+          } yield {
+            def expected(value: Double) = List(
+              FamilyState(
+                name = "test_gauge",
+                `type` = "GAUGE",
+                help = "test gauge",
+                dataPoints = List(GaugeDP(Map.empty, value))
+              )
+            )
+            assertEquals(s1, expected(5.0))
+            assertEquals(s2, expected(3.0))
+            assertEquals(s3, expected(10.0))
+          }
+        }
+        .flatMap(_ => getRegistryState)
+        .map(snap => assertEquals(snap, Nil))
+    }
+  }
+
+  test("gauge callback — every scrape re-invokes the callback and propagates the current value") {
+    resource.use { factory =>
+      val iterator = Iterator(
+        NonEmptyList.of((50.0, "n0"), (100.0, "n1")),
+        NonEmptyList.of((75.0, "n0"), (150.0, "n1"))
+      )
+      val callback = IO.delay(iterator.next())
+      factory
+        .gauge("test_callback_gauge")
+        .ofDouble
+        .help("test gauge callback")
+        .label[String]("node")
+        .callback(callback)
+        .build
+        .use { _ =>
+          def expected(v0: Double, v1: Double) = List(
+            FamilyState(
+              name = "test_callback_gauge",
+              `type` = "GAUGE",
+              help = "test gauge callback",
+              dataPoints = List(
+                GaugeDP(Map("node" -> "n0"), v0),
+                GaugeDP(Map("node" -> "n1"), v1)
+              )
+            )
+          )
+          for {
+            snap1 <- getRegistryState
+            snap2 <- getRegistryState
+          } yield {
+            assertEquals(snap1, expected(50.0, 100.0))
+            assertEquals(snap2, expected(75.0, 150.0))
+          }
+        }
+        .flatMap(_ => getRegistryState)
+        .map(snap => assertEquals(snap, Nil))
+    }
+  }
+
+  // histogram
+
+  test("classic histogram — scrape produces classic buckets, no native data") {
+    resource.use { factory =>
+      factory
+        .histogram("test_classic_histogram")
+        .ofDouble
+        .help("test classic histogram")
+        .buckets(NonEmptySeq.of(0.1, 0.5, 1.0, 5.0))
+        .build
+        .use { h =>
+          for {
+            _    <- h.observe(0.05) >> h.observe(0.3) >> h.observe(0.7) >> h.observe(2.0)
+            snap <- getRegistryState
+          } yield assertEquals(
+            snap,
+            List(
+              FamilyState(
+                name = "test_classic_histogram",
+                `type` = "HISTOGRAM",
+                help = "test classic histogram",
+                dataPoints = List(
+                  HistogramDP(
+                    labels = Map.empty,
+                    count = 4L,
+                    sum = 3.05,
+                    classic = Some(
+                      List(
+                        ClassicBucket(0.1, 1L, None),
+                        ClassicBucket(0.5, 1L, None),
+                        ClassicBucket(1.0, 1L, None),
+                        ClassicBucket(5.0, 1L, None),
+                        ClassicBucket(Double.PositiveInfinity, 0L, None)
+                      )
+                    ),
+                    native = None
+                  )
+                )
+              )
+            )
+          )
+        }
+        .flatMap(_ => getRegistryState)
+        .map(snap => assertEquals(snap, Nil))
+    }
+  }
+
+  test("native histogram — scrape produces native bucket data, no classic buckets") {
+    resource.use { factory =>
+      factory
+        .nativeHistogram("test_native_histogram")
+        .help("test native histogram")
+        .build
+        .use { h =>
+          for {
+            _    <- h.observe(0.05) >> h.observe(0.3) >> h.observe(0.7) >> h.observe(2.0)
+            snap <- getRegistryState
+          } yield assertEquals(
+            snap,
+            List(
+              FamilyState(
+                name = "test_native_histogram",
+                `type` = "HISTOGRAM",
+                help = "test native histogram",
+                dataPoints = List(
+                  HistogramDP(
+                    labels = Map.empty, count = 4L, sum = 3.05, classic = None,
+                    native = Some(NativeHistogramState(defaultNativeSchema))
+                  )
+                )
+              )
+            )
+          )
+        }
+        .flatMap(_ => getRegistryState)
+        .map(snap => assertEquals(snap, Nil))
+    }
+  }
+
+  test("dual-mode histogram (.withNative) — scrape produces BOTH classic and native data") {
+    resource.use { factory =>
+      factory
+        .histogram("test_dual_histogram")
+        .ofDouble
+        .help("test dual-mode (NHCB-friendly) histogram")
+        .buckets(NonEmptySeq.of(0.1, 0.5, 1.0, 5.0))
+        .withNative
+        .build
+        .use { h =>
+          for {
+            _    <- h.observe(0.05) >> h.observe(0.3) >> h.observe(0.7) >> h.observe(2.0)
+            snap <- getRegistryState
+          } yield assertEquals(
+            snap,
+            List(
+              FamilyState(
+                name = "test_dual_histogram",
+                `type` = "HISTOGRAM",
+                help = "test dual-mode (NHCB-friendly) histogram",
+                dataPoints = List(
+                  HistogramDP(
+                    labels = Map.empty,
+                    count = 4L,
+                    sum = 3.05,
+                    classic = Some(
+                      List(
+                        ClassicBucket(0.1, 1L, None),
+                        ClassicBucket(0.5, 1L, None),
+                        ClassicBucket(1.0, 1L, None),
+                        ClassicBucket(5.0, 1L, None),
+                        ClassicBucket(Double.PositiveInfinity, 0L, None)
+                      )
+                    ),
+                    native = Some(NativeHistogramState(defaultNativeSchema))
+                  )
+                )
+              )
+            )
+          )
+        }
+        .flatMap(_ => getRegistryState)
+        .map(snap => assertEquals(snap, Nil))
+    }
+  }
+
+  test("native histogram — custom NativeHistogram config propagates initialSchema to the scraped snapshot") {
+    resource.use { factory =>
+      factory
+        .nativeHistogram("test_native_tuned", NativeHistogram.Default.withInitialSchema(3))
+        .help("native with custom schema")
+        .build
+        .use { h =>
+          for {
+            _    <- h.observe(1.0)
+            snap <- getRegistryState
+          } yield assertEquals(
+            snap,
+            List(
+              FamilyState(
+                name = "test_native_tuned",
+                `type` = "HISTOGRAM",
+                help = "native with custom schema",
+                dataPoints = List(
+                  HistogramDP(
+                    labels = Map.empty, count = 1L, sum = 1.0, classic = None,
+                    native = Some(NativeHistogramState(schema = 3))
+                  )
+                )
+              )
+            )
+          )
+        }
+        .flatMap(_ => getRegistryState)
+        .map(snap => assertEquals(snap, Nil))
+    }
+  }
+
+  test("histogram callback — every scrape re-invokes the callback and propagates the current value") {
+    resource.use { factory =>
+      // bucketValues are CUMULATIVE counts indexed by (declared-buckets ++ +Inf) — so for buckets
+      // 0.1, 1.0, 5.0 the cumulative counts [1, 2, 3, 3] mean (≤0.1, ≤1.0, ≤5.0, ≤+Inf) which the
+      // exposition writer flattens to per-bucket counts [1, 1, 1, 0] for the snapshot.
+      val iterator = Iterator(
+        NonEmptyList.of((Histogram.Value[Double](2.55, NonEmptySeq.of(1.0, 2.0, 3.0, 3.0)), "alpha")),
+        NonEmptyList.of((Histogram.Value[Double](4.10, NonEmptySeq.of(2.0, 3.0, 4.0, 4.0)), "alpha"))
+      )
+      val callback = IO.delay(iterator.next())
+      factory
+        .histogram("test_callback_histogram")
+        .ofDouble
+        .help("test histogram callback")
+        .buckets(NonEmptySeq.of(0.1, 1.0, 5.0))
+        .label[String]("variant")
+        .callback(callback)
+        .build
+        .use { _ =>
+          def expected(count: Long, sum: Double, b1: Long, b2: Long, b3: Long, bInf: Long) = List(
+            FamilyState(
+              name = "test_callback_histogram",
+              `type` = "HISTOGRAM",
+              help = "test histogram callback",
+              dataPoints = List(
+                HistogramDP(
+                  labels = Map("variant" -> "alpha"),
+                  count = count,
+                  sum = sum,
+                  classic = Some(
+                    List(
+                      ClassicBucket(0.1, b1, None),
+                      ClassicBucket(1.0, b2, None),
+                      ClassicBucket(5.0, b3, None),
+                      ClassicBucket(Double.PositiveInfinity, bInf, None)
+                    )
+                  ),
+                  native = None
+                )
+              )
+            )
+          )
+          for {
+            snap1 <- getRegistryState
+            snap2 <- getRegistryState
+          } yield {
+            // Cumulative [1, 2, 3, 3] → per-bucket [1, 1, 1, 0], count = 3, sum = 2.55
+            assertEquals(snap1, expected(count = 3L, sum = 2.55, b1 = 1L, b2 = 1L, b3 = 1L, bInf = 0L))
+            // Cumulative [2, 3, 4, 4] → per-bucket [2, 1, 1, 0], count = 4, sum = 4.10
+            assertEquals(snap2, expected(count = 4L, sum = 4.10, b1 = 2L, b2 = 1L, b3 = 1L, bInf = 0L))
+          }
+        }
+        .flatMap(_ => getRegistryState)
+        .map(snap => assertEquals(snap, Nil))
+    }
+  }
+
+  // summary
+
+  test("summary — quantiles propagate and observations are aggregated") {
+    resource.use { factory =>
+      factory
+        .summary("test_summary")
+        .ofDouble
+        .help("test summary")
+        .quantile(Summary.Quantile.from(0.5).toOption.get, Summary.AllowedError.from(0.05).toOption.get)
+        .quantile(Summary.Quantile.from(0.99).toOption.get, Summary.AllowedError.from(0.01).toOption.get)
+        .build
+        .use { sum =>
+          for {
+            _    <- sum.observe(0.1) >> sum.observe(0.5) >> sum.observe(1.0) >> sum.observe(2.5)
+            snap <- getRegistryState.map(zeroSummaryQuantiles)
+          } yield assertEquals(
+            snap,
+            List(
+              FamilyState(
+                name = "test_summary",
+                `type` = "SUMMARY",
+                help = "test summary",
+                // Quantile *values* are zeroed by `zeroSummaryQuantiles` (streaming algorithm output is
+                // implementation-defined); the assertion still pins count, sum and the declared levels.
+                dataPoints = List(SummaryDP(Map.empty, 4L, 4.1, Map(0.5 -> 0.0, 0.99 -> 0.0)))
+              )
+            )
+          )
+        }
+        .flatMap(_ => getRegistryState)
+        .map(snap => assertEquals(snap, Nil))
+    }
+  }
+
+  test("summary callback — every scrape re-invokes the callback and propagates the current value") {
+    resource.use { factory =>
+      val iterator = Iterator(
+        NonEmptyList.of(
+          (Summary.Value[Double](count = 10L, sum = 42.5, quantiles = Map(0.5 -> 1.2, 0.99 -> 9.5)), "alpha")
+        ),
+        NonEmptyList.of(
+          (Summary.Value[Double](count = 20L, sum = 100.0, quantiles = Map(0.5 -> 2.4, 0.99 -> 18.0)), "alpha")
+        )
+      )
+      val callback = IO.delay(iterator.next())
+      factory
+        .summary("test_callback_summary")
+        .ofDouble
+        .help("test summary callback")
+        .label[String]("variant")
+        .callback(callback)
+        .build
+        .use { _ =>
+          def expected(count: Long, sum: Double, quantiles: Map[Double, Double]) = List(
+            FamilyState(
+              name = "test_callback_summary",
+              `type` = "SUMMARY",
+              help = "test summary callback",
+              dataPoints = List(SummaryDP(Map("variant" -> "alpha"), count, sum, quantiles))
+            )
+          )
+          for {
+            snap1 <- getRegistryState
+            snap2 <- getRegistryState
+          } yield {
+            assertEquals(snap1, expected(10L, 42.5, Map(0.5 -> 1.2, 0.99 -> 9.5)))
+            assertEquals(snap2, expected(20L, 100.0, Map(0.5 -> 2.4, 0.99 -> 18.0)))
+          }
+        }
+        .flatMap(_ => getRegistryState)
+        .map(snap => assertEquals(snap, Nil))
+    }
+  }
+
+  // info
+  //
+  // Upstream stores Info under its base name (without the `_info` suffix). The wire format still emits
+  // `test_build_info{...} 1` — the suffix is added by the exposition writer, so the snapshot metadata
+  // name is `test_build`.
+
+  test("info — declared labels propagate to scrape output via setLabelValues") {
+    resource.use { factory =>
+      factory
+        .info("test_build_info")
+        .help("test build info")
+        .label[String]("version")
+        .label[String]("commit")
+        .build
+        .use { i =>
+          for {
+            _    <- i.info(("1.2.3", "abc1234"))
+            snap <- getRegistryState
+          } yield assertEquals(
+            snap,
+            List(
+              FamilyState(
+                name = "test_build",
+                `type` = "INFO",
+                help = "test build info",
+                dataPoints = List(InfoDP(Map("version" -> "1.2.3", "commit" -> "abc1234")))
+              )
+            )
+          )
+        }
+        .flatMap(_ => getRegistryState)
+        .map(snap => assertEquals(snap, Nil))
+    }
+  }
+
+  // metric collection
+
+  test("metric-collection callback — every scrape re-invokes the callback and propagates the current collection") {
+    resource.use { factory =>
+      def collection(counterValue: Double, gaugeValue: Double): MetricCollection =
+        MetricCollection.empty
+          .appendDoubleCounter(
+            Counter.Name.unsafeFrom("collection_counter_total"),
+            Metric.Help("test counter"),
+            Map.empty[Label.Name, String],
+            counterValue
+          )
+          .appendDoubleGauge(
+            Gauge.Name.unsafeFrom("collection_gauge"),
+            Metric.Help("test gauge"),
+            Map.empty[Label.Name, String],
+            gaugeValue
+          )
+
+      val iterator = Iterator(collection(42.0, 7.0), collection(100.0, 200.0))
+      val callback = IO.delay(iterator.next())
+
+      factory
+        .metricCollectionCallback(callback)
+        .build
+        .use { _ =>
+          def expected(counterValue: Double, gaugeValue: Double) = List(
+            FamilyState(
+              name = "collection_counter",
+              `type` = "COUNTER",
+              help = "test counter",
+              dataPoints = List(CounterDP(Map.empty, counterValue, None))
+            ),
+            FamilyState(
+              name = "collection_gauge",
+              `type` = "GAUGE",
+              help = "test gauge",
+              dataPoints = List(GaugeDP(Map.empty, gaugeValue))
+            )
+          )
+          for {
+            snap1 <- getRegistryState
+            snap2 <- getRegistryState
+          } yield {
+            assertEquals(snap1, expected(42.0, 7.0))
+            assertEquals(snap2, expected(100.0, 200.0))
+          }
+        }
+        .flatMap(_ => getRegistryState)
+        .map(snap => assertEquals(snap, Nil))
+    }
+  }
+
+  // name collisions
+  //
+  // Reformulated through the DSL: `factory.counter(...)`/`.gauge(...)` for active registration,
+  // `.callback(io)` for pull registration. The error messages assert through `metricCollisionMessage`
+  // / `callbackCollisionMessage` so a backend whose error strings diverge can override them centrally
+  // rather than override every test.
+
+  private val collisionHelp: Metric.Help = Metric.Help.from("collision contract test").toOption.get
+
+  test("name-collision: returns an existing metric when labels and name are the same") {
+    resource.use { factory =>
+      val mk = factory.counter("collision_one_total").ofDouble.help(collisionHelp).label[String]("region").build
+      def expected(value: Double) = List(
+        FamilyState(
+          name = "collision_one",
+          `type` = "COUNTER",
+          help = "collision contract test",
+          dataPoints = List(
+            CounterDP(
+              labels = Map("region" -> "x"),
+              value = value,
+              exemplar = None
+            )
+          )
+        )
+      )
+      mk.use { c1 =>
+        mk.use { c2 =>
+          // both refcount holders alive → one family
+          c2.inc(1.0, "x") >>
+            getRegistryState.map(assertEquals(_, expected(1.0)))
+        } >> c1.inc(1.0, "x") >>
+          // inner release decremented to 1; family still registered
+          getRegistryState.map(assertEquals(_, expected(2.0)))
+      } >>
+        // outer release decremented to 0; family unregistered
+        getRegistryState.map(assertEquals(_, Nil))
+    }
+  }
+
+  test("name-collision: fails to build a metric when a callback of the same name exists") {
+    resource.use { factory =>
+      val callback = factory
+        .counter("collision_two_total")
+        .ofDouble
+        .help(collisionHelp)
+        .label[String]("region")
+        .callback(IO.pure(NonEmptyList.one((0.0, "x"))))
+        .build
+      val metric = factory
+        .counter("collision_two_total")
+        .ofDouble
+        .help(collisionHelp)
+        .label[String]("region")
+        .build
+
+      (callback >> metric).use_.attempt.map { res =>
+        assertEquals(
+          res.leftMap(_.getMessage),
+          Left(s"A callback with the same name as 'collision_two_total' is already registered with different labels and/or type")
+        )
+      }
+    }
+  }
+
+  test("name-collision: fails to build a callback when a metric of the same name exists") {
+    resource.use { factory =>
+      val metric = factory
+        .counter("collision_three_total")
+        .ofDouble
+        .help(collisionHelp)
+        .label[String]("region")
+        .build
+      val callback = factory
+        .counter("collision_three_total")
+        .ofDouble
+        .help(collisionHelp)
+        .label[String]("region")
+        .callback(IO.pure(NonEmptyList.one((0.0, "x"))))
+        .build
+
+      (metric >> callback).use_.attempt.map { res =>
+        assertEquals(
+          res.leftMap(_.getMessage),
+          Left(metricCollisionMessage("collision_three_total"))
+        )
+      }
+    }
+  }
+
+  test("name-collision: fails when a metric with the same name and different labels") {
+    resource.use { factory =>
+      val m1 = factory
+        .counter("collision_four_total")
+        .ofDouble
+        .help(collisionHelp)
+        .label[String]("region")
+        .build
+      val m2 = factory
+        .counter("collision_four_total")
+        .ofDouble
+        .help(collisionHelp)
+        .label[String]("different")
+        .build
+
+      (m1 >> m2).use_.attempt.map { res =>
+        assertEquals(
+          res.leftMap(_.getMessage),
+          Left(metricCollisionMessage("collision_four_total"))
+        )
+      }
+    }
+  }
+
+  test("name-collision: fails when a metric with the same name and different type") {
+    resource.use { factory =>
+      val counter = factory
+        .counter("collision_five_total")
+        .ofDouble
+        .help(collisionHelp)
+        .label[String]("region")
+        .build
+      val gauge = factory
+        .gauge("collision_five")
+        .ofDouble
+        .help(collisionHelp)
+        .label[String]("region")
+        .build
+
+      (counter >> gauge).use_.attempt.map { res =>
+        assertEquals(
+          res.leftMap(_.getMessage),
+          Left(metricCollisionMessage("collision_five"))
+        )
+      }
+    }
+  }
+
+}

--- a/modules/prometheus4cats-testkit/src/main/scala/prometheus4cats/testkit/DslSuite.scala
+++ b/modules/prometheus4cats-testkit/src/main/scala/prometheus4cats/testkit/DslSuite.scala
@@ -16,12 +16,13 @@
 
 package prometheus4cats.testkit
 
+import scala.concurrent.duration._
+
 import cats.data.NonEmptyList
 import cats.data.NonEmptySeq
 import cats.effect.IO
 import cats.effect.kernel.Resource
 import cats.syntax.all._
-
 import munit.CatsEffectSuite
 import prometheus4cats._
 
@@ -89,6 +90,17 @@ trait DslSuite { self: CatsEffectSuite =>
   /** Default `initialSchema` a backend picks for a `NativeHistogram` when none is configured. */
   protected def defaultNativeSchema: Int = 5
 
+  /** Fixed `Exemplar[IO]` brought into implicit scope for every test. Counter `.inc` and histogram `.observe` calls
+    * attach this exemplar when the DSL routes through the appropriate registry method.
+    */
+  implicit protected val exemplar: Exemplar[IO] = new Exemplar[IO] {
+    override def get: IO[Option[Exemplar.Labels]] =
+      IO(Exemplar.Labels.of(Exemplar.LabelName("trace_id") -> "abc123").toOption)
+  }
+
+  /** Concrete value the implicit `exemplar` returns — handy for asserting against in expected literals. */
+  protected val exemplarLabels: Map[String, String] = Map("trace_id" -> "abc123")
+
   /** Error message a backend raises when a `factory.<kind>(name).callback(...)` is registered against a name already
     * owned by an active (push) metric. Backends that route through the prometheus4cats core get this for free.
     */
@@ -126,33 +138,126 @@ trait DslSuite { self: CatsEffectSuite =>
             _     <- c.inc(2.0, "alpha")
             snap2 <- getRegistryState
           } yield {
-            assertEquals(
-              snap1,
-              List(
-                FamilyState(
-                  name = "test_counter",
-                  `type` = "COUNTER",
-                  help = "test counter",
-                  dataPoints = List(CounterDP(Map("variant" -> "alpha"), 1.0, None))
-                )
+            def expected(value: Double) = List(
+              FamilyState(
+                name = "test_counter",
+                `type` = "COUNTER",
+                help = "test counter",
+                dataPoints = List(CounterDP(Map("variant" -> "alpha"), value, None))
               )
             )
-            assertEquals(
-              snap2,
-              List(
-                FamilyState(
-                  name = "test_counter",
-                  `type` = "COUNTER",
-                  help = "test counter",
-                  dataPoints = List(CounterDP(Map("variant" -> "alpha"), 3.0, None))
-                )
-              )
-            )
+            assertEquals(snap1, expected(1.0))
+            assertEquals(snap2, expected(3.0))
           }
         }
         .flatMap(_ => getRegistryState)
         .map(snap => assertEquals(snap, Nil))
 
+    }
+  }
+
+  // Each exemplar test below uses a freshly-built counter so v6's exemplar retention period (the
+  // minimum interval between consecutive exemplars) doesn't suppress the assertion. Combining multiple
+  // exemplar-attaching calls into one counter only the first one would survive.
+
+  test("counter — incWithExemplar attaches the implicit Exemplar to the snapshot") {
+    resource.use { factory =>
+      factory
+        .counter("test_implicit_exemplar_counter_total")
+        .ofDouble
+        .help("test implicit exemplar counter")
+        .build
+        .use { c =>
+          for {
+            _    <- c.incWithExemplar(1.0)
+            snap <- getRegistryState
+          } yield assertEquals(
+            snap,
+            List(
+              FamilyState(
+                name = "test_implicit_exemplar_counter",
+                `type` = "COUNTER",
+                help = "test implicit exemplar counter",
+                dataPoints = List(CounterDP(Map.empty, 1.0, Some(exemplarLabels)))
+              )
+            )
+          )
+        }
+        .flatMap(_ => getRegistryState)
+        .map(snap => assertEquals(snap, Nil))
+    }
+  }
+
+  test("counter — incProvidedExemplar attaches the explicitly-supplied Exemplar.Labels") {
+    resource.use { factory =>
+      val explicitLabels = Exemplar.Labels
+        .of(Exemplar.LabelName("trace_id") -> "def456", Exemplar.LabelName("span_id") -> "span789")
+        .toOption
+        .get
+      factory
+        .counter("test_provided_exemplar_counter_total")
+        .ofDouble
+        .help("test provided exemplar counter")
+        .build
+        .use { c =>
+          for {
+            _    <- c.incProvidedExemplar(1.0, Some(explicitLabels))
+            snap <- getRegistryState
+          } yield assertEquals(
+            snap,
+            List(
+              FamilyState(
+                name = "test_provided_exemplar_counter",
+                `type` = "COUNTER",
+                help = "test provided exemplar counter",
+                dataPoints = List(
+                  CounterDP(Map.empty, 1.0, Some(Map("trace_id" -> "def456", "span_id" -> "span789")))
+                )
+              )
+            )
+          )
+        }
+        .flatMap(_ => getRegistryState)
+        .map(snap => assertEquals(snap, Nil))
+    }
+  }
+
+  test("counter — incWithSampledExemplar attaches the sampler's output to the snapshot") {
+    resource.use { factory =>
+      val sampledLabels = Exemplar.Labels
+        .of(Exemplar.LabelName("trace_id") -> "sampled001")
+        .toOption
+        .get
+      implicit val sampler: ExemplarSampler.Counter[IO, Double] = new ExemplarSampler.Counter[IO, Double] {
+        // Both overloads always emit the same exemplar — enough to verify the sampler is being consulted.
+        override def sample(previous: Option[Exemplar.Data]): IO[Option[Exemplar.Data]] =
+          IO.pure(Some(Exemplar.Data(sampledLabels, java.time.Instant.now)))
+        override def sample(value: Double, previous: Option[Exemplar.Data]): IO[Option[Exemplar.Data]] =
+          IO.pure(Some(Exemplar.Data(sampledLabels, java.time.Instant.now)))
+      }
+      factory
+        .counter("test_sampled_exemplar_counter_total")
+        .ofDouble
+        .help("test sampled exemplar counter")
+        .build
+        .use { c =>
+          for {
+            _    <- c.incWithSampledExemplar(1.0)
+            snap <- getRegistryState
+          } yield assertEquals(
+            snap,
+            List(
+              FamilyState(
+                name = "test_sampled_exemplar_counter",
+                `type` = "COUNTER",
+                help = "test sampled exemplar counter",
+                dataPoints = List(CounterDP(Map.empty, 1.0, Some(Map("trace_id" -> "sampled001"))))
+              )
+            )
+          )
+        }
+        .flatMap(_ => getRegistryState)
+        .map(snap => assertEquals(snap, Nil))
     }
   }
 
@@ -298,6 +403,161 @@ trait DslSuite { self: CatsEffectSuite =>
                         ClassicBucket(0.5, 1L, None),
                         ClassicBucket(1.0, 1L, None),
                         ClassicBucket(5.0, 1L, None),
+                        ClassicBucket(Double.PositiveInfinity, 0L, None)
+                      )
+                    ),
+                    native = None
+                  )
+                )
+              )
+            )
+          )
+        }
+        .flatMap(_ => getRegistryState)
+        .map(snap => assertEquals(snap, Nil))
+    }
+  }
+
+  // Each histogram exemplar test below uses a single `observe*` call so v6's exemplar retention
+  // period doesn't suppress subsequent exemplar updates. The observed value lands in exactly one
+  // classic bucket — that bucket carries the exemplar; the other buckets stay `None`.
+
+  test("classic histogram — observeWithExemplar attaches the implicit Exemplar to the matching bucket") {
+    resource.use { factory =>
+      factory
+        .histogram("test_implicit_exemplar_histogram")
+        .ofDouble
+        .help("test implicit exemplar histogram")
+        .buckets(NonEmptySeq.of(0.1, 0.5, 1.0, 5.0))
+        .build
+        .use { h =>
+          for {
+            _    <- h.observeWithExemplar(0.05)
+            snap <- getRegistryState
+          } yield assertEquals(
+            snap,
+            List(
+              FamilyState(
+                name = "test_implicit_exemplar_histogram",
+                `type` = "HISTOGRAM",
+                help = "test implicit exemplar histogram",
+                dataPoints = List(
+                  HistogramDP(
+                    labels = Map.empty,
+                    count = 1L,
+                    sum = 0.05,
+                    classic = Some(
+                      List(
+                        ClassicBucket(0.1, 1L, Some(exemplarLabels)),
+                        ClassicBucket(0.5, 0L, None),
+                        ClassicBucket(1.0, 0L, None),
+                        ClassicBucket(5.0, 0L, None),
+                        ClassicBucket(Double.PositiveInfinity, 0L, None)
+                      )
+                    ),
+                    native = None
+                  )
+                )
+              )
+            )
+          )
+        }
+        .flatMap(_ => getRegistryState)
+        .map(snap => assertEquals(snap, Nil))
+    }
+  }
+
+  test("classic histogram — observeProvidedExemplar attaches the explicitly-supplied Exemplar.Labels") {
+    resource.use { factory =>
+      val explicitLabels = Exemplar.Labels
+        .of(Exemplar.LabelName("trace_id") -> "def456", Exemplar.LabelName("span_id") -> "span789")
+        .toOption
+        .get
+      factory
+        .histogram("test_provided_exemplar_histogram")
+        .ofDouble
+        .help("test provided exemplar histogram")
+        .buckets(NonEmptySeq.of(0.1, 0.5, 1.0, 5.0))
+        .build
+        .use { h =>
+          for {
+            _    <- h.observeProvidedExemplar(0.3, Some(explicitLabels))
+            snap <- getRegistryState
+          } yield assertEquals(
+            snap,
+            List(
+              FamilyState(
+                name = "test_provided_exemplar_histogram",
+                `type` = "HISTOGRAM",
+                help = "test provided exemplar histogram",
+                dataPoints = List(
+                  HistogramDP(
+                    labels = Map.empty,
+                    count = 1L,
+                    sum = 0.3,
+                    classic = Some(
+                      List(
+                        ClassicBucket(0.1, 0L, None),
+                        ClassicBucket(0.5, 1L, Some(Map("trace_id" -> "def456", "span_id" -> "span789"))),
+                        ClassicBucket(1.0, 0L, None),
+                        ClassicBucket(5.0, 0L, None),
+                        ClassicBucket(Double.PositiveInfinity, 0L, None)
+                      )
+                    ),
+                    native = None
+                  )
+                )
+              )
+            )
+          )
+        }
+        .flatMap(_ => getRegistryState)
+        .map(snap => assertEquals(snap, Nil))
+    }
+  }
+
+  test("classic histogram — observeWithSampledExemplar attaches the sampler's output to the matching bucket") {
+    resource.use { factory =>
+      val sampledLabels = Exemplar.Labels
+        .of(Exemplar.LabelName("trace_id") -> "sampled001")
+        .toOption
+        .get
+      implicit val sampler: ExemplarSampler.Histogram[IO, Double] = new ExemplarSampler.Histogram[IO, Double] {
+        override def sample(
+            value: Double,
+            buckets: NonEmptySeq[Double],
+            previous: Option[Exemplar.Data]
+        ): IO[Option[Exemplar.Data]] =
+          IO.pure(Some(Exemplar.Data(sampledLabels, java.time.Instant.now)))
+      }
+      factory
+        .histogram("test_sampled_exemplar_histogram")
+        .ofDouble
+        .help("test sampled exemplar histogram")
+        .buckets(NonEmptySeq.of(0.1, 0.5, 1.0, 5.0))
+        .build
+        .use { h =>
+          for {
+            _    <- h.observeWithSampledExemplar(0.7)
+            snap <- getRegistryState
+          } yield assertEquals(
+            snap,
+            List(
+              FamilyState(
+                name = "test_sampled_exemplar_histogram",
+                `type` = "HISTOGRAM",
+                help = "test sampled exemplar histogram",
+                dataPoints = List(
+                  HistogramDP(
+                    labels = Map.empty,
+                    count = 1L,
+                    sum = 0.7,
+                    classic = Some(
+                      List(
+                        ClassicBucket(0.1, 0L, None),
+                        ClassicBucket(0.5, 0L, None),
+                        ClassicBucket(1.0, 1L, Some(Map("trace_id" -> "sampled001"))),
+                        ClassicBucket(5.0, 0L, None),
                         ClassicBucket(Double.PositiveInfinity, 0L, None)
                       )
                     ),
@@ -636,6 +896,203 @@ trait DslSuite { self: CatsEffectSuite =>
             assertEquals(snap1, expected(42.0, 7.0))
             assertEquals(snap2, expected(100.0, 200.0))
           }
+        }
+        .flatMap(_ => getRegistryState)
+        .map(snap => assertEquals(snap, Nil))
+    }
+  }
+
+  // timer
+  //
+  // `Timer` is a derived metric built on top of a Histogram via `.asTimer`. `recordTime` observes the
+  // duration converted to seconds; `recordTimeWithExemplar` does the same and additionally attaches the
+  // implicit `Exemplar[F]` to the bucket the duration lands in.
+
+  test("histogram-backed Timer — recordTime observes the duration as seconds into the matching bucket") {
+    resource.use { factory =>
+      factory
+        .histogram("test_timer_seconds")
+        .ofDouble
+        .help("test timer")
+        .buckets(NonEmptySeq.of(0.1, 0.5, 1.0))
+        .asTimer
+        .build
+        .use { timer =>
+          for {
+            _    <- timer.recordTime(50.millis) // 0.05s → lands in bucket 0.1
+            snap <- getRegistryState
+          } yield assertEquals(
+            snap,
+            List(
+              FamilyState(
+                name = "test_timer_seconds",
+                `type` = "HISTOGRAM",
+                help = "test timer",
+                dataPoints = List(
+                  HistogramDP(
+                    labels = Map.empty,
+                    count = 1L,
+                    sum = 0.05,
+                    classic = Some(
+                      List(
+                        ClassicBucket(0.1, 1L, None),
+                        ClassicBucket(0.5, 0L, None),
+                        ClassicBucket(1.0, 0L, None),
+                        ClassicBucket(Double.PositiveInfinity, 0L, None)
+                      )
+                    ),
+                    native = None
+                  )
+                )
+              )
+            )
+          )
+        }
+        .flatMap(_ => getRegistryState)
+        .map(snap => assertEquals(snap, Nil))
+    }
+  }
+
+  test("native histogram-backed Timer — recordTime observes the duration as seconds into native bucket data") {
+    resource.use { factory =>
+      factory
+        .nativeHistogram("test_native_timer_seconds")
+        .help("test native timer")
+        .asTimer
+        .build
+        .use { timer =>
+          for {
+            _    <- timer.recordTime(50.millis)
+            snap <- getRegistryState
+          } yield assertEquals(
+            snap,
+            List(
+              FamilyState(
+                name = "test_native_timer_seconds",
+                `type` = "HISTOGRAM",
+                help = "test native timer",
+                dataPoints = List(
+                  HistogramDP(
+                    labels = Map.empty, count = 1L, sum = 0.05, classic = None,
+                    native = Some(NativeHistogramState(defaultNativeSchema))
+                  )
+                )
+              )
+            )
+          )
+        }
+        .flatMap(_ => getRegistryState)
+        .map(snap => assertEquals(snap, Nil))
+    }
+  }
+
+  test("histogram-backed Timer — recordTimeWithExemplar attaches the implicit Exemplar to the matching bucket") {
+    resource.use { factory =>
+      factory
+        .histogram("test_timer_exemplar_seconds")
+        .ofDouble
+        .help("test timer exemplar")
+        .buckets(NonEmptySeq.of(0.1, 0.5, 1.0))
+        .asTimer
+        .build
+        .use { timer =>
+          for {
+            _    <- timer.recordTimeWithExemplar(50.millis)
+            snap <- getRegistryState
+          } yield assertEquals(
+            snap,
+            List(
+              FamilyState(
+                name = "test_timer_exemplar_seconds",
+                `type` = "HISTOGRAM",
+                help = "test timer exemplar",
+                dataPoints = List(
+                  HistogramDP(
+                    labels = Map.empty,
+                    count = 1L,
+                    sum = 0.05,
+                    classic = Some(
+                      List(
+                        ClassicBucket(0.1, 1L, Some(exemplarLabels)),
+                        ClassicBucket(0.5, 0L, None),
+                        ClassicBucket(1.0, 0L, None),
+                        ClassicBucket(Double.PositiveInfinity, 0L, None)
+                      )
+                    ),
+                    native = None
+                  )
+                )
+              )
+            )
+          )
+        }
+        .flatMap(_ => getRegistryState)
+        .map(snap => assertEquals(snap, Nil))
+    }
+  }
+
+  // outcome recorder
+  //
+  // `OutcomeRecorder` is a derived metric built on top of a Counter via `.asOutcomeRecorder`. Each
+  // surrounded operation routes to one of three `outcome_status` label values (succeeded / errored /
+  // canceled); only the label value actually observed appears in the snapshot. `surroundWithExemplar`
+  // attaches the implicit `Exemplar[F]` to the relevant counter sample when the corresponding
+  // `recordExemplarOn*` flag is `true`.
+
+  test("counter-backed OutcomeRecorder — surround increments the succeeded counter on F[_] success") {
+    resource.use { factory =>
+      factory
+        .counter("test_outcome_total")
+        .ofDouble
+        .help("test outcome")
+        .asOutcomeRecorder
+        .build
+        .use { recorder =>
+          for {
+            _    <- recorder.surround(IO.unit)
+            snap <- getRegistryState
+          } yield assertEquals(
+            snap,
+            List(
+              FamilyState(
+                name = "test_outcome",
+                `type` = "COUNTER",
+                help = "test outcome",
+                dataPoints = List(CounterDP(Map("outcome_status" -> "succeeded"), 1.0, None))
+              )
+            )
+          )
+        }
+        .flatMap(_ => getRegistryState)
+        .map(snap => assertEquals(snap, Nil))
+    }
+  }
+
+  test(
+    "counter-backed OutcomeRecorder — surroundWithExemplar attaches the implicit Exemplar to the succeeded counter"
+  ) {
+    resource.use { factory =>
+      factory
+        .counter("test_outcome_exemplar_total")
+        .ofDouble
+        .help("test outcome exemplar")
+        .asOutcomeRecorder
+        .build
+        .use { recorder =>
+          for {
+            _    <- recorder.surroundWithExemplar(IO.unit, recordExemplarOnSucceeded = true)
+            snap <- getRegistryState
+          } yield assertEquals(
+            snap,
+            List(
+              FamilyState(
+                name = "test_outcome_exemplar",
+                `type` = "COUNTER",
+                help = "test outcome exemplar",
+                dataPoints = List(CounterDP(Map("outcome_status" -> "succeeded"), 1.0, Some(exemplarLabels)))
+              )
+            )
+          )
         }
         .flatMap(_ => getRegistryState)
         .map(snap => assertEquals(snap, Nil))


### PR DESCRIPTION
This PR:

1. Adds `DslSuite` which tests the library from Dsl layer and asserts data in the provided `MetricRegistry`
2. Based on existing `JavaMetricRegistrySuite`
