### PR TITLE
Memoize data-point resolution per label value

### DIFF
--- a/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
+++ b/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
@@ -38,6 +38,7 @@ import io.prometheus.metrics.instrumentation.jvm.JvmMetrics
 import io.prometheus.metrics.model.registry.PrometheusRegistry
 import io.prometheus.metrics.model.snapshots.Labels
 import prometheus4cats._
+import prometheus4cats.javaclient.internal.DataPointResolver
 import prometheus4cats.javaclient.internal.Utils
 import prometheus4cats.javaclient.models.MetricType
 import prometheus4cats.util.DoubleMetricRegistry
@@ -172,6 +173,11 @@ class JavaMetricRegistry[F[_]: Async] private (
       renderedName = fullName,
       labels = allLabelNames
     ).map { case (counter, exemplarRef) =>
+      val resolver = new DataPointResolver[A, CounterDataPoint](
+        f,
+        commonLabelValuesArray,
+        (lbls: Array[String]) => counter.labelValues(lbls: _*)
+      )
       Counter.make(
         Counter.ExemplarState.fromRef(exemplarRef),
         1.0,
@@ -180,12 +186,11 @@ class JavaMetricRegistry[F[_]: Async] private (
             labels: A,
             exemplar: Option[Exemplar.Labels]
         ) =>
-          Utils.modifyMetric[F, Counter.Name, CounterDataPoint](
+          Utils.modifyMetric[F, A, Counter.Name, CounterDataPoint](
             metricName = name,
             allLabelNames = allLabelNames,
-            dynamicLabels = f(labels),
-            commonLabelValues = commonLabelValuesArray,
-            getDataPoint = (lbls: Array[String]) => counter.labelValues(lbls: _*),
+            labels = labels,
+            resolver = resolver,
             modify = (dp: CounterDataPoint) =>
               exemplar.fold(dp.inc(d))(e => dp.incWithExemplar(d, transformExemplarLabels(e))),
             logger = logger
@@ -220,15 +225,15 @@ class JavaMetricRegistry[F[_]: Async] private (
       renderedName = fullName,
       labels = allLabelNames
     ).map { case (gauge, _) =>
+      val resolver = new DataPointResolver[A, GaugeDataPoint](
+        f,
+        commonLabelValuesArray,
+        (lbls: Array[String]) => gauge.labelValues(lbls: _*)
+      )
       @inline
       def modify(g: GaugeDataPoint => Unit, labels: A): F[Unit] =
-        Utils.modifyMetric[F, Gauge.Name, GaugeDataPoint](
-          metricName = name,
-          allLabelNames = allLabelNames,
-          dynamicLabels = f(labels),
-          commonLabelValues = commonLabelValuesArray,
-          getDataPoint = (lbls: Array[String]) => gauge.labelValues(lbls: _*),
-          modify = g,
+        Utils.modifyMetric[F, A, Gauge.Name, GaugeDataPoint](
+          metricName = name, allLabelNames = allLabelNames, labels = labels, resolver = resolver, modify = g,
           logger = logger
         )
 
@@ -276,15 +281,19 @@ class JavaMetricRegistry[F[_]: Async] private (
       renderedName = fullName,
       labels = allLabelNames
     ).map { case (histogram, exemplarRef) =>
+      val resolver = new DataPointResolver[A, DistributionDataPoint](
+        f,
+        commonLabelValuesArray,
+        (lbls: Array[String]) => histogram.labelValues(lbls: _*)
+      )
       Histogram.make[F, Double, A](
         exemplarState(exemplarRef),
         _observe = { (d: Double, labels: A, exemplar: Option[Exemplar.Labels]) =>
-          Utils.modifyMetric[F, Histogram.Name, DistributionDataPoint](
+          Utils.modifyMetric[F, A, Histogram.Name, DistributionDataPoint](
             metricName = name,
             allLabelNames = allLabelNames,
-            dynamicLabels = f(labels),
-            commonLabelValues = commonLabelValuesArray,
-            getDataPoint = (lbls: Array[String]) => histogram.labelValues(lbls: _*),
+            labels = labels,
+            resolver = resolver,
             modify = (dp: DistributionDataPoint) =>
               exemplar.fold(dp.observe(d))(e => dp.observeWithExemplar(d, transformExemplarLabels(e))),
             logger = logger
@@ -419,13 +428,17 @@ class JavaMetricRegistry[F[_]: Async] private (
       renderedName = fullName,
       labels = allLabelNames
     ).map { case (summary, _) =>
+      val resolver = new DataPointResolver[A, DistributionDataPoint](
+        f,
+        commonLabelValuesArray,
+        (lbls: Array[String]) => summary.labelValues(lbls: _*)
+      )
       Summary.make[F, Double, A] { case (d, labels) =>
-        Utils.modifyMetric[F, Summary.Name, DistributionDataPoint](
+        Utils.modifyMetric[F, A, Summary.Name, DistributionDataPoint](
           metricName = name,
           allLabelNames = allLabelNames,
-          dynamicLabels = f(labels),
-          commonLabelValues = commonLabelValuesArray,
-          getDataPoint = (lbls: Array[String]) => summary.labelValues(lbls: _*),
+          labels = labels,
+          resolver = resolver,
           modify = (dp: DistributionDataPoint) => dp.observe(d),
           logger = logger
         )

--- a/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/internal/Utils.scala
+++ b/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/internal/Utils.scala
@@ -59,11 +59,16 @@ final private[javaclient] class DataPointResolver[A, D](
   /** Renders the full label-value array for `labels`. Only needed on resolution misses and error paths. */
   def labelArray(labels: A): Array[String] = Utils.buildLabelArray(f(labels), commonLabelValues)
 
-  // computeIfAbsent fast-paths present keys without locking on modern JDKs, so the hot path
-  // (label value already resolved) is a single lock-free map read.
-  def apply(labels: A): D =
-    if (cache.size < maxCachedLabelSets || cache.containsKey(labels)) cache.computeIfAbsent(labels, compute)
-    else compute(labels)
+  // Plain get-then-compute rather than bare computeIfAbsent: computeIfAbsent only skips
+  // locking when the key is the first node of its hash bin, so under collision chains it
+  // synchronizes on every call. A get hit is always a lock-free read; the racy get/compute
+  // window is benign because computeIfAbsent deduplicates the insert.
+  def apply(labels: A): D = {
+    val cached = cache.get(labels)
+    if (cached != null) cached // scalafix:ok
+    else if (cache.size >= maxCachedLabelSets) compute(labels)
+    else cache.computeIfAbsent(labels, compute)
+  }
 
 }
 

--- a/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/internal/Utils.scala
+++ b/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/internal/Utils.scala
@@ -16,6 +16,8 @@
 
 package prometheus4cats.javaclient.internal
 
+import java.util.concurrent.ConcurrentHashMap
+
 import cats.effect.kernel.Sync
 import cats.syntax.all._
 
@@ -23,6 +25,53 @@ import io.prometheus.metrics.core.metrics.MetricWithFixedMetadata
 import io.prometheus.metrics.model.registry.PrometheusRegistry
 import prometheus4cats.Label
 import prometheus4cats.javaclient.models.Exceptions._
+
+/** Memoizes the resolution from a typed label value `A` to the upstream
+  * [[io.prometheus.metrics.core.datapoints.DataPoint]] it addresses.
+  *
+  * Resolving a data point on every metric update is one of the dominant costs of recording a labelled metric: the typed
+  * labels are rendered to strings, copied into an array, and the upstream client then allocates a sorted `Labels`
+  * object and hashes it to find the data point. None of those steps' inputs change between updates with the same label
+  * value, and data points are never removed while a collector is registered, so the resolved data point is cached keyed
+  * by `A`. Subsequent updates reduce to one map hit plus the underlying adder/observation.
+  *
+  * Failed resolutions are not cached: `computeIfAbsent` stores nothing when the mapping function throws.
+  *
+  * The cache stops accepting new entries once [[DataPointResolver.MaxCachedLabelSets]] distinct label values have been
+  * seen and resolves directly instead; label sets with cardinality beyond the cap are pathological for Prometheus
+  * itself, and the cap also bounds memory should an `A` without value-based equality slip through.
+  */
+final private[javaclient] class DataPointResolver[A, D](
+    f: A => IndexedSeq[String],
+    commonLabelValues: Array[String],
+    getDataPoint: Array[String] => D,
+    maxCachedLabelSets: Int = DataPointResolver.MaxCachedLabelSets
+) {
+
+  private[this] val cache = new ConcurrentHashMap[A, D]()
+
+  private[this] val compute = new java.util.function.Function[A, D] {
+
+    override def apply(labels: A): D = getDataPoint(labelArray(labels))
+
+  }
+
+  /** Renders the full label-value array for `labels`. Only needed on resolution misses and error paths. */
+  def labelArray(labels: A): Array[String] = Utils.buildLabelArray(f(labels), commonLabelValues)
+
+  // computeIfAbsent fast-paths present keys without locking on modern JDKs, so the hot path
+  // (label value already resolved) is a single lock-free map read.
+  def apply(labels: A): D =
+    if (cache.size < maxCachedLabelSets || cache.containsKey(labels)) cache.computeIfAbsent(labels, compute)
+    else compute(labels)
+
+}
+
+private[javaclient] object DataPointResolver {
+
+  private[internal] val MaxCachedLabelSets = 65536
+
+}
 
 private[javaclient] object Utils {
 
@@ -48,24 +97,24 @@ private[javaclient] object Utils {
     arr
   }
 
-  /** Retrieves the [[io.prometheus.metrics.core.datapoints.DataPoint]] for the given label values and applies the
-    * `modify` function to it. Errors raised by either the data-point lookup or the modification are wrapped in a
-    * [[UnhandledPrometheusException]] and forwarded to the logger so they are observable but not propagated.
+  /** Resolves the [[io.prometheus.metrics.core.datapoints.DataPoint]] for the given typed label value (via the
+    * memoizing `resolver`) and applies the `modify` function to it. Errors raised by either the data-point resolution
+    * or the modification are wrapped in a [[UnhandledPrometheusException]] and forwarded to the logger so they are
+    * observable but not propagated. Rendered label values for the error message are only computed on the error path.
     */
-  private[javaclient] def modifyMetric[F[_]: Sync, A, D](
-      metricName: A,
+  private[javaclient] def modifyMetric[F[_]: Sync, A, M, D](
+      metricName: M,
       allLabelNames: IndexedSeq[Label.Name],
-      dynamicLabels: IndexedSeq[String],
-      commonLabelValues: Array[String],
-      getDataPoint: Array[String] => D,
+      labels: A,
+      resolver: DataPointResolver[A, D],
       modify: D => Unit,
       logger: Throwable => String => F[Unit]
   ): F[Unit] = {
-    val labelArray = buildLabelArray(dynamicLabels, commonLabelValues)
     val mod: F[Unit] =
       for {
-        dp <- handleErrors(Sync[F].delay(getDataPoint(labelArray)), metricName, allLabelNames, labelArray)
-        _  <- handleErrors(Sync[F].delay(modify(dp)), metricName, allLabelNames, labelArray)
+        dp <-
+          handleErrors(Sync[F].delay(resolver(labels)), metricName, allLabelNames, () => resolver.labelArray(labels))
+        _ <- handleErrors(Sync[F].delay(modify(dp)), metricName, allLabelNames, () => resolver.labelArray(labels))
       } yield ()
 
     mod.recoverWith { case e: PrometheusException[_] =>
@@ -77,13 +126,13 @@ private[javaclient] object Utils {
       fa: F[B],
       metricName: A,
       labelNames: IndexedSeq[Label.Name],
-      labels: Array[String]
+      labels: () => Array[String]
   ): F[B] =
     fa.handleErrorWith(e =>
       classStringRep(e)
         .flatMap(className =>
           Sync[F].raiseError(
-            UnhandledPrometheusException(className, metricName, labelNames.zip(labels.toIndexedSeq).toMap, e)
+            UnhandledPrometheusException(className, metricName, labelNames.zip(labels().toIndexedSeq).toMap, e)
           )
         )
     )

--- a/modules/prometheus4cats-java/src/test/scala/prometheus4cats/javaclient/internal/DataPointResolverSuite.scala
+++ b/modules/prometheus4cats-java/src/test/scala/prometheus4cats/javaclient/internal/DataPointResolverSuite.scala
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2022-2026 Permutive Ltd. <https://permutive.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package prometheus4cats.javaclient.internal
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import munit.FunSuite
+
+class DataPointResolverSuite extends FunSuite {
+
+  private def resolver(
+      resolutions: AtomicInteger,
+      renders: AtomicInteger,
+      maxCachedLabelSets: Int = DataPointResolver.MaxCachedLabelSets
+  ): DataPointResolver[(String, String), String] =
+    new DataPointResolver[(String, String), String](
+      f = { case (a, b) =>
+        renders.incrementAndGet()
+        IndexedSeq(a, b)
+      },
+      commonLabelValues = Array("common"),
+      getDataPoint = { arr =>
+        resolutions.incrementAndGet()
+        arr.mkString(",")
+      },
+      maxCachedLabelSets = maxCachedLabelSets
+    )
+
+  test("resolves a label value once and reuses the data point") {
+    val resolutions = new AtomicInteger()
+    val renders     = new AtomicInteger()
+    val r           = resolver(resolutions, renders)
+
+    val first  = r(("a", "b"))
+    val second = r(("a", "b"))
+    val third  = r(("a", "b"))
+
+    assertEquals(first, "a,b,common")
+    assertEquals(second, first)
+    assertEquals(third, first)
+    assertEquals(resolutions.get(), 1)
+    assertEquals(renders.get(), 1)
+  }
+
+  test("distinct label values resolve to distinct data points") {
+    val resolutions = new AtomicInteger()
+    val renders     = new AtomicInteger()
+    val r           = resolver(resolutions, renders)
+
+    assertEquals(r(("a", "b")), "a,b,common")
+    assertEquals(r(("c", "d")), "c,d,common")
+    assertEquals(resolutions.get(), 2)
+  }
+
+  test("failed resolutions are not cached") {
+    val attempts = new AtomicInteger()
+    val r = new DataPointResolver[String, String](
+      f = IndexedSeq(_),
+      commonLabelValues = Array.empty,
+      getDataPoint = { arr =>
+        if (attempts.incrementAndGet() == 1) throw new IllegalArgumentException("boom") // scalafix:ok
+        arr.mkString(",")
+      }
+    )
+
+    val _ = intercept[IllegalArgumentException](r("a"))
+    assertEquals(r("a"), "a")
+    assertEquals(attempts.get(), 2)
+  }
+
+  test("stops caching new label values beyond the cap but keeps serving cached ones") {
+    val resolutions = new AtomicInteger()
+    val renders     = new AtomicInteger()
+    val r           = resolver(resolutions, renders, maxCachedLabelSets = 2)
+
+    assertEquals(r(("a", "1")), "a,1,common")
+    assertEquals(r(("a", "2")), "a,2,common")
+    // cap reached: new label values resolve directly, every time
+    assertEquals(r(("a", "3")), "a,3,common")
+    assertEquals(r(("a", "3")), "a,3,common")
+    assertEquals(resolutions.get(), 4)
+    // cached values are still served from the cache
+    assertEquals(r(("a", "1")), "a,1,common")
+    assertEquals(resolutions.get(), 4)
+  }
+
+  test("labelArray renders dynamic labels followed by common label values") {
+    val r = resolver(new AtomicInteger(), new AtomicInteger())
+
+    assertEquals(r.labelArray(("x", "y")).toList, List("x", "y", "common"))
+  }
+
+}


### PR DESCRIPTION
## Problem

Every update of a labelled metric re-resolves the upstream `DataPoint`: the typed label value `A` is rendered to strings (`f(labels)` — e.g. `UUID.toString` per label), copied into an array, and `prometheus-metrics-core`'s `labelValues(...)` then allocates a sorted `Labels` object and hashes it to find the data point — all before the actual `inc`/`observe`.

Profiling a metric-heavy production service (audience-matching-internal, ~560 req/s with per-request counter updates) attributed **~15% of CPU samples** to this plumbing: `ConcurrentHashMap` lookups, `String.equals`/`hashCode`, and label rendering, dwarfing the `DoubleAdder.add` doing the real work.

## Change

`DataPointResolver` (new, `javaclient.internal`) memoizes `A → DataPoint` per registered metric:

- **Correctness**: data points are never removed while a collector is registered (the library exposes no `remove`/`reset`), so cached references cannot go stale. Failed resolutions are not cached (`computeIfAbsent` stores nothing when the mapping function throws).
- **Hot path**: one lock-free `computeIfAbsent` hit, then the underlying adder/observation. Label rendering, array building, and the upstream `Labels` allocation/sort happen once per distinct label value.
- **Bounded**: beyond 65,536 distinct label values the cache stops accepting entries and resolves directly — label cardinality that high is already pathological for Prometheus, and the cap bounds memory even if an `A` without value-based equality is used.
- **Error messages**: rendered label values for `UnhandledPrometheusException` are computed lazily, only on the error path.

All four labelled metric types (counter, gauge, histogram, summary) go through the same seam, so each gets the cache from one change in `Utils.modifyMetric` plus its call sites.

Covered by a new `DataPointResolverSuite` (single resolution per label value, distinct values, failure non-caching, cap behaviour) plus the existing cross-backend `DslSuite`. Cross-compiles on 2.13.18 and 3.3.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)