### PR TITLE
Add withStaleSeriesEviction to JavaMetricRegistry.Builder

### DIFF
--- a/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
+++ b/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/JavaMetricRegistry.scala
@@ -29,6 +29,7 @@ import cats.syntax.all._
 import io.prometheus.metrics.core.datapoints.CounterDataPoint
 import io.prometheus.metrics.core.datapoints.DistributionDataPoint
 import io.prometheus.metrics.core.datapoints.GaugeDataPoint
+import io.prometheus.metrics.core.metrics.StatefulMetric
 import io.prometheus.metrics.core.metrics.{Counter => PCounter}
 import io.prometheus.metrics.core.metrics.{Gauge => PGauge}
 import io.prometheus.metrics.core.metrics.{Histogram => PHistogram}
@@ -38,6 +39,7 @@ import io.prometheus.metrics.instrumentation.jvm.JvmMetrics
 import io.prometheus.metrics.model.registry.PrometheusRegistry
 import io.prometheus.metrics.model.snapshots.Labels
 import prometheus4cats._
+import prometheus4cats.javaclient.internal.StaleSeriesEvictor
 import prometheus4cats.javaclient.internal.Utils
 import prometheus4cats.javaclient.models.MetricType
 import prometheus4cats.util.DoubleMetricRegistry
