### PR TITLE
series/6.x - deprecate .ofLong and .ofDouble - higher kinds fix

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -55,4 +55,10 @@ lazy val `prometheus4cats-java` = module
 lazy val sandbox = module
   .settings(libraryDependencies ++= Dependencies.sandbox)
   .settings(publish / skip := true)
+  // Regression guard for the v6 DSL: factory methods (`counter`, `gauge`, `histogram`, `summary`)
+  // must compile without the `higherKinds` language feature enabled at the consumer. Removing
+  // this flag here exercises the same scalac setup downstream services have (tpolecat defaults
+  // don't include `-language:higherKinds`). If a future change re-introduces a higher-kinded
+  // implicit on the factory return types, the sandbox compile will catch it.
+  .settings(Compile / scalacOptions -= "-language:higherKinds")
   .dependsOn(prometheus4cats, `prometheus4cats-java`)

--- a/modules/prometheus4cats/src/main/scala/prometheus4cats/MetricFactory.scala
+++ b/modules/prometheus4cats/src/main/scala/prometheus4cats/MetricFactory.scala
@@ -67,8 +67,6 @@ sealed abstract class MetricFactory[F[_]](
       commonLabels
     ) {}
 
-  type GaugeDsl[MDsl[_[_], _, _[_[_], _, _]], A] = HelpStep[MDsl[F, A, Gauge]]
-
   /** Starts creating a "gauge" metric.
     *
     * @example
@@ -79,8 +77,8 @@ sealed abstract class MetricFactory[F[_]](
     * @return
     *   Gauge builder
     */
