### PR TITLE
Deprecate .ofLong / .ofDouble — default to Double

### DIFF
--- a/.github/docs/README.md
+++ b/.github/docs/README.md
@@ -35,13 +35,12 @@ val counterResource =
     registry <- JavaMetricRegistry.Builder[IO]().build
     factory = MetricFactory.builder.build(registry)
     counter <- factory.counter("my_counter_total")
-                 .ofLong
                  .help("My Counter")
                  .label[String]("some_label")
                  .build
   } yield counter
 
-counterResource.use { counter => counter.inc("Some label value") }
+counterResource.use { counter => counter.inc(1.0, "Some label value") }
 ```
 
 If you want to know more about all the library's features, please head on to [its website](https://permutive-engineering.github.io/prometheus4cats/) where you will find much more information.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,13 @@ the [migration guide](./website/docs/migrating-from-v5.md) for the upgrade path.
 - Exemplar retention period enforced by upstream `prometheus-metrics-core` — approximately 7 seconds
   minimum between consecutive exemplars landing in the same classic-histogram bucket
 
+### Deprecated
+
+- `.ofLong` / `.ofDouble` on the factory type-step. `Double` is now the default — call `.help`
+  directly off `factory.counter(name)` / `.gauge(name)` / `.histogram(name)` / `.summary(name)`.
+  Callers wanting `Long` semantics should use `.contramap[Long](_.toDouble)` on the resulting DSL.
+  The deprecated methods still work for one release.
+
 ### Removed
 
 - **BREAKING**: self-observability metrics (`prometheus4cats_registered_metrics`,

--- a/README.md
+++ b/README.md
@@ -35,13 +35,12 @@ val counterResource =
     registry <- JavaMetricRegistry.Builder[IO]().build
     factory = MetricFactory.builder.build(registry)
     counter <- factory.counter("my_counter_total")
-                 .ofLong
                  .help("My Counter")
                  .label[String]("some_label")
                  .build
   } yield counter
 
-counterResource.use { counter => counter.inc("Some label value") }
+counterResource.use { counter => counter.inc(1.0, "Some label value") }
 ```
 
 If you want to know more about all the library's features, please head on to [its website](https://permutive-engineering.github.io/prometheus4cats/) where you will find much more information.