@@ -55,8 +57,22 @@ class JavaMetricRegistry[F[_]: Async] private (
     private val registry: PrometheusRegistry,
     private val ref: Ref[F, State[F]],
     private val sem: Semaphore[F],
-    private val logger: Throwable => String => F[Unit]
+    private val logger: Throwable => String => F[Unit],
+    private val evictor: Option[StaleSeriesEvictor]
 ) extends DoubleMetricRegistry[F] {
+
+  private def touched[D](
+      labelNames: IndexedSeq[Label.Name],
+      metric: StatefulMetric[_, _]
+  )(getDataPoint: Array[String] => D): Array[String] => D =
+    evictor match {
+      case Some(e) if labelNames.nonEmpty =>
+        lbls => {
+          e.touch(metric, lbls)
+          getDataPoint(lbls)
+        }
+      case _ => getDataPoint
+    }
 
   type Underlying = PrometheusRegistry
 
@@ -185,7 +201,7 @@ class JavaMetricRegistry[F[_]: Async] private (
             allLabelNames = allLabelNames,
             dynamicLabels = f(labels),
             commonLabelValues = commonLabelValuesArray,
-            getDataPoint = (lbls: Array[String]) => counter.labelValues(lbls: _*),
+            getDataPoint = touched(labelNames, counter)((lbls: Array[String]) => counter.labelValues(lbls: _*)),
             modify = (dp: CounterDataPoint) =>
               exemplar.fold(dp.inc(d))(e => dp.incWithExemplar(d, transformExemplarLabels(e))),
             logger = logger
@@ -227,7 +243,7 @@ class JavaMetricRegistry[F[_]: Async] private (
           allLabelNames = allLabelNames,
           dynamicLabels = f(labels),
           commonLabelValues = commonLabelValuesArray,
-          getDataPoint = (lbls: Array[String]) => gauge.labelValues(lbls: _*),
+          getDataPoint = touched(labelNames, gauge)((lbls: Array[String]) => gauge.labelValues(lbls: _*)),
           modify = g,
           logger = logger
         )
@@ -284,7 +300,7 @@ class JavaMetricRegistry[F[_]: Async] private (
             allLabelNames = allLabelNames,
             dynamicLabels = f(labels),
             commonLabelValues = commonLabelValuesArray,
-            getDataPoint = (lbls: Array[String]) => histogram.labelValues(lbls: _*),
+            getDataPoint = touched(labelNames, histogram)((lbls: Array[String]) => histogram.labelValues(lbls: _*)),
             modify = (dp: DistributionDataPoint) =>
               exemplar.fold(dp.observe(d))(e => dp.observeWithExemplar(d, transformExemplarLabels(e))),
             logger = logger
@@ -425,7 +441,7 @@ class JavaMetricRegistry[F[_]: Async] private (
           allLabelNames = allLabelNames,
           dynamicLabels = f(labels),
           commonLabelValues = commonLabelValuesArray,
-          getDataPoint = (lbls: Array[String]) => summary.labelValues(lbls: _*),
+          getDataPoint = touched(labelNames, summary)((lbls: Array[String]) => summary.labelValues(lbls: _*)),
           modify = (dp: DistributionDataPoint) => dp.observe(d),
           logger = logger
         )
@@ -539,15 +555,17 @@ object JavaMetricRegistry {
   sealed abstract class Builder[F[_]: Async](
       val promRegistry: PrometheusRegistry,
       val logger: Throwable => String => F[Unit],
-      val registerJvmMetrics: Boolean
+      val registerJvmMetrics: Boolean,
+      val staleSeriesTtl: Option[FiniteDuration]
   ) {
 
     private def copy(
         promRegistry: PrometheusRegistry = promRegistry,
         logger: Throwable => String => F[Unit] = logger,
-        registerJvmMetrics: Boolean = registerJvmMetrics
+        registerJvmMetrics: Boolean = registerJvmMetrics,
+        staleSeriesTtl: Option[FiniteDuration] = staleSeriesTtl
     ): Builder[F] =
-      new Builder(promRegistry, logger, registerJvmMetrics) {}
+      new Builder(promRegistry, logger, registerJvmMetrics, staleSeriesTtl) {}
 
     def withRegistry(promRegistry: PrometheusRegistry): Builder[F] = copy(promRegistry = promRegistry)
 
@@ -559,26 +577,45 @@ object JavaMetricRegistry {
       */
     def withJvmMetrics: Builder[F] = copy(registerJvmMetrics = true)
 
+    /** Evict label sets that have not been written to for `ttl`. A background sweep (every quarter of the TTL) removes
+      * idle series from the underlying collectors, so they stop being exposed; a later write recreates the series,
+      * which then starts again from zero. Intended for metrics labelled by unbounded or churning values, where the
+      * registry would otherwise accumulate dead series for the lifetime of the process. Only metrics with at least one
+      * label are affected; callback-backed metrics never are.
+      */
+    def withStaleSeriesEviction(ttl: FiniteDuration): Builder[F] = copy(staleSeriesTtl = Some(ttl))
+
     def build: Resource[F, JavaMetricRegistry[F]] =
       Resource.eval {
         if (registerJvmMetrics) Sync[F].delay(JvmMetrics.builder().register(promRegistry))
         else Applicative[F].unit
       }.flatMap { _ =>
+        val evictor = staleSeriesTtl.map(new StaleSeriesEvictor(_))
+
         val acquire = for {
           ref <- Ref.of[F, State[F]](Map.empty)
           sem <- Semaphore[F](1L)
-          reg  = new JavaMetricRegistry[F](promRegistry, ref, sem, logger)
+          reg  = new JavaMetricRegistry[F](promRegistry, ref, sem, logger, evictor)
         } yield reg
 
-        Resource.make(acquire) { reg =>
-          reg.ref.get.flatMap { metrics =>
-            if (metrics.nonEmpty)
-              metrics.values.toList.traverse_ { case (_, (collector, _, _)) =>
-                Utils.unregister(collector, promRegistry, logger)
-              }
-            else Applicative[F].unit
+        Resource
+          .make(acquire) { reg =>
+            reg.ref.get.flatMap { metrics =>
+              if (metrics.nonEmpty)
+                metrics.values.toList.traverse_ { case (_, (collector, _, _)) =>
+                  Utils.unregister(collector, promRegistry, logger)
+                }
+              else Applicative[F].unit
+            }
           }
-        }
+          .flatTap { _ =>
+            evictor.fold(Resource.unit[F]) { e =>
+              val sweep = Sync[F]
+                .delay(e.sweep())
+                .handleErrorWith(logger(_)("Failed to evict stale Prometheus series"))
+              Async[F].background((Temporal[F].sleep(e.sweepInterval) >> sweep).foreverM[Unit]).void
+            }
+          }
       }
 
   }
@@ -589,7 +626,8 @@ object JavaMetricRegistry {
       new Builder[F](
         promRegistry = PrometheusRegistry.defaultRegistry,
         logger = _ => _ => Async[F].unit,
-        registerJvmMetrics = false
+        registerJvmMetrics = false,
+        staleSeriesTtl = None
       ) {}
 
   }

--- a/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/internal/StaleSeriesEvictor.scala
+++ b/modules/prometheus4cats-java/src/main/scala/prometheus4cats/javaclient/internal/StaleSeriesEvictor.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2022-2026 Permutive Ltd. <https://permutive.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package prometheus4cats.javaclient.internal
+
+import java.util.concurrent.ConcurrentHashMap
+
+import scala.concurrent.duration._
+
+import io.prometheus.metrics.core.metrics.StatefulMetric
+
+/** Tracks the last write time of every (metric, label values) pair and removes pairs that have not been written to
+  * within `ttl` from the underlying collector, so idle series stop being exposed. A series removed by a sweep is
+  * recreated (from zero) by its next write. Writes racing a sweep keep their map entry and are re-evaluated on the next
+  * sweep; at worst a series that was written to in the instant it was being evicted restarts from zero.
+  */
+final private[javaclient] class StaleSeriesEvictor(ttl: FiniteDuration) {
+
+  import StaleSeriesEvictor.Key
+
+  private[this] val lastTouched = new ConcurrentHashMap[Key, java.lang.Long]()
+
+  val sweepInterval: FiniteDuration = ttl / 4
+
+  def touch(metric: StatefulMetric[_, _], labelValues: Array[String]): Unit =
+    lastTouched.put(new Key(metric, labelValues), java.lang.Long.valueOf(System.nanoTime())): Unit
+
+  def sweep(): Unit = {
+    val cutoff = System.nanoTime() - ttl.toNanos
+    lastTouched.forEach { (key, lastWrite) =>
+      if (lastWrite.longValue() < cutoff && lastTouched.remove(key, lastWrite))
+        key.metric.remove(key.labelValues: _*)
+    }
+  }
+
+}
+
+private[javaclient] object StaleSeriesEvictor {
+
+  @SuppressWarnings(Array("scalafix:Disable.equals", "scalafix:Disable.hashCode"))
+  final private class Key(val metric: StatefulMetric[_, _], val labelValues: Array[String]) {
+
+    override val hashCode: Int =
+      System.identityHashCode(metric) * 31 + java.util.Arrays.hashCode(labelValues.asInstanceOf[Array[AnyRef]])
+
+    override def equals(other: Any): Boolean = other match {
+      case that: Key =>
+        (that.metric eq metric) && java.util.Arrays.equals(
+          that.labelValues.asInstanceOf[Array[AnyRef]],
+          labelValues.asInstanceOf[Array[AnyRef]]
+        )
+      case _ => false
+    }
+
+  }
+
+}

--- a/modules/prometheus4cats-java/src/test/scala/prometheus4cats/javaclient/JavaMetricRegistrySuite.scala
+++ b/modules/prometheus4cats-java/src/test/scala/prometheus4cats/javaclient/JavaMetricRegistrySuite.scala
@@ -16,6 +16,7 @@
 
 package prometheus4cats.javaclient
 
+import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
 
 import cats.effect.IO
@@ -155,5 +156,46 @@ class JavaMetricRegistrySuite extends CatsEffectSuite with DslSuite {
           )
       }
       .sortBy(_.name)
+
+  // ─── suite-local tests ────────────────────────────────────────────────────────────────────────────
+
+  test("withStaleSeriesEviction removes idle label sets and recreates them on the next write") {
+    val promRegistry = new PrometheusRegistry()
+
+    def series(labelValue: String): Option[Double] =
+      promRegistry
+        .scrape()
+        .asScala
+        .toList
+        .collectFirst { case s: CounterSnapshot =>
+          s.getDataPoints.asScala.collectFirst {
+            case dp if promLabelsToMap(dp.getLabels).get("status").contains(labelValue) => dp.getValue
+          }
+        }
+        .flatten
+
+    JavaMetricRegistry
+      .Builder[IO]()
+      .withRegistry(promRegistry)
+      .withStaleSeriesEviction(500.millis)
+      .build
+      .map(MetricFactory.builder.build[IO](_))
+      .flatMap(_.counter("eviction_test_total").help("eviction test").label[String]("status").build)
+      .use { counter =>
+        for {
+          _      <- counter.inc("idle") >> counter.inc("active")
+          before <- IO.delay((series("idle"), series("active")))
+          _      <- (IO.sleep(100.millis) >> counter.inc("active")).replicateA_(10)
+          after  <- IO.delay((series("idle"), series("active")))
+          _      <- counter.inc("idle")
+          revived = series("idle")
+        } yield {
+          assertEquals(before, (Some(1.0), Some(1.0)))
+          assertEquals(after._1, None)
+          assert(after._2.exists(_ >= 10.0))
+          assertEquals(revived, Some(1.0))
+        }
+      }
+  }
 
 }


### PR DESCRIPTION
Adds an opt-in `Builder.withStaleSeriesEviction(ttl)` to the v6 Java backend: the registry tracks the last write to every (metric, label values) pair, and a background sweep (every `ttl / 4`) removes label sets that have not been written to within `ttl` via `StatefulMetric.remove`, so idle series stop being exposed. A later write recreates the series, which restarts from zero.

Motivation: metrics labelled by unbounded or churning values otherwise accumulate dead series for the lifetime of the process, growing the exposition (and scrape cost) without bound. Eviction bounds it to the recently-active label sets.

Notes:
- Only labelled stateful metrics participate; unlabelled metrics and callback-backed metrics are untouched.
- A write racing a sweep keeps its tracking entry (conditional remove), so it is re-evaluated next sweep; at worst a series written in the instant of its eviction restarts from zero.
- No public API changes outside the new `Builder` method; the core `MetricRegistry` abstraction is untouched.

Tested with a suite case covering idle-series removal, survival of actively-written series, and recreation after eviction.