-  def gauge(name: Gauge.Name): TypeStep[GaugeDsl[MetricDsl, *]] =
-    new TypeStep[GaugeDsl[MetricDsl, *]](
+  def gauge(name: Gauge.Name): GaugeFactoryStep[F] =
+    new GaugeFactoryStep[F](
       new HelpStep(help =>
         new MetricDsl(
           new LabelledMetricPartiallyApplied[F, Long, Gauge] {
@@ -107,8 +105,6 @@ sealed abstract class MetricFactory[F[_]](
       )
     )
 
-  type CounterDsl[MDsl[_[_], _, _[_[_], _, _]], A] = HelpStep[MDsl[F, A, Counter]]
-
   /** Starts creating a "counter" metric.
     *
     * @example
@@ -119,8 +115,8 @@ sealed abstract class MetricFactory[F[_]](
     * @return
     *   Counter builder
     */
-  def counter(name: Counter.Name): TypeStep[CounterDsl[MetricDsl, *]] =
-    new TypeStep[CounterDsl[MetricDsl, *]](
+  def counter(name: Counter.Name): CounterFactoryStep[F] =
+    new CounterFactoryStep[F](
       new HelpStep(help =>
         new MetricDsl(
           new LabelledMetricPartiallyApplied[F, Long, Counter] {
@@ -146,14 +142,6 @@ sealed abstract class MetricFactory[F[_]](
         )
       )
     )
-
-  type HistogramDsl[MDsl[_[_], _, _[_[_], _, _]], A] = HelpStep[BucketDsl[MDsl[F, A, Histogram], A]]
-
-  /** Type alias for the histogram DSL chain returned by [[histogram]]. After `.buckets(...)` the chain produces a value
-    * extending both `MetricDsl[F, A, Histogram]` and the `HistogramMetricDsl` mixin (which adds `.withNative` for
-    * dual-mode promotion).
-    */
-  type HistogramWithNativeDsl[A] = HelpStep[BucketDsl[HistogramMetricDsl[F, A], A]]
 
   /** Starts creating a "histogram" metric.
     *
@@ -183,8 +171,8 @@ sealed abstract class MetricFactory[F[_]](
     * @return
     *   Histogram builder
     */
-  def histogram(name: Histogram.Name): TypeStep[HistogramWithNativeDsl] =
-    new TypeStep[HistogramWithNativeDsl](
+  def histogram(name: Histogram.Name): HistogramFactoryStep[F] =
+    new HistogramFactoryStep[F](
       new HelpStep(help =>
         new BucketDsl[HistogramMetricDsl[F, Long], Long](buckets =>
           new HistogramMetricDsl.Plain[F, Long](
@@ -240,8 +228,6 @@ sealed abstract class MetricFactory[F[_]](
       )
     )
 
-  type NativeHistogramWithNativeDsl[A] = HelpStep[MetricDsl[F, A, Histogram]]
-
   /** Starts creating a "native histogram" metric.
     *
     * Native histograms (sometimes called sparse or exponential histograms) automatically allocate buckets sized by an
@@ -279,38 +265,37 @@ sealed abstract class MetricFactory[F[_]](
   def nativeHistogram(
       name: Histogram.Name,
       config: NativeHistogram = NativeHistogram.Default
-  ) = new TypeStep[NativeHistogramWithNativeDsl](
-    new HelpStep(help =>
-      new MetricDsl(
-        new LabelledMetricPartiallyApplied[F, Long, Histogram] {
+  ): NativeHistogramFactoryStep[F] =
+    new NativeHistogramFactoryStep[F](
+      new HelpStep(help =>
+        new MetricDsl(
+          new LabelledMetricPartiallyApplied[F, Long, Histogram] {
 
-          override def apply[B](
-              labels: IndexedSeq[Label.Name]
-          )(f: B => IndexedSeq[String]): Resource[F, Histogram[F, Long, B]] =
-            metricRegistry.createAndRegisterLongNativeHistogram(
-              prefix, name, help, commonLabels, labels, config
-            )(f)
+            override def apply[B](
+                labels: IndexedSeq[Label.Name]
+            )(f: B => IndexedSeq[String]): Resource[F, Histogram[F, Long, B]] =
+              metricRegistry.createAndRegisterLongNativeHistogram(
+                prefix, name, help, commonLabels, labels, config
+              )(f)
 
-        }
-      )
-    ),
-    new HelpStep(help =>
-      new MetricDsl(
-        new LabelledMetricPartiallyApplied[F, Double, Histogram] {
+          }
+        )
+      ),
+      new HelpStep(help =>
+        new MetricDsl(
+          new LabelledMetricPartiallyApplied[F, Double, Histogram] {
 
-          override def apply[B](
-              labels: IndexedSeq[Label.Name]
-          )(f: B => IndexedSeq[String]): Resource[F, Histogram[F, Double, B]] =
-            metricRegistry.createAndRegisterDoubleNativeHistogram(
-              prefix, name, help, commonLabels, labels, config
-            )(f)
+            override def apply[B](
+                labels: IndexedSeq[Label.Name]
+            )(f: B => IndexedSeq[String]): Resource[F, Histogram[F, Double, B]] =
+              metricRegistry.createAndRegisterDoubleNativeHistogram(
+                prefix, name, help, commonLabels, labels, config
+              )(f)
 
-        }
+          }
+        )
       )
     )
-  )
-
-  type SummaryDslLambda[A] = HelpStep[SummaryDsl.Base[F, A]]
 
   /** Starts creating a "summary" metric.
     *
@@ -328,8 +313,8 @@ sealed abstract class MetricFactory[F[_]](
     * @return
     *   Summary builder
     */
-  def summary(name: Summary.Name): TypeStep[SummaryDslLambda] =
-    new TypeStep[SummaryDslLambda](
+  def summary(name: Summary.Name): SummaryFactoryStep[F] =
+    new SummaryFactoryStep[F](
       new HelpStep(help =>
         new SummaryDsl[F, Long](
           makeSummary = (quantiles, maxAge, ageBuckets) =>

--- a/modules/prometheus4cats/src/main/scala/prometheus4cats/internal/package.scala
+++ b/modules/prometheus4cats/src/main/scala/prometheus4cats/internal/package.scala
@@ -27,10 +27,10 @@ import cats.effect.kernel.Resource
 import cats.syntax.all._
 
 import prometheus4cats.OutcomeRecorder.Status
-import prometheus4cats.internal.histogram.BucketDsl
-import prometheus4cats.internal.summary.SummaryDsl
 import prometheus4cats._
 import prometheus4cats.internal.InitLast.Aux
+import prometheus4cats.internal.histogram.BucketDsl
+import prometheus4cats.internal.summary.SummaryDsl
 
 trait BuildStep[F[_], A] { self =>
 

--- a/modules/prometheus4cats/src/main/scala/prometheus4cats/internal/package.scala
+++ b/modules/prometheus4cats/src/main/scala/prometheus4cats/internal/package.scala
@@ -498,9 +498,9 @@ class HelpStep[+A] private[prometheus4cats] (f: Metric.Help => A) {
 
 /** Per-metric-kind replacement for the v6 `TypeStep[D[_]]` shim. Each factory method (`counter`, `gauge`, `histogram`,
   * `summary`) returns a concrete subclass of [[HelpStep]] specialised to the `Double`-valued DSL, so `.help(...)`
-  * chains directly without an `.ofDouble` step. The deprecated `.ofLong` / `.ofDouble` accessors are preserved on
-  * the concrete factory steps below for one release as plain methods — no higher-kinded implicit conversion is
-  * needed, so consumer call sites compile without `-language:higherKinds`.
+  * chains directly without an `.ofDouble` step. The deprecated `.ofLong` / `.ofDouble` accessors are preserved on the
+  * concrete factory steps below for one release as plain methods — no higher-kinded implicit conversion is needed, so
+  * consumer call sites compile without `-language:higherKinds`.
   */
 class CounterFactoryStep[F[_]] private[prometheus4cats] (
     longDsl: HelpStep[MetricDsl[F, Long, Counter]],
@@ -541,11 +541,10 @@ class HistogramFactoryStep[F[_]] private[prometheus4cats] (
 
 }
 
-/** Native histograms are `Double`-only in spirit — buckets are real-valued regardless of input
-  * type — but the deprecated `.ofLong` / `.ofDouble` accessors are preserved here for one release
-  * to keep source-compat with v5-style call sites. Callers should drop the `.ofDouble` step (the
-  * default `.help` path resolves to the same `Double` DSL) and replace `.ofLong` with
-  * `.help(...).contramap[Long](_.toDouble)`.
+/** Native histograms are `Double`-only in spirit — buckets are real-valued regardless of input type — but the
+  * deprecated `.ofLong` / `.ofDouble` accessors are preserved here for one release to keep source-compat with v5-style
+  * call sites. Callers should drop the `.ofDouble` step (the default `.help` path resolves to the same `Double` DSL)
+  * and replace `.ofLong` with `.help(...).contramap[Long](_.toDouble)`.
   */
 class NativeHistogramFactoryStep[F[_]] private[prometheus4cats] (
     longDsl: HelpStep[MetricDsl[F, Long, Histogram]],

--- a/modules/prometheus4cats/src/main/scala/prometheus4cats/internal/package.scala
+++ b/modules/prometheus4cats/src/main/scala/prometheus4cats/internal/package.scala
@@ -27,6 +27,8 @@ import cats.effect.kernel.Resource
 import cats.syntax.all._
 
 import prometheus4cats.OutcomeRecorder.Status
+import prometheus4cats.internal.histogram.BucketDsl
+import prometheus4cats.internal.summary.SummaryDsl
 import prometheus4cats._
 import prometheus4cats.internal.InitLast.Aux
 
@@ -494,30 +496,80 @@ class HelpStep[+A] private[prometheus4cats] (f: Metric.Help => A) {
 
 }
 
-class TypeStep[+D[_]] private[prometheus4cats] (long: D[Long], private[prometheus4cats] val double: D[Double]) {
+/** Per-metric-kind replacement for the v6 `TypeStep[D[_]]` shim. Each factory method (`counter`, `gauge`, `histogram`,
+  * `summary`) returns a concrete subclass of [[HelpStep]] specialised to the `Double`-valued DSL, so `.help(...)`
+  * chains directly without an `.ofDouble` step. The deprecated `.ofLong` / `.ofDouble` accessors are preserved on
+  * the concrete factory steps below for one release as plain methods — no higher-kinded implicit conversion is
+  * needed, so consumer call sites compile without `-language:higherKinds`.
+  */
+class CounterFactoryStep[F[_]] private[prometheus4cats] (
+    longDsl: HelpStep[MetricDsl[F, Long, Counter]],
+    doubleDsl: HelpStep[MetricDsl[F, Double, Counter]]
+) extends HelpStep[MetricDsl[F, Double, Counter]](h => doubleDsl.help(h)) {
 
-  @deprecated(
-    "use .ofDouble.contramap[Long](_.toDouble) — Double is now the default; an implicit conversion exposes the Double DSL directly on the factory method's return value",
-    "6.0.0"
-  )
-  def ofLong: D[Long] = long
+  @deprecated("Double is now the default — call .help directly", "6.0.0")
+  def ofDouble: HelpStep[MetricDsl[F, Double, Counter]] = doubleDsl
 
-  @deprecated(
-    "Double is now the default — call .help directly (an implicit conversion exposes the Double DSL on the factory method's return value)",
-    "6.0.0"
-  )
-  def ofDouble: D[Double] = double
+  @deprecated("Use .help(...).contramap[Long](_.toDouble) on the resulting DSL", "6.0.0")
+  def ofLong: HelpStep[MetricDsl[F, Long, Counter]] = longDsl
 
 }
 
-object TypeStep {
+class GaugeFactoryStep[F[_]] private[prometheus4cats] (
+    longDsl: HelpStep[MetricDsl[F, Long, Gauge]],
+    doubleDsl: HelpStep[MetricDsl[F, Double, Gauge]]
+) extends HelpStep[MetricDsl[F, Double, Gauge]](h => doubleDsl.help(h)) {
 
-  /** Source-compat shim: makes `factory.counter(name).help(...)` (and similar) compile by transparently selecting the
-    * `Double`-valued DSL. Replaces the old `factory.counter(name).ofDouble.help(...)` two-step. `Long`-valued metrics
-    * are no longer the default; callers wanting `Long` semantics should `.ofDouble.contramap[Long](_.toDouble)`.
-    */
-  @SuppressWarnings(Array("scalafix:DisableSyntax.implicitConversion"))
-  implicit def typeStepIsDouble[D[_]](step: TypeStep[D]): D[Double] = step.double
+  @deprecated("Double is now the default — call .help directly", "6.0.0")
+  def ofDouble: HelpStep[MetricDsl[F, Double, Gauge]] = doubleDsl
+
+  @deprecated("Use .help(...).contramap[Long](_.toDouble) on the resulting DSL", "6.0.0")
+  def ofLong: HelpStep[MetricDsl[F, Long, Gauge]] = longDsl
+
+}
+
+class HistogramFactoryStep[F[_]] private[prometheus4cats] (
+    longDsl: HelpStep[BucketDsl[HistogramMetricDsl[F, Long], Long]],
+    doubleDsl: HelpStep[BucketDsl[HistogramMetricDsl[F, Double], Double]]
+) extends HelpStep[BucketDsl[HistogramMetricDsl[F, Double], Double]](h => doubleDsl.help(h)) {
+
+  @deprecated("Double is now the default — call .help directly", "6.0.0")
+  def ofDouble: HelpStep[BucketDsl[HistogramMetricDsl[F, Double], Double]] = doubleDsl
+
+  @deprecated("Use .help(...).buckets(...).contramap[Long](_.toDouble) on the resulting DSL", "6.0.0")
+  def ofLong: HelpStep[BucketDsl[HistogramMetricDsl[F, Long], Long]] = longDsl
+
+}
+
+/** Native histograms are `Double`-only in spirit — buckets are real-valued regardless of input
+  * type — but the deprecated `.ofLong` / `.ofDouble` accessors are preserved here for one release
+  * to keep source-compat with v5-style call sites. Callers should drop the `.ofDouble` step (the
+  * default `.help` path resolves to the same `Double` DSL) and replace `.ofLong` with
+  * `.help(...).contramap[Long](_.toDouble)`.
+  */
+class NativeHistogramFactoryStep[F[_]] private[prometheus4cats] (
+    longDsl: HelpStep[MetricDsl[F, Long, Histogram]],
+    doubleDsl: HelpStep[MetricDsl[F, Double, Histogram]]
+) extends HelpStep[MetricDsl[F, Double, Histogram]](h => doubleDsl.help(h)) {
+
+  @deprecated("Double is now the default — call .help directly", "6.0.0")
+  def ofDouble: HelpStep[MetricDsl[F, Double, Histogram]] = doubleDsl
+
+  @deprecated("Use .help(...).contramap[Long](_.toDouble) on the resulting DSL", "6.0.0")
+  def ofLong: HelpStep[MetricDsl[F, Long, Histogram]] = longDsl
+
+}
+
+class SummaryFactoryStep[F[_]] private[prometheus4cats] (
+    longDsl: HelpStep[SummaryDsl.Base[F, Long]],
+    doubleDsl: HelpStep[SummaryDsl.Base[F, Double]]
+) extends HelpStep[SummaryDsl.Base[F, Double]](h => doubleDsl.help(h)) {
+
+  @deprecated("Double is now the default — call .help directly", "6.0.0")
+  def ofDouble: HelpStep[SummaryDsl.Base[F, Double]] = doubleDsl
+
+  @deprecated("Use .help(...).contramap[Long](_.toDouble) on the resulting DSL", "6.0.0")
+  def ofLong: HelpStep[SummaryDsl.Base[F, Long]] = longDsl
 
 }
 


### PR DESCRIPTION
This PR:

1. Drops implicit conversion introduce to bridge the `TypeStep` 
2. Adapts metric DSL to accomodate that directly

The implicit conversion required higher kinds ty parameter. The previous version did not require that. Requiring downstream consumers to adjust their compiler settings is a big breaking change.
