### PR TITLE
series/6.x - consolidate .ofDouble and .ofLong

### DIFF
--- a/modules/prometheus4cats-testkit/src/main/scala/prometheus4cats/testkit/DslSuite.scala
+++ b/modules/prometheus4cats-testkit/src/main/scala/prometheus4cats/testkit/DslSuite.scala
@@ -578,6 +578,7 @@ trait DslSuite { self: CatsEffectSuite =>
     resource.use { factory =>
       factory
         .nativeHistogram("test_native_histogram")
+        .ofDouble
         .help("test native histogram")
         .build
         .use { h =>
@@ -656,6 +657,7 @@ trait DslSuite { self: CatsEffectSuite =>
     resource.use { factory =>
       factory
         .nativeHistogram("test_native_tuned", NativeHistogram.Default.withInitialSchema(3))
+        .ofDouble
         .help("native with custom schema")
         .build
         .use { h =>
@@ -958,6 +960,7 @@ trait DslSuite { self: CatsEffectSuite =>
     resource.use { factory =>
       factory
         .nativeHistogram("test_native_timer_seconds")
+        .ofDouble
         .help("test native timer")
         .asTimer
         .build

--- a/modules/prometheus4cats/src/main/scala/prometheus4cats/MetricFactory.scala
+++ b/modules/prometheus4cats/src/main/scala/prometheus4cats/MetricFactory.scala
@@ -244,6 +244,8 @@ sealed abstract class MetricFactory[F[_]](
       )
     )
 
+  type NativeHistogramWithNativeDsl[A] = HelpStep[MetricDsl[F, A, Histogram]]
+
   /** Starts creating a "native histogram" metric.
     *
     * Native histograms (sometimes called sparse or exponential histograms) automatically allocate buckets sized by an
@@ -281,7 +283,21 @@ sealed abstract class MetricFactory[F[_]](
   def nativeHistogram(
       name: Histogram.Name,
       config: NativeHistogram = NativeHistogram.Default
-  ): HelpStep[MetricDsl[F, Double, Histogram]] =
+  ) = new TypeStep[NativeHistogramWithNativeDsl](
+    new HelpStep(help =>
+      new MetricDsl(
+        new LabelledMetricPartiallyApplied[F, Long, Histogram] {
+
+          override def apply[B](
+              labels: IndexedSeq[Label.Name]
+          )(f: B => IndexedSeq[String]): Resource[F, Histogram[F, Long, B]] =
+            metricRegistry.createAndRegisterLongNativeHistogram(
+              prefix, name, help, commonLabels, labels, config
+            )(f)
+
+        }
+      )
+    ),
     new HelpStep(help =>
       new MetricDsl(
         new LabelledMetricPartiallyApplied[F, Double, Histogram] {
@@ -296,6 +312,7 @@ sealed abstract class MetricFactory[F[_]](
         }
       )
     )
+  )
 
   type SummaryDslLambda[A] = HelpStep[SummaryDsl.Base[F, A]]
 

--- a/modules/prometheus4cats/src/main/scala/prometheus4cats/MetricRegistry.scala
+++ b/modules/prometheus4cats/src/main/scala/prometheus4cats/MetricRegistry.scala
@@ -279,6 +279,19 @@ trait MetricRegistry[F[_]] {
       config: NativeHistogram
   )(f: A => IndexedSeq[String]): Resource[F, Histogram[F, Double, A]]
 
+  /** [[scala.Long]] variant of [[createAndRegisterDoubleNativeHistogram]]. Backends are expected to honour this by
+    * registering a Double-typed native histogram underneath and converting Long observations to Double at the call site;
+    * the native histogram's exponential bucket layout doesn't care about the original numeric type.
+    */
+  def createAndRegisterLongNativeHistogram[A](
+      prefix: Option[Metric.Prefix],
+      name: Histogram.Name,
+      help: Metric.Help,
+      commonLabels: Metric.CommonLabels,
+      labelNames: IndexedSeq[Label.Name],
+      config: NativeHistogram
+  )(f: A => IndexedSeq[String]): Resource[F, Histogram[F, Long, A]]
+
   /** Create and register a summary that records [[scala.Double]] values against a metrics registry
     *
     * @param prefix
@@ -439,6 +452,16 @@ object MetricRegistry {
       )(f: A => IndexedSeq[String]): Resource[F, Histogram[F, Double, A]] =
         Resource.pure(Histogram.noop)
 
+      override def createAndRegisterLongNativeHistogram[A](
+          prefix: Option[Metric.Prefix],
+          name: Histogram.Name,
+          help: Metric.Help,
+          commonLabels: CommonLabels,
+          labelNames: IndexedSeq[Label.Name],
+          config: NativeHistogram
+      )(f: A => IndexedSeq[String]): Resource[F, Histogram[F, Long, A]] =
+        Resource.pure(Histogram.noop)
+
       override def createAndRegisterDoubleHistogramWithNative[A](
           prefix: Option[Metric.Prefix],
           name: Histogram.Name,
@@ -534,6 +557,21 @@ object MetricRegistry {
       )(f: A => IndexedSeq[String]): Resource[G, Histogram[G, Double, A]] =
         self
           .createAndRegisterDoubleNativeHistogram(
+            prefix, name, help, commonLabels, labelNames, config
+          )(f)
+          .mapK(fk)
+          .map(_.mapK(fk))
+
+      override def createAndRegisterLongNativeHistogram[A](
+          prefix: Option[Metric.Prefix],
+          name: Histogram.Name,
+          help: Metric.Help,
+          commonLabels: CommonLabels,
+          labelNames: IndexedSeq[Label.Name],
+          config: NativeHistogram
+      )(f: A => IndexedSeq[String]): Resource[G, Histogram[G, Long, A]] =
+        self
+          .createAndRegisterLongNativeHistogram(
             prefix, name, help, commonLabels, labelNames, config
           )(f)
           .mapK(fk)

--- a/modules/prometheus4cats/src/main/scala/prometheus4cats/MetricRegistry.scala
+++ b/modules/prometheus4cats/src/main/scala/prometheus4cats/MetricRegistry.scala
@@ -280,8 +280,8 @@ trait MetricRegistry[F[_]] {
   )(f: A => IndexedSeq[String]): Resource[F, Histogram[F, Double, A]]
 
   /** [[scala.Long]] variant of [[createAndRegisterDoubleNativeHistogram]]. Backends are expected to honour this by
-    * registering a Double-typed native histogram underneath and converting Long observations to Double at the call site;
-    * the native histogram's exponential bucket layout doesn't care about the original numeric type.
+    * registering a Double-typed native histogram underneath and converting Long observations to Double at the call
+    * site; the native histogram's exponential bucket layout doesn't care about the original numeric type.
     */
   def createAndRegisterLongNativeHistogram[A](
       prefix: Option[Metric.Prefix],

--- a/modules/prometheus4cats/src/main/scala/prometheus4cats/util/DoubleMetricRegistry.scala
+++ b/modules/prometheus4cats/src/main/scala/prometheus4cats/util/DoubleMetricRegistry.scala
@@ -69,6 +69,17 @@ trait DoubleMetricRegistry[F[_]] extends MetricRegistry[F] {
       prefix, name, help, commonLabels, labelNames, buckets.map(_.toDouble), nativeHistogram
     )(f).map(_.contramap(_.toDouble))
 
+  override def createAndRegisterLongNativeHistogram[A](
+      prefix: Option[Metric.Prefix],
+      name: Histogram.Name,
+      help: Metric.Help,
+      commonLabels: Metric.CommonLabels,
+      labelNames: IndexedSeq[Label.Name],
+      config: NativeHistogram
+  )(f: A => IndexedSeq[String]): Resource[F, Histogram[F, Long, A]] =
+    createAndRegisterDoubleNativeHistogram(prefix, name, help, commonLabels, labelNames, config)(f)
+      .map(_.contramap[Long](_.toDouble))
+
   override def createAndRegisterLongSummary[A](
       prefix: Option[Metric.Prefix],
       name: Summary.Name,

--- a/modules/prometheus4cats/src/test/scala/test/ExternalPackageMetricRegistry.scala
+++ b/modules/prometheus4cats/src/test/scala/test/ExternalPackageMetricRegistry.scala
@@ -91,6 +91,15 @@ class ExternalPackageMetricRegistry extends MetricRegistry[IO] with CallbackRegi
       config: NativeHistogram
   )(f: A => IndexedSeq[String]): Resource[IO, Histogram[IO, Double, A]] = ???
 
+  override def createAndRegisterLongNativeHistogram[A](
+      prefix: Option[Metric.Prefix],
+      name: Histogram.Name,
+      help: Metric.Help,
+      commonLabels: Metric.CommonLabels,
+      labelNames: IndexedSeq[Label.Name],
+      config: NativeHistogram
+  )(f: A => IndexedSeq[String]): Resource[IO, Histogram[IO, Long, A]] = ???
+
   override def createAndRegisterDoubleHistogramWithNative[A](
       prefix: Option[Metric.Prefix],
       name: Histogram.Name,

--- a/modules/prometheus4cats/src/test/scala/test/MetricsFactoryDslTest.scala
+++ b/modules/prometheus4cats/src/test/scala/test/MetricsFactoryDslTest.scala
@@ -172,7 +172,7 @@ class MetricsFactoryDslTest[F[_]: MonadCancelThrow: Clock] {
   longHistogramBuilder.unsafeLabels(Label.Name("label1"), Label.Name("label2")).build
 
   // Native histograms — double-only by design, no .ofLong / .ofDouble step.
-  val nativeHistogramBuilder = factory.nativeHistogram("test_native").help("help")
+  val nativeHistogramBuilder = factory.nativeHistogram("test_native").ofDouble.help("help")
 
   nativeHistogramBuilder.build
 
@@ -190,6 +190,7 @@ class MetricsFactoryDslTest[F[_]: MonadCancelThrow: Clock] {
   // With a custom NativeHistogram tuning config.
   factory
     .nativeHistogram("test_native_tuned", NativeHistogram.Default.withInitialSchema(6).withMaxNumberOfBuckets(80))
+    .ofLong
     .help("help")
     .label[String]("label1")
     .build


### PR DESCRIPTION
This PR:

1. Adds `.ofLong` and `.ofDouble` back to native histogram. This is in contradiction to what is stated on https://github.com/permutive-engineering/prometheus4cats/issues/138
2. It was easy to add back and keep the API consistent.