--- a/modules/prometheus4cats-testkit/src/main/scala/prometheus4cats/testkit/DslSuite.scala
+++ b/modules/prometheus4cats-testkit/src/main/scala/prometheus4cats/testkit/DslSuite.scala
@@ -128,7 +128,6 @@ trait DslSuite { self: CatsEffectSuite =>
     resource.use { factory =>
       factory
         .counter("test_counter_total")
-        .ofDouble
         .help("test counter")
         .label[String]("variant")
         .build
@@ -165,7 +164,6 @@ trait DslSuite { self: CatsEffectSuite =>
     resource.use { factory =>
       factory
         .counter("test_implicit_exemplar_counter_total")
-        .ofDouble
         .help("test implicit exemplar counter")
         .build
         .use { c =>
@@ -197,7 +195,6 @@ trait DslSuite { self: CatsEffectSuite =>
         .get
       factory
         .counter("test_provided_exemplar_counter_total")
-        .ofDouble
         .help("test provided exemplar counter")
         .build
         .use { c =>
@@ -238,7 +235,6 @@ trait DslSuite { self: CatsEffectSuite =>
       }
       factory
         .counter("test_sampled_exemplar_counter_total")
-        .ofDouble
         .help("test sampled exemplar counter")
         .build
         .use { c =>
@@ -268,7 +264,6 @@ trait DslSuite { self: CatsEffectSuite =>
       val callback = IO.delay(NonEmptyList.of(iterator.next()))
       factory
         .counter("test_callback_counter_total")
-        .ofDouble
         .help("test counter callback")
         .label[String]("variant")
         .callback(callback)
@@ -303,7 +298,6 @@ trait DslSuite { self: CatsEffectSuite =>
     resource.use { factory =>
       factory
         .gauge("test_gauge")
-        .ofDouble
         .help("test gauge")
         .build
         .use { g =>
@@ -342,7 +336,6 @@ trait DslSuite { self: CatsEffectSuite =>
       val callback = IO.delay(iterator.next())
       factory
         .gauge("test_callback_gauge")
-        .ofDouble
         .help("test gauge callback")
         .label[String]("node")
         .callback(callback)
@@ -378,7 +371,6 @@ trait DslSuite { self: CatsEffectSuite =>
     resource.use { factory =>
       factory
         .histogram("test_classic_histogram")
-        .ofDouble
         .help("test classic histogram")
         .buckets(NonEmptySeq.of(0.1, 0.5, 1.0, 5.0))
         .build
@@ -427,7 +419,6 @@ trait DslSuite { self: CatsEffectSuite =>
     resource.use { factory =>
       factory
         .histogram("test_implicit_exemplar_histogram")
-        .ofDouble
         .help("test implicit exemplar histogram")
         .buckets(NonEmptySeq.of(0.1, 0.5, 1.0, 5.0))
         .build
@@ -476,7 +467,6 @@ trait DslSuite { self: CatsEffectSuite =>
         .get
       factory
         .histogram("test_provided_exemplar_histogram")
-        .ofDouble
         .help("test provided exemplar histogram")
         .buckets(NonEmptySeq.of(0.1, 0.5, 1.0, 5.0))
         .build
@@ -533,7 +523,6 @@ trait DslSuite { self: CatsEffectSuite =>
       }
       factory
         .histogram("test_sampled_exemplar_histogram")
-        .ofDouble
         .help("test sampled exemplar histogram")
         .buckets(NonEmptySeq.of(0.1, 0.5, 1.0, 5.0))
         .build
@@ -578,7 +567,6 @@ trait DslSuite { self: CatsEffectSuite =>
     resource.use { factory =>
       factory
         .nativeHistogram("test_native_histogram")
-        .ofDouble
         .help("test native histogram")
         .build
         .use { h =>
@@ -611,7 +599,6 @@ trait DslSuite { self: CatsEffectSuite =>
     resource.use { factory =>
       factory
         .histogram("test_dual_histogram")
-        .ofDouble
         .help("test dual-mode (NHCB-friendly) histogram")
         .buckets(NonEmptySeq.of(0.1, 0.5, 1.0, 5.0))
         .withNative
@@ -657,7 +644,6 @@ trait DslSuite { self: CatsEffectSuite =>
     resource.use { factory =>
       factory
         .nativeHistogram("test_native_tuned", NativeHistogram.Default.withInitialSchema(3))
-        .ofDouble
         .help("native with custom schema")
         .build
         .use { h =>
@@ -698,7 +684,6 @@ trait DslSuite { self: CatsEffectSuite =>
       val callback = IO.delay(iterator.next())
       factory
         .histogram("test_callback_histogram")
-        .ofDouble
         .help("test histogram callback")
         .buckets(NonEmptySeq.of(0.1, 1.0, 5.0))
         .label[String]("variant")
@@ -749,7 +734,6 @@ trait DslSuite { self: CatsEffectSuite =>
     resource.use { factory =>
       factory
         .summary("test_summary")
-        .ofDouble
         .help("test summary")
         .quantile(Summary.Quantile.from(0.5).toOption.get, Summary.AllowedError.from(0.05).toOption.get)
         .quantile(Summary.Quantile.from(0.99).toOption.get, Summary.AllowedError.from(0.01).toOption.get)
@@ -790,7 +774,6 @@ trait DslSuite { self: CatsEffectSuite =>
       val callback = IO.delay(iterator.next())
       factory
         .summary("test_callback_summary")
-        .ofDouble
         .help("test summary callback")
         .label[String]("variant")
         .callback(callback)
@@ -915,7 +898,6 @@ trait DslSuite { self: CatsEffectSuite =>
     resource.use { factory =>
       factory
         .histogram("test_timer_seconds")
-        .ofDouble
         .help("test timer")
         .buckets(NonEmptySeq.of(0.1, 0.5, 1.0))
         .asTimer
@@ -960,7 +942,6 @@ trait DslSuite { self: CatsEffectSuite =>
     resource.use { factory =>
       factory
         .nativeHistogram("test_native_timer_seconds")
-        .ofDouble
         .help("test native timer")
         .asTimer
         .build
@@ -994,7 +975,6 @@ trait DslSuite { self: CatsEffectSuite =>
     resource.use { factory =>
       factory
         .histogram("test_timer_exemplar_seconds")
-        .ofDouble
         .help("test timer exemplar")
         .buckets(NonEmptySeq.of(0.1, 0.5, 1.0))
         .asTimer
@@ -1047,7 +1027,6 @@ trait DslSuite { self: CatsEffectSuite =>
     resource.use { factory =>
       factory
         .counter("test_outcome_total")
-        .ofDouble
         .help("test outcome")
         .asOutcomeRecorder
         .build
@@ -1078,7 +1057,6 @@ trait DslSuite { self: CatsEffectSuite =>
     resource.use { factory =>
       factory
         .counter("test_outcome_exemplar_total")
-        .ofDouble
         .help("test outcome exemplar")
         .asOutcomeRecorder
         .build
@@ -1114,7 +1092,7 @@ trait DslSuite { self: CatsEffectSuite =>
 
   test("name-collision: returns an existing metric when labels and name are the same") {
     resource.use { factory =>
-      val mk = factory.counter("collision_reuse_total").ofDouble.help(collisionHelp).label[String]("region").build
+      val mk = factory.counter("collision_reuse_total").help(collisionHelp).label[String]("region").build
       def expected(value: Double) = List(
         FamilyState(
           name = "collision_reuse",
@@ -1147,14 +1125,12 @@ trait DslSuite { self: CatsEffectSuite =>
     resource.use { factory =>
       val callback = factory
         .counter("collision_metric_after_callback_total")
-        .ofDouble
         .help(collisionHelp)
         .label[String]("region")
         .callback(IO.pure(NonEmptyList.one((0.0, "x"))))
         .build
       val metric = factory
         .counter("collision_metric_after_callback_total")
-        .ofDouble
         .help(collisionHelp)
         .label[String]("region")
         .build
@@ -1172,13 +1148,11 @@ trait DslSuite { self: CatsEffectSuite =>
     resource.use { factory =>
       val metric = factory
         .counter("collision_callback_after_metric_total")
-        .ofDouble
         .help(collisionHelp)
         .label[String]("region")
         .build
       val callback = factory
         .counter("collision_callback_after_metric_total")
-        .ofDouble
         .help(collisionHelp)
         .label[String]("region")
         .callback(IO.pure(NonEmptyList.one((0.0, "x"))))
@@ -1197,13 +1171,11 @@ trait DslSuite { self: CatsEffectSuite =>
     resource.use { factory =>
       val m1 = factory
         .counter("collision_different_labels_total")
-        .ofDouble
         .help(collisionHelp)
         .label[String]("region")
         .build
       val m2 = factory
         .counter("collision_different_labels_total")
-        .ofDouble
         .help(collisionHelp)
         .label[String]("different")
         .build
@@ -1225,7 +1197,6 @@ trait DslSuite { self: CatsEffectSuite =>
       val callback = IO.pure(NonEmptyList.of((1.0, "x"), (2.0, "x")))
       factory
         .counter("collision_dup_label_total")
-        .ofDouble
         .help(collisionHelp)
         .label[String]("name")
         .callback(callback)
@@ -1247,13 +1218,11 @@ trait DslSuite { self: CatsEffectSuite =>
     resource.use { factory =>
       val counter = factory
         .counter("collision_different_type_total")
-        .ofDouble
         .help(collisionHelp)
         .label[String]("region")
         .build
       val gauge = factory
         .gauge("collision_different_type")
-        .ofDouble
         .help(collisionHelp)
         .label[String]("region")
         .build

--- a/modules/prometheus4cats/src/main/scala/prometheus4cats/MetricFactory.scala
+++ b/modules/prometheus4cats/src/main/scala/prometheus4cats/MetricFactory.scala
@@ -38,9 +38,8 @@ import prometheus4cats.internal.summary.SummaryDsl
   *   {{{
   * val factory: MetricFactory[IO] = ???
   *
-  * val counter: Resource[IO, Counter[IO, Long, Unit]] =
+  * val counter: Resource[IO, Counter[IO, Double, Unit]] =
   *   factory.counter("my_counter")
-  *     .ofLong
   *     .help("Total number of requests")
   *     .build
   *   }}}
@@ -75,7 +74,7 @@ sealed abstract class MetricFactory[F[_]](
   /** Starts creating a "gauge" metric.
     *
     * @example
-    *   {{{ metrics.gauge("my_gauge").ofDouble.help("my gauge help").label[Int]("first_label")
+    *   {{{ metrics.gauge("my_gauge").help("my gauge help").label[Int]("first_label")
     *   .label[String]("second_label").label[Boolean]("third_label") .build }}}
     * @param name
     *   [[Gauge.Name]] value
@@ -115,7 +114,7 @@ sealed abstract class MetricFactory[F[_]](
   /** Starts creating a "counter" metric.
     *
     * @example
-    *   {{{ metrics.counter("my_counter").ofLong.help("my counter help") .label[Int]("first_label")
+    *   {{{ metrics.counter("my_counter").help("my counter help") .label[Int]("first_label")
     *   .label[String]("second_label") .label[Boolean]("third_label") .build }}}
     * @param name
     *   [[Counter.Name]] value
@@ -168,16 +167,16 @@ sealed abstract class MetricFactory[F[_]](
     * @example
     *   {{{
     * // Classic-only (existing behaviour):
-    * metrics.histogram("http_dur").ofDouble.help("...").buckets(0.005, 0.01, 0.025, 0.05, 0.1, 0.5, 1, 5, 10).build
+    * metrics.histogram("http_dur").help("...").buckets(0.005, 0.01, 0.025, 0.05, 0.1, 0.5, 1, 5, 10).build
     *
     * // Dual-mode (NHCB-friendly): same buckets, plus native exponential.
-    * metrics.histogram("http_dur").ofDouble.help("...")
+    * metrics.histogram("http_dur").help("...")
     *   .buckets(0.005, 0.01, 0.025, 0.05, 0.1, 0.5, 1, 5, 10)
     *   .withNative
     *   .build
     *
     * // Dual-mode with custom native tuning.
-    * metrics.histogram("http_dur").ofDouble.help("...")
+    * metrics.histogram("http_dur").help("...")
     *   .buckets(0.005, 0.01, ...)
     *   .withNative(NativeHistogram.Default.withInitialSchema(6))
     *   .build
@@ -321,7 +320,6 @@ sealed abstract class MetricFactory[F[_]](
     * @example
     *   {{{
     * metrics.summary("my_summary")
-    *   .ofDouble
     *   .help("Request latency distribution")
     *   .quantile(0.5, 0.05)
     *   .quantile(0.9, 0.01)
@@ -434,7 +432,6 @@ object MetricFactory {
     * // Register a callback-based gauge
     * val gauge: Resource[IO, Unit] =
     *   factory.gauge("active_connections")
-    *     .ofLong
     *     .help("Number of active connections")
     *     .callback(connectionPool.activeCount)
     *     .build

--- a/modules/prometheus4cats/src/main/scala/prometheus4cats/internal/package.scala
+++ b/modules/prometheus4cats/src/main/scala/prometheus4cats/internal/package.scala
@@ -707,11 +707,29 @@ class HelpStep[+A] private[prometheus4cats] (f: Metric.Help => A) {
 
 }
 
-class TypeStep[+D[_]] private[prometheus4cats] (long: D[Long], double: D[Double]) {
+class TypeStep[+D[_]] private[prometheus4cats] (long: D[Long], private[prometheus4cats] val double: D[Double]) {
 
+  @deprecated(
+    "use .ofDouble.contramap[Long](_.toDouble) — Double is now the default; an implicit conversion exposes the Double DSL directly on the factory method's return value",
+    "6.0.0"
+  )
   def ofLong: D[Long] = long
 
+  @deprecated(
+    "Double is now the default — call .help directly (an implicit conversion exposes the Double DSL on the factory method's return value)",
+    "6.0.0"
+  )
   def ofDouble: D[Double] = double
+
+}
+
+object TypeStep {
+
+  /** Source-compat shim: makes `factory.counter(name).help(...)` (and similar) compile by transparently selecting the
+    * `Double`-valued DSL. Replaces the old `factory.counter(name).ofDouble.help(...)` two-step. `Long`-valued metrics
+    * are no longer the default; callers wanting `Long` semantics should `.ofDouble.contramap[Long](_.toDouble)`.
+    */
+  implicit def typeStepIsDouble[D[_]](step: TypeStep[D]): D[Double] = step.double
 
 }
 

--- a/modules/prometheus4cats/src/main/scala/prometheus4cats/internal/package.scala
+++ b/modules/prometheus4cats/src/main/scala/prometheus4cats/internal/package.scala
@@ -729,6 +729,7 @@ object TypeStep {
     * `Double`-valued DSL. Replaces the old `factory.counter(name).ofDouble.help(...)` two-step. `Long`-valued metrics
     * are no longer the default; callers wanting `Long` semantics should `.ofDouble.contramap[Long](_.toDouble)`.
     */
+  @SuppressWarnings(Array("scalafix:DisableSyntax.implicitConversion"))
   implicit def typeStepIsDouble[D[_]](step: TypeStep[D]): D[Double] = step.double
 
 }

--- a/modules/prometheus4cats/src/test/scala/test/MetricsFactoryDslTest.scala
+++ b/modules/prometheus4cats/src/test/scala/test/MetricsFactoryDslTest.scala
@@ -29,6 +29,7 @@ import cats.effect.kernel.MonadCancelThrow
 import prometheus4cats._
 
 @nowarn("msg=unused value")
+@nowarn("cat=deprecation")
 @SuppressWarnings(Array("all"))
 class MetricsFactoryDslTest[F[_]: MonadCancelThrow: Clock] {
 

--- a/modules/sandbox/src/main/scala/prometheus4cats/sandbox/Sandbox.scala
+++ b/modules/sandbox/src/main/scala/prometheus4cats/sandbox/Sandbox.scala
@@ -62,41 +62,36 @@ object Sandbox extends IOApp.Simple {
 
       random <- Resource.eval(Random.scalaUtilRandom[IO])
 
-      counter <- factory.counter("counter_total").ofDouble.help("Test counter").label[String]("label").build
+      counter <- factory.counter("counter_total").help("Test counter").label[String]("label").build
 
       sampledCounter <- factory
                           .counter("sampled_counter_total")
-                          .ofDouble
                           .help("Counter with downsampled exemplars (~1 in 10)")
                           .label[String]("label")
                           .build
 
       classic <- factory
                    .histogram("classic_histogram_seconds")
-                   .ofDouble
                    .help("Classic histogram with curated buckets")
                    .buckets(LatencyBuckets)
                    .build
 
       native <- factory
                   .nativeHistogram("native_histogram_seconds")
-                  .ofDouble
                   .help("Native (sparse / exponential) histogram, no declared buckets")
                   .build
 
       dual <- factory
                 .histogram("dual_histogram_seconds")
-                .ofDouble
                 .help("Dual-mode histogram: classic + native from one declaration")
                 .buckets(LatencyBuckets)
                 .withNative
                 .build
 
-      gauge <- factory.gauge("gauge_value").ofDouble.help("Test gauge — sine wave 0..100").build
+      gauge <- factory.gauge("gauge_value").help("Test gauge — sine wave 0..100").build
 
       summary <- factory
                    .summary("summary_seconds")
-                   .ofDouble
                    .help("Test summary with p50 / p90 / p99 quantiles")
                    .quantile(
                      Summary.Quantile.from(0.5).toOption.get,
@@ -122,7 +117,6 @@ object Sandbox extends IOApp.Simple {
 
       timer <- factory
                  .histogram("operation_duration_seconds")
-                 .ofDouble
                  .help("Histogram-backed Timer (.asTimer) — observes durations of timed operations")
                  .buckets(LatencyBuckets)
                  .asTimer
@@ -131,7 +125,6 @@ object Sandbox extends IOApp.Simple {
       outcomeRecorder <-
         factory
           .counter("operation_total")
-          .ofDouble
           .help("Counter-backed OutcomeRecorder (.asOutcomeRecorder) — counts succeeded/errored/canceled outcomes")
           .asOutcomeRecorder
           .build
@@ -142,7 +135,6 @@ object Sandbox extends IOApp.Simple {
       _ <-
         factory
           .gauge("process_uptime_seconds")
-          .ofDouble
           .help("Process uptime in seconds (pull-mode gauge callback example)")
           .callback(IO.delay(ManagementFactory.getRuntimeMXBean.getUptime / 1000.0))
           .build

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -39,13 +39,12 @@ val counterResource =
     registry <- JavaMetricRegistry.Builder[IO]().build
     factory = MetricFactory.builder.build(registry)
     counter <- factory.counter("my_counter_total")
-                 .ofLong
                  .help("My Counter")
                  .label[String]("some_label")
                  .build
   } yield counter
 
-counterResource.use { counter => counter.inc("Some label value") }
+counterResource.use { counter => counter.inc(1.0, "Some label value") }
 ```
 
 [Prometheus]: https://prometheus.io

--- a/website/docs/interface/dsl.md
+++ b/website/docs/interface/dsl.md
@@ -58,10 +58,8 @@ factory.info("info_info")
 
 ## Specifying the Underlying Number Format
 
-```scala mdoc:silent
-factory.counter("counter_total").ofDouble
-factory.counter("counter_total").ofLong
-```
+All metric values are `Double` by default — the underlying Prometheus wire format stores everything as `double`, so a
+separate `Long` path was duplication. `Long`-valued sources should `.contramap[Long](_.toDouble)` on the resulting DSL.
 
 ## Defining the Help String
 
@@ -148,9 +146,8 @@ unsafeLabelledCounter.build.evalMap(_.inc(3.0, labels))
 ```scala mdoc:silent
 val intCounter: Resource[IO, Counter[IO, Int, Unit]] = factory
   .counter("counter_total")
-  .ofLong
   .help("Describe what this metric does")
-  .contramap[Int](_.toLong)
+  .contramap[Int](_.toDouble)
   .build
 ```
 
@@ -164,11 +161,10 @@ val shortCounter: Resource[IO, Counter[IO, Short, Unit]] =
 ```scala mdoc:silent
 val intLabelledCounter: Resource[IO, Counter[IO, Int, (String, Int)]] = factory
   .counter("counter_total")
-  .ofLong
   .help("Describe what this metric does")
   .label[String]("string_label")
   .label[Int]("int_label")
-  .contramap[Int](_.toLong)
+  .contramap[Int](_.toDouble)
   .build
 ```
 
@@ -185,9 +181,8 @@ This can work as a nice alternative to
 ```scala mdoc:silent
 case class LabelsClass(string: String, int: Int)
 
-val updatedLabelsCounter: Resource[IO, Counter[IO, Long, LabelsClass]] = factory
+val updatedLabelsCounter: Resource[IO, Counter[IO, Double, LabelsClass]] = factory
   .counter("counter_total")
-  .ofLong
   .help("Describe what this metric does")
   .label[String]("string_label")
   .label[Int]("int_label")

--- a/website/docs/interface/dsl.md
+++ b/website/docs/interface/dsl.md
@@ -66,7 +66,7 @@ factory.counter("counter_total").ofLong
 ## Defining the Help String
 
 ```scala mdoc:silent
-factory.counter("counter_total").ofDouble.help("Describe what this metric does")
+factory.counter("counter_total").help("Describe what this metric does")
 ```
 
 ## Building a Simple Metric
@@ -77,7 +77,7 @@ This will return a `cats.effect.Resource` of your desired metric, which will de-
 ```scala mdoc:silent
 val simpleCounter = factory
   .counter("counter_total")
-  .ofDouble
+  
   .help("Describe what this metric does")
 
 simpleCounter.build
@@ -99,7 +99,7 @@ case class MyClass(value: String)
 
 val tupleLabelledCounter = factory
   .counter("counter_total")
-  .ofDouble
+  
   .help("Describe what this metric does")
   .label[String]("this_uses_show")
   .label[MyClass]("this_doesnt_use_show", _.value)
@@ -114,7 +114,7 @@ case class MyMultiClass(value1: String, value2: Int)
 
 val classLabelledCounter = factory
   .counter("counter_total")
-  .ofDouble
+  
   .help("Describe what this metric does")
   .labels[MyMultiClass](
     Label.Name("label1") -> (_.value1),
@@ -129,7 +129,7 @@ classLabelledCounter.build.evalMap(_.inc(2.0, MyMultiClass("label_value", 42)))
 ```scala mdoc:silent
 val unsafeLabelledCounter = factory
   .counter("counter_total")
-  .ofDouble
+  
   .help("Describe what this metric does")
   .unsafeLabels(Label.Name("label1"), Label.Name("label2"))
 
@@ -217,13 +217,13 @@ All [primitive] metric types, with exception to `Info` can be implemented as cal
 ```scala mdoc:silent
 factory
   .counter("counter_total")
-  .ofDouble
+  
   .help("Describe what this metric does")
   .callback(IO(1.0))
 
 factory
   .gauge("gauge")
-  .ofDouble
+  
   .help("Describe what this metric does")
   .callback(IO(1.0))
 ```
@@ -236,7 +236,7 @@ import cats.data.NonEmptySeq
 
 factory
   .histogram("histogram")
-  .ofDouble
+  
   .help("Describe what this metric does")
   .buckets(0.1, 0.5)
   .callback(
@@ -251,7 +251,7 @@ factory
 ```scala mdoc:silent
 factory
   .summary("summary")
-  .ofDouble
+  
   .help("Describe what this metric does")
   .callback(
     IO(Summary.Value(count = 1L, sum = 1.0, quantiles = Map(0.5 -> 1.0)))

--- a/website/docs/interface/exemplar.md
+++ b/website/docs/interface/exemplar.md
@@ -33,7 +33,7 @@ val factory: MetricFactory[IO] = MetricFactory.noop[IO]
 
 val counterResource = factory
   .counter("requests_total")
-  .ofDouble
+  
   .help("Counter that attaches an exemplar to every inc")
   .build
 ```

--- a/website/docs/metrics/derived-metric-types.md
+++ b/website/docs/metrics/derived-metric-types.md
@@ -143,9 +143,8 @@ To help disambiguate the difference in behaviour the `OutcomeRecorder` type will
 ### Obtaining from a `Counter`
 
 ```scala mdoc:silent
-val simpleOutcomeCounter: Resource[IO, OutcomeRecorder.Aux[IO, Long, Unit, Counter]] = factory
+val simpleOutcomeCounter: Resource[IO, OutcomeRecorder.Aux[IO, Double, Unit, Counter]] = factory
   .counter("outcome_total")
-  .ofLong
   .help("Records the outcome of some operation")
   .asOutcomeRecorder
   .build
@@ -153,9 +152,8 @@ val simpleOutcomeCounter: Resource[IO, OutcomeRecorder.Aux[IO, Long, Unit, Count
 
 ```scala mdoc:silent
 val labelledOutcomeCounter:
-  Resource[IO, OutcomeRecorder.Aux[IO, Long, String, Counter]] = factory
+  Resource[IO, OutcomeRecorder.Aux[IO, Double, String, Counter]] = factory
     .counter("outcome_total")
-    .ofLong
     .help("Records the outcome of some operation")
     .label[String]("some_label")
     .asOutcomeRecorder
@@ -165,9 +163,8 @@ val labelledOutcomeCounter:
 ### Obtaining from a `Gauge`
 
 ```scala mdoc:silent
-val simpleOutcomeGauge: Resource[IO, OutcomeRecorder.Aux[IO, Long, Unit, Gauge]] = factory
+val simpleOutcomeGauge: Resource[IO, OutcomeRecorder.Aux[IO, Double, Unit, Gauge]] = factory
   .gauge("outcome")
-  .ofLong
   .help("Records the outcome of some operation")
   .asOutcomeRecorder
   .build
@@ -175,9 +172,8 @@ val simpleOutcomeGauge: Resource[IO, OutcomeRecorder.Aux[IO, Long, Unit, Gauge]]
 
 ```scala mdoc:silent
 val labelledOutcomeGauge:
-  Resource[IO, OutcomeRecorder.Aux[IO, Long, String, Gauge]] = factory
+  Resource[IO, OutcomeRecorder.Aux[IO, Double, String, Gauge]] = factory
     .gauge("outcome")
-    .ofLong
     .help("Records the outcome of some operation")
     .label[String]("some_label")
     .asOutcomeRecorder

--- a/website/docs/metrics/derived-metric-types.md
+++ b/website/docs/metrics/derived-metric-types.md
@@ -35,7 +35,7 @@ operations.
 ```scala mdoc:silent
 val simpleTimerHistogram: Resource[IO, Timer.Aux[IO, Unit, Histogram]] = factory
   .histogram("time")
-  .ofDouble
+  
   .help("Records how long an operation took")
   .buckets(1.0, 2.0)
   .asTimer
@@ -45,7 +45,7 @@ val simpleTimerHistogram: Resource[IO, Timer.Aux[IO, Unit, Histogram]] = factory
 ```scala mdoc:silent
 val labelledTimerHistogram: Resource[IO, Timer.Aux[IO, String, Histogram]] = factory
   .histogram("time")
-  .ofDouble
+  
   .help("Records how long an operation took")
   .buckets(1.0, 2.0)
   .label[String]("some_label")
@@ -58,7 +58,7 @@ val labelledTimerHistogram: Resource[IO, Timer.Aux[IO, String, Histogram]] = fac
 ```scala mdoc:silent
 val simpleTimerSummary: Resource[IO, Timer.Aux[IO, Unit, Summary]] = factory
   .summary("time")
-  .ofDouble
+  
   .help("Records how long an operation took")
   .asTimer
   .build
@@ -67,7 +67,7 @@ val simpleTimerSummary: Resource[IO, Timer.Aux[IO, Unit, Summary]] = factory
 ```scala mdoc:silent
 val labelledTimerSummary: Resource[IO, Timer.Aux[IO, String, Summary]] = factory
   .summary("time")
-  .ofDouble
+  
   .help("Records how long an operation took")
   .label[String]("some_label")
   .asTimer
@@ -79,7 +79,7 @@ val labelledTimerSummary: Resource[IO, Timer.Aux[IO, String, Summary]] = factory
 ```scala mdoc:silent
 val simpleTimerGauge: Resource[IO, Timer.Aux[IO, Unit, Gauge]] = factory
   .gauge("time")
-  .ofDouble
+  
   .help("Records how long an operation took")
   .asTimer
   .build
@@ -88,7 +88,7 @@ val simpleTimerGauge: Resource[IO, Timer.Aux[IO, Unit, Gauge]] = factory
 ```scala mdoc:silent
 val labelledTimerGauge: Resource[IO, Timer.Aux[IO, String, Gauge]] = factory
   .gauge("time")
-  .ofDouble
+  
   .help("Records how long an operation took")
   .label[String]("some_label")
   .asTimer
@@ -105,7 +105,7 @@ system time.
 ```scala mdoc:silent
 val simpleCurrentTimeRecorderGauge: Resource[IO, CurrentTimeRecorder[IO, Unit]] = factory
   .gauge("current_time")
-  .ofDouble
+  
   .help("Records how long an operation took")
   .asCurrentTimeRecorder
   .build
@@ -116,7 +116,7 @@ val labelledCurrentTimeRecorderGauge:
   Resource[IO, CurrentTimeRecorder[IO, String]] =
     factory
       .gauge("current_time")
-      .ofDouble
+      
       .help("Records how long an operation took")
       .label[String]("some_label")
       .asCurrentTimeRecorder

--- a/website/docs/metrics/primitive-metric-types.md
+++ b/website/docs/metrics/primitive-metric-types.md
@@ -47,7 +47,7 @@ See the example below on how to obtain a `Histogram` from a [`MetricFactory`]:
 ```scala mdoc:silent
 val histogram = factory
   .histogram("my_histogram")
-  .ofDouble
+  
   .help("Metric description")
 ```
 
@@ -105,7 +105,7 @@ See the example below on how to obtain a native histogram from a [`MetricFactory
 ```scala mdoc:silent
 val nativeHistogram = factory
   .nativeHistogram("my_native_histogram")
-  .ofDouble
+  
   .help("Metric description")
 ```
 
@@ -120,7 +120,7 @@ Prometheus Java client and is appropriate for most workloads.
 ```scala mdoc:silent
 val tunedNativeHistogram = factory
   .nativeHistogram("my_tuned_histogram", NativeHistogram.Default.withInitialSchema(3))
-  .ofDouble
+  
   .help("Metric description")
 ```
 
@@ -136,7 +136,7 @@ See the example below on how to obtain a `Summary` from a [`MetricFactory`]:
 ```scala mdoc:silent
 val summary = factory
   .summary("my_summary")
-  .ofDouble
+  
   .help("Metric description")
 ```
 
@@ -151,7 +151,7 @@ In addition to count and sum, you can configure a `Summary` to provide quantiles
 ```scala mdoc:silent
 val quantileSummary = factory
   .summary("my_summary")
-  .ofDouble
+  
   .help("Metric description")
   .quantile(0.5, 0.01)    // 0.5 quantile (median) with 0.01 allowed error
   .quantile(0.95, 0.005)  // 0.95 quantile with 0.005 allowed error
@@ -187,7 +187,7 @@ import scala.concurrent.duration._
 
 val ageSummary = factory
   .summary("my_summary")
-  .ofDouble
+  
   .help("Metric description")
   .maxAge(10.seconds)
   .ageBuckets(5)

--- a/website/docs/metrics/primitive-metric-types.md
+++ b/website/docs/metrics/primitive-metric-types.md
@@ -23,7 +23,7 @@ This implements an [OpenMetrics] counter, allowing a number to be incremented by
 See the example below on how to obtain a `Counter` from a [`MetricFactory`]:
 
 ```scala mdoc:silent
-factory.counter("my_counter_total").ofLong.help("Metric description")
+factory.counter("my_counter_total").help("Metric description")
 ```
 
 
@@ -35,7 +35,7 @@ value, as well as reset to `0`.
 See the example below on how to obtain a `Gauge` from a [`MetricFactory`]:
 
 ```scala mdoc:silent
-factory.gauge("my_gauge").ofLong.help("Metric description")
+factory.gauge("my_gauge").help("Metric description")
 ```
 
 ## `Histogram`

--- a/website/docs/migrating-from-v5.md
+++ b/website/docs/migrating-from-v5.md
@@ -49,7 +49,7 @@ import prometheus4cats.MetricFactory
 def withNativeHistogram(factory: MetricFactory[IO]) =
   factory
     .nativeHistogram("request_latency_seconds")
-    .ofDouble
+    
     .help("Request latency, native bucket distribution")
     .build
 ```
@@ -70,7 +70,7 @@ import cats.data.NonEmptySeq
 def withDualHistogram(factory: MetricFactory[IO]) =
   factory
     .histogram("request_latency_seconds")
-    .ofDouble
+    
     .help("Request latency, both classic and native representations")
     .buckets(NonEmptySeq.of(0.005, 0.01, 0.05, 0.1, 0.5, 1.0, 5.0))
     .withNative


### PR DESCRIPTION
## Summary

- Adds an implicit `TypeStep[D] => D[Double]` conversion so `factory.counter(name).help(...)` chains directly off the factory without an `.ofDouble` step.
- `@deprecated` annotations on both `.ofLong` and `.ofDouble` (kept for v5 source compat — both still compile, with a warning).
- Long-valued sources should `.contramap[Long](_.toDouble)` on the resulting Double DSL. Prometheus stores all values as `double` internally so the parallel Long path was duplication.
- Docs, sandbox, testkit DSL suite, and README updated to the new path.

First half of #145 (closed); the callback-drop half is stacked in the follow-up PR.

## Test plan

- [x] \`sbt +compile\` (2.13 + 3.3)
- [x] \`sbt +test\` — all 110+ tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